### PR TITLE
Adding tokenizer function to BLEU and updating the README

### DIFF
--- a/metrics/bleu/README.md
+++ b/metrics/bleu/README.md
@@ -2,25 +2,25 @@
 
 
 ## Metric Description
-BLEU (Bilingual Evaluation Understudy) is an algorithm for evaluating the quality of text which has been machine-translated from one natural language to another. Quality is considered to be the correspondence between a machine's output and that of a human: "the closer a machine translation is to a professional human translation, the better it is" – this is the central idea behind BLEU. BLEU was one of the first metrics to claim a high correlation with human judgements of quality, and remains one of the most popular automated and inexpensive metrics. 
+BLEU (Bilingual Evaluation Understudy) is an algorithm for evaluating the quality of text which has been machine-translated from one natural language to another. Quality is considered to be the correspondence between a machine's output and that of a human: "the closer a machine translation is to a professional human translation, the better it is" – this is the central idea behind BLEU. BLEU was one of the first metrics to claim a high correlation with human judgements of quality, and remains one of the most popular automated and inexpensive metrics.
 
-Scores are calculated for individual translated segments—generally sentences—by comparing them with a set of good quality reference translations. Those scores are then averaged over the whole corpus to reach an estimate of the translation's overall quality. Neither intelligibility nor grammatical correctness are not taken into account. 
+Scores are calculated for individual translated segments—generally sentences—by comparing them with a set of good quality reference translations. Those scores are then averaged over the whole corpus to reach an estimate of the translation's overall quality. Neither intelligibility nor grammatical correctness are not taken into account.
 
 ## Intended Uses
 BLEU and BLEU-derived metrics are most often used for machine translation.
 
 ## How to Use
 
-This metric takes as input lists of predicted sentences and reference sentences:
+This metric takes as input a list of predicted sentences and a list of lists of reference sentences (since each predicted sentence can have multiple references):
 
 ```python
 >>> predictions = [
-...     ["hello", "there", "general", "kenobi",
-...     ["foo", "bar" "foobar"]
+...     ["hello there general kenobi",
+...     ["foo bar foobar"]
 ... ]
 >>> references = [
-...     [["hello", "there", "general", "kenobi"]],
-...     [["foo", "bar", "foobar"]]
+...     [["hello there general kenobi"], ["hello there !"]],
+...     [["foo bar foobar"]]
 ... ]
 >>> bleu = evaluate.load_metric("bleu")
 >>> results = bleu.compute(predictions=predictions, references=references)
@@ -29,8 +29,9 @@ This metric takes as input lists of predicted sentences and reference sentences:
 ```
 
 ### Inputs
-- **predictions** (`list` of `list`s): Translations to score. Each translation should be tokenized into a list of tokens.
-- **references** (`list` of `list`s): references for each translation. Each reference should be tokenized into a list of tokens.
+- **predictions** (`list` of `str`s): Translations to score.
+- **references** (`list` of `list`s of `str`s): references for each translation.
+- ** tokenizer** : approach used for tokenizing `predictions` and `references`. The default tokenizer is based on whitespace (using the `string.split()` function). It can be replaced by any function that takes a string as input and returns a list of tokens as output. E.g. `word_tokenize()` from [NLTK](https://www.nltk.org/api/nltk.tokenize.html) or pretrained tokenizers from the [Tokenizers library](https://huggingface.co/docs/tokenizers/index).
 - **max_order** (`int`): Maximum n-gram order to use when computing BLEU score. Defaults to `4`.
 - **smooth** (`boolean`): Whether or not to apply Lin et al. 2004 smoothing. Defaults to `False`.
 
@@ -56,15 +57,15 @@ The [Attention is All you Need paper](https://proceedings.neurips.cc/paper/2017/
 
 ### Examples
 
-Example where each sample has 1 reference:
+Example where each prediction has 1 reference:
 ```python
 >>> predictions = [
-...     ["hello", "there", "general", "kenobi",
-...     ["foo", "bar" "foobar"]
+...     ["hello there general kenobi",
+...     ["foo bar foobar"]
 ... ]
 >>> references = [
-...     [["hello", "there", "general", "kenobi"]],
-...     [["foo", "bar", "foobar"]]
+...     [["hello there general kenobi"]],
+...     [["foo bar foobar"]]
 ... ]
 >>> bleu = evaluate.load_metric("bleu")
 >>> results = bleu.compute(predictions=predictions, references=references)
@@ -72,15 +73,15 @@ Example where each sample has 1 reference:
 {'bleu': 0.6370964381207871, 'precisions': [0.8333333333333334, 0.75, 1.0, 1.0], 'brevity_penalty': 0.7165313105737893, 'length_ratio': 0.75, 'translation_length': 6, 'reference_length': 8}
 ```
 
-Example where the second sample has 2 references:
+Example where the second prediction has 2 references:
 ```python
 >>> predictions = [
-...     ["hello", "there", "general", "kenobi",
-...     ["foo", "bar" "foobar"]
+...     ["hello there general kenobi",
+...     ["foo bar foobar"]
 ... ]
 >>> references = [
-...     [["hello", "there", "general", "kenobi"], ["hello", "there", "!"]],
-...     [["foo", "bar", "foobar"]]
+...     [["hello there general kenobi"], ["hello there!"]],
+...     [["foo bar foobar"]]
 ... ]
 >>> bleu = evaluate.load_metric("bleu")
 >>> results = bleu.compute(predictions=predictions, references=references)
@@ -88,9 +89,18 @@ Example where the second sample has 2 references:
 {'bleu': 1.0, 'precisions': [1.0, 1.0, 1.0, 1.0], 'brevity_penalty': 1.0, 'length_ratio': 1.1666666666666667, 'translation_length': 7, 'reference_length': 6}
 ```
 
+Example with the word tokenizer from NLTK:
+```python
+>>> bleu = evaluate.load_metric("bleu")
+>>> from nltk.tokenize import word_tokenize
+>>> results = bleu.compute(predictions=predictions, references=references, tokenizer=word_tokenize)
+>>> print(results)
+{'bleu': 1.0, 'precisions': [1.0, 1.0, 1.0, 1.0], 'brevity_penalty': 1.0, 'length_ratio': 1.1666666666666667, 'translation_length': 7, 'reference_length': 6}
+```
+
 ## Limitations and Bias
-This metric hase multiple known limitations and biases:
-- BLEU compares overlap in tokens from the predictions and references, instead of comparing meaning. This can lead to discrepencies between BLEU scores and human ratings. 
+This metric has multiple known limitations:
+- BLEU compares overlap in tokens from the predictions and references, instead of comparing meaning. This can lead to discrepancies between BLEU scores and human ratings.
 - BLEU scores are not comparable across different datasets, nor are they comparable across different languages.
 - BLEU scores can vary greatly depending on which parameters are used to generate the scores, especially when different tokenization and normalization techniques are used. It is therefore not possible to compare BLEU scores generated using different parameters, or when these parameters are unknown.
 - Shorter predicted translations achieve higher scores than longer ones, simply due to how the score is calculated. A brevity penalty is introduced to attempt to counteract this.


### PR DESCRIPTION
An initial attempt at externalizing the tokenizer function -- instead of the previous behavior, when the input `predictions` and `references` had to be already tokenized, this implementation allows users to specify their own tokenizer (or use the default `string.split()` behavior). 

WDYT @lhoestq @lvwerra ?