### PR TITLE
Changing BLEU tokenizer behavior and making the default tokenizer 13a

### DIFF
--- a/metrics/bleu/README.md
+++ b/metrics/bleu/README.md
@@ -32,7 +32,7 @@ This metric takes as input a list of predicted sentences and a list of lists of 
     The default tokenizer is `tokenizer_13a`, a relatively minimal tokenization approach that is however equivalent to `mteval-v13a`, used by WMT.
     This can be replaced by another tokenizer from a source such as [SacreBLEU](https://github.com/mjpost/sacrebleu/tree/master/sacrebleu/tokenizers).
 
-The default tokenizer is based on whitespace (using the `string.split()` function). It can be replaced by any function that takes a string as input and returns a list of tokens as output. E.g. `word_tokenize()` from [NLTK](https://www.nltk.org/api/nltk.tokenize.html) or pretrained tokenizers from the [Tokenizers library](https://huggingface.co/docs/tokenizers/index).
+The default tokenizer is based on whitespace and regexes. It can be replaced by any function that takes a string as input and returns a list of tokens as output. E.g. `word_tokenize()` from [NLTK](https://www.nltk.org/api/nltk.tokenize.html) or pretrained tokenizers from the [Tokenizers library](https://huggingface.co/docs/tokenizers/index).
 - **max_order** (`int`): Maximum n-gram order to use when computing BLEU score. Defaults to `4`.
 - **smooth** (`boolean`): Whether or not to apply Lin et al. 2004 smoothing. Defaults to `False`.
 

--- a/metrics/bleu/README.md
+++ b/metrics/bleu/README.md
@@ -2,25 +2,25 @@
 
 
 ## Metric Description
-BLEU (Bilingual Evaluation Understudy) is an algorithm for evaluating the quality of text which has been machine-translated from one natural language to another. Quality is considered to be the correspondence between a machine's output and that of a human: "the closer a machine translation is to a professional human translation, the better it is" – this is the central idea behind BLEU. BLEU was one of the first metrics to claim a high correlation with human judgements of quality, and remains one of the most popular automated and inexpensive metrics. 
+BLEU (Bilingual Evaluation Understudy) is an algorithm for evaluating the quality of text which has been machine-translated from one natural language to another. Quality is considered to be the correspondence between a machine's output and that of a human: "the closer a machine translation is to a professional human translation, the better it is" – this is the central idea behind BLEU. BLEU was one of the first metrics to claim a high correlation with human judgements of quality, and remains one of the most popular automated and inexpensive metrics.
 
-Scores are calculated for individual translated segments—generally sentences—by comparing them with a set of good quality reference translations. Those scores are then averaged over the whole corpus to reach an estimate of the translation's overall quality. Neither intelligibility nor grammatical correctness are not taken into account. 
+Scores are calculated for individual translated segments—generally sentences—by comparing them with a set of good quality reference translations. Those scores are then averaged over the whole corpus to reach an estimate of the translation's overall quality. Neither intelligibility nor grammatical correctness are not taken into account.
 
 ## Intended Uses
 BLEU and BLEU-derived metrics are most often used for machine translation.
 
 ## How to Use
 
-This metric takes as input lists of predicted sentences and reference sentences:
+This metric takes as input a list of predicted sentences and a list of lists of reference sentences (since each predicted sentence can have multiple references):
 
 ```python
 >>> predictions = [
-...     ["hello", "there", "general", "kenobi",
-...     ["foo", "bar" "foobar"]
+...     ["hello there general kenobi",
+...     ["foo bar foobar"]
 ... ]
 >>> references = [
-...     [["hello", "there", "general", "kenobi"]],
-...     [["foo", "bar", "foobar"]]
+...     [["hello there general kenobi"], ["hello there !"]],
+...     [["foo bar foobar"]]
 ... ]
 >>> bleu = evaluate.load_metric("bleu")
 >>> results = bleu.compute(predictions=predictions, references=references)
@@ -29,8 +29,9 @@ This metric takes as input lists of predicted sentences and reference sentences:
 ```
 
 ### Inputs
-- **predictions** (`list` of `list`s): Translations to score. Each translation should be tokenized into a list of tokens.
-- **references** (`list` of `list`s): references for each translation. Each reference should be tokenized into a list of tokens.
+- **predictions** (`list` of `str`s): Translations to score.
+- **references** (`list` of `list`s of `str`s): references for each translation.
+- ** tokenizer** : approach used for tokenizing `predictions` and `references`. The default tokenizer is based on whitespace (using the `string.split()` function). It can be replaced by any function that takes a string as input and returns a list of tokens as output. E.g. `word_tokenize()` from [NLTK](https://www.nltk.org/api/nltk.tokenize.html) or pretrained tokenizers from the [Tokenizers library](https://huggingface.co/docs/tokenizers/index).
 - **max_order** (`int`): Maximum n-gram order to use when computing BLEU score. Defaults to `4`.
 - **smooth** (`boolean`): Whether or not to apply Lin et al. 2004 smoothing. Defaults to `False`.
 
@@ -56,15 +57,15 @@ The [Attention is All you Need paper](https://proceedings.neurips.cc/paper/2017/
 
 ### Examples
 
-Example where each sample has 1 reference:
+Example where each prediction has 1 reference:
 ```python
 >>> predictions = [
-...     ["hello", "there", "general", "kenobi",
-...     ["foo", "bar" "foobar"]
+...     ["hello there general kenobi",
+...     ["foo bar foobar"]
 ... ]
 >>> references = [
-...     [["hello", "there", "general", "kenobi"]],
-...     [["foo", "bar", "foobar"]]
+...     [["hello there general kenobi"]],
+...     [["foo bar foobar"]]
 ... ]
 >>> bleu = evaluate.load_metric("bleu")
 >>> results = bleu.compute(predictions=predictions, references=references)
@@ -72,15 +73,15 @@ Example where each sample has 1 reference:
 {'bleu': 0.6370964381207871, 'precisions': [0.8333333333333334, 0.75, 1.0, 1.0], 'brevity_penalty': 0.7165313105737893, 'length_ratio': 0.75, 'translation_length': 6, 'reference_length': 8}
 ```
 
-Example where the second sample has 2 references:
+Example where the second prediction has 2 references:
 ```python
 >>> predictions = [
-...     ["hello", "there", "general", "kenobi",
-...     ["foo", "bar" "foobar"]
+...     ["hello there general kenobi",
+...     ["foo bar foobar"]
 ... ]
 >>> references = [
-...     [["hello", "there", "general", "kenobi"], ["hello", "there", "!"]],
-...     [["foo", "bar", "foobar"]]
+...     [["hello there general kenobi"], ["hello there!"]],
+...     [["foo bar foobar"]]
 ... ]
 >>> bleu = evaluate.load_metric("bleu")
 >>> results = bleu.compute(predictions=predictions, references=references)
@@ -88,9 +89,18 @@ Example where the second sample has 2 references:
 {'bleu': 1.0, 'precisions': [1.0, 1.0, 1.0, 1.0], 'brevity_penalty': 1.0, 'length_ratio': 1.1666666666666667, 'translation_length': 7, 'reference_length': 6}
 ```
 
+Example with the word tokenizer from NLTK:
+```python
+>>> bleu = evaluate.load_metric("bleu")
+>>> from nltk.tokenize import word_tokenize
+>>> results = bleu.compute(predictions=predictions, references=references, tokenizer=word_tokenize)
+>>> print(results)
+{'bleu': 1.0, 'precisions': [1.0, 1.0, 1.0, 1.0], 'brevity_penalty': 1.0, 'length_ratio': 1.1666666666666667, 'translation_length': 7, 'reference_length': 6}
+```
+
 ## Limitations and Bias
-This metric hase multiple known limitations and biases:
-- BLEU compares overlap in tokens from the predictions and references, instead of comparing meaning. This can lead to discrepencies between BLEU scores and human ratings. 
+This metric has multiple known limitations:
+- BLEU compares overlap in tokens from the predictions and references, instead of comparing meaning. This can lead to discrepancies between BLEU scores and human ratings.
 - BLEU scores are not comparable across different datasets, nor are they comparable across different languages.
 - BLEU scores can vary greatly depending on which parameters are used to generate the scores, especially when different tokenization and normalization techniques are used. It is therefore not possible to compare BLEU scores generated using different parameters, or when these parameters are unknown.
 - Shorter predicted translations achieve higher scores than longer ones, simply due to how the score is calculated. A brevity penalty is introduced to attempt to counteract this.

--- a/metrics/bleu/README.md
+++ b/metrics/bleu/README.md
@@ -14,24 +14,25 @@ BLEU and BLEU-derived metrics are most often used for machine translation.
 This metric takes as input a list of predicted sentences and a list of lists of reference sentences (since each predicted sentence can have multiple references):
 
 ```python
->>> predictions = [
-...     ["hello there general kenobi",
-...     ["foo bar foobar"]
-... ]
+>>> predictions = ["hello there general kenobi", "foo bar foobar"]
 >>> references = [
-...     [["hello there general kenobi"], ["hello there !"]],
-...     [["foo bar foobar"]]
+...     ["hello there general kenobi", "hello there !"],
+...     ["foo bar foobar"]
 ... ]
 >>> bleu = evaluate.load_metric("bleu")
 >>> results = bleu.compute(predictions=predictions, references=references)
 >>> print(results)
-{'bleu': 0.6370964381207871, 'precisions': [0.8333333333333334, 0.75, 1.0, 1.0], 'brevity_penalty': 0.7165313105737893, 'length_ratio': 0.75, 'translation_length': 6, 'reference_length': 8}
+{'bleu': 1.0, 'precisions': [1.0, 1.0, 1.0, 1.0], 'brevity_penalty': 1.0, 'length_ratio': 1.1666666666666667, 'translation_length': 7, 'reference_length': 6}
 ```
 
 ### Inputs
 - **predictions** (`list` of `str`s): Translations to score.
 - **references** (`list` of `list`s of `str`s): references for each translation.
-- ** tokenizer** : approach used for tokenizing `predictions` and `references`. The default tokenizer is based on whitespace (using the `string.split()` function). It can be replaced by any function that takes a string as input and returns a list of tokens as output. E.g. `word_tokenize()` from [NLTK](https://www.nltk.org/api/nltk.tokenize.html) or pretrained tokenizers from the [Tokenizers library](https://huggingface.co/docs/tokenizers/index).
+- ** tokenizer** : approach used for standardizing `predictions` and `references`.
+    The default tokenizer is `tokenizer_13a`, a relatively minimal tokenization approach that is however equivalent to `mteval-v13a`, used by WMT.
+    This can be replaced by another tokenizer from a source such as [SacreBLEU](https://github.com/mjpost/sacrebleu/tree/master/sacrebleu/tokenizers).
+
+The default tokenizer is based on whitespace (using the `string.split()` function). It can be replaced by any function that takes a string as input and returns a list of tokens as output. E.g. `word_tokenize()` from [NLTK](https://www.nltk.org/api/nltk.tokenize.html) or pretrained tokenizers from the [Tokenizers library](https://huggingface.co/docs/tokenizers/index).
 - **max_order** (`int`): Maximum n-gram order to use when computing BLEU score. Defaults to `4`.
 - **smooth** (`boolean`): Whether or not to apply Lin et al. 2004 smoothing. Defaults to `False`.
 
@@ -45,7 +46,7 @@ This metric takes as input a list of predicted sentences and a list of lists of 
 
 Output Example:
 ```python
-{'bleu': 1.0, 'precisions': [1.0, 1.0, 1.0, 1.0], 'brevity_penalty': 1.0, 'length_ratio': 1.167, 'translation_length': 7, 'reference_length': 6}
+{'bleu': 1.0, 'precisions': [1.0, 1.0, 1.0, 1.0], 'brevity_penalty': 1.0, 'length_ratio': 1.1666666666666667, 'translation_length': 7, 'reference_length': 6}
 ```
 
 BLEU's output is always a number between 0 and 1. This value indicates how similar the candidate text is to the reference texts, with values closer to 1 representing more similar texts. Few human translations will attain a score of 1, since this would indicate that the candidate is identical to one of the reference translations. For this reason, it is not necessary to attain a score of 1. Because there are more opportunities to match, adding additional reference translations will increase the BLEU score.
@@ -59,18 +60,15 @@ The [Attention is All you Need paper](https://proceedings.neurips.cc/paper/2017/
 
 Example where each prediction has 1 reference:
 ```python
->>> predictions = [
-...     ["hello there general kenobi",
-...     ["foo bar foobar"]
-... ]
+>>> predictions = ["hello there general kenobi","foo bar foobar"]
 >>> references = [
-...     [["hello there general kenobi"]],
-...     [["foo bar foobar"]]
+...     ["hello there general kenobi"],
+...     ["foo bar foobar"]
 ... ]
 >>> bleu = evaluate.load_metric("bleu")
 >>> results = bleu.compute(predictions=predictions, references=references)
 >>> print(results)
-{'bleu': 0.6370964381207871, 'precisions': [0.8333333333333334, 0.75, 1.0, 1.0], 'brevity_penalty': 0.7165313105737893, 'length_ratio': 0.75, 'translation_length': 6, 'reference_length': 8}
+{'bleu': 1.0, 'precisions': [1.0, 1.0, 1.0, 1.0], 'brevity_penalty': 1.0, 'length_ratio': 1.0, 'translation_length': 7, 'reference_length': 7}
 ```
 
 Example where the second prediction has 2 references:
@@ -93,6 +91,14 @@ Example with the word tokenizer from NLTK:
 ```python
 >>> bleu = evaluate.load_metric("bleu")
 >>> from nltk.tokenize import word_tokenize
+>>> predictions = [
+...     ["hello there general kenobi",
+...     ["foo bar foobar"]
+... ]
+>>> references = [
+...     [["hello there general kenobi"], ["hello there!"]],
+...     [["foo bar foobar"]]
+... ]
 >>> results = bleu.compute(predictions=predictions, references=references, tokenizer=word_tokenize)
 >>> print(results)
 {'bleu': 1.0, 'precisions': [1.0, 1.0, 1.0, 1.0], 'brevity_penalty': 1.0, 'length_ratio': 1.1666666666666667, 'translation_length': 7, 'reference_length': 6}
@@ -101,10 +107,9 @@ Example with the word tokenizer from NLTK:
 ## Limitations and Bias
 This metric has multiple known limitations:
 - BLEU compares overlap in tokens from the predictions and references, instead of comparing meaning. This can lead to discrepancies between BLEU scores and human ratings.
-- BLEU scores are not comparable across different datasets, nor are they comparable across different languages.
-- BLEU scores can vary greatly depending on which parameters are used to generate the scores, especially when different tokenization and normalization techniques are used. It is therefore not possible to compare BLEU scores generated using different parameters, or when these parameters are unknown.
 - Shorter predicted translations achieve higher scores than longer ones, simply due to how the score is calculated. A brevity penalty is introduced to attempt to counteract this.
-
+- BLEU scores are not comparable across different datasets, nor are they comparable across different languages.
+- BLEU scores can vary greatly depending on which parameters are used to generate the scores, especially when different tokenization and normalization techniques are used. It is therefore not possible to compare BLEU scores generated using different parameters, or when these parameters are unknown. For more discussion around this topic, see the following [issue](https://github.com/huggingface/datasets/issues/137).
 
 ## Citation
 ```bibtex

--- a/metrics/bleu/bleu.py
+++ b/metrics/bleu/bleu.py
@@ -19,6 +19,7 @@ import evaluate
 
 from .nmt_bleu import compute_bleu  # From: https://github.com/tensorflow/nmt/blob/master/nmt/scripts/bleu.py
 
+from .tokenizer_13a import Tokenizer13a
 
 _CITATION = """\
 @INPROCEEDINGS{Papineni02bleu:a,
@@ -43,19 +44,13 @@ _CITATION = """\
 """
 
 _DESCRIPTION = """\
-BLEU (bilingual evaluation understudy) is an algorithm for evaluating the quality of text which has been machine-translated from one natural language to another.
-Quality is considered to be the correspondence between a machine's output and that of a human: "the closer a machine translation is to a professional human translation,
-the better it is" – this is the central idea behind BLEU. BLEU was one of the first metrics to claim a high correlation with human judgements of quality, and
-remains one of the most popular automated and inexpensive metrics.
+BLEU (Bilingual Evaluation Understudy) is an algorithm for evaluating the quality of text which has been machine-translated from one natural language to another.
+Quality is considered to be the correspondence between a machine's output and that of a human: "the closer a machine translation is to a professional human translation, the better it is"
+– this is the central idea behind BLEU. BLEU was one of the first metrics to claim a high correlation with human judgements of quality, and remains one of the most popular automated and inexpensive metrics.
 
 Scores are calculated for individual translated segments—generally sentences—by comparing them with a set of good quality reference translations.
-Those scores are then averaged over the whole corpus to reach an estimate of the translation's overall quality. Intelligibility or grammatical correctness
-are not taken into account[citation needed].
-
-BLEU's output is always a number between 0 and 1. This value indicates how similar the candidate text is to the reference texts, with values closer to 1
-representing more similar texts. Few human translations will attain a score of 1, since this would indicate that the candidate is identical to one of the
-reference translations. For this reason, it is not necessary to attain a score of 1. Because there are more opportunities to match, adding additional
-reference translations will increase the BLEU score.
+Those scores are then averaged over the whole corpus to reach an estimate of the translation's overall quality.
+Neither intelligibility nor grammatical correctness are not taken into account.
 """
 
 _KWARGS_DESCRIPTION = """
@@ -64,9 +59,8 @@ Args:
     predictions: list of translations to score.
     references: list of lists of references for each translation.
     tokenizer : approach used for tokenizing `predictions` and `references`.
-        The default tokenizer is based on whitespace (using the `string.split()` function).
+        The default tokenizer is `tokenizer_13a`, a minimal tokenization approach that is equivalent to `mteval-v13a`, used by WMT.
         This can be replaced by any function that takes a string as input and returns a list of tokens as output.
-        E.g. `word_tokenize()` from NLTK or pretrained tokenizers from the Tokenizers library
     max_order: Maximum n-gram order to use when computing BLEU score.
     smooth: Whether or not to apply Lin et al. 2004 smoothing.
 Returns:
@@ -78,13 +72,10 @@ Returns:
     'reference_length': reference_length
 Examples:
 
-    >>> predictions = [
-    ...     ["hello", "there", "general", "kenobi"],                             # tokenized prediction of the first sample
-    ...     ["foo", "bar", "foobar"]                                             # tokenized prediction of the second sample
-    ... ]
+    >>> predictions = ["hello there general kenobi", "foo bar foobar"]
     >>> references = [
-    ...     [["hello", "there", "general", "kenobi"], ["hello", "there", "!"]],  # tokenized references for the first sample (2 references)
-    ...     [["foo", "bar", "foobar"]]                                           # tokenized references for the second sample (1 reference)
+    ...     ["hello there general kenobi", "hello there!"],
+    ...     ["foo bar foobar"]
     ... ]
     >>> bleu = evaluate.load_metric("bleu")
     >>> results = bleu.compute(predictions=predictions, references=references)
@@ -113,10 +104,7 @@ class Bleu(evaluate.Metric):
             ],
         )
 
-    def tokenizer(string):
-        return string.split()
-
-    def _compute(self, predictions, references, tokenizer=tokenizer, max_order=4, smooth=False):
+    def _compute(self, predictions, references, tokenizer=Tokenizer13a(), max_order=4, smooth=False):
         references = [[tokenizer(r) for r in ref] for ref in references]
         predictions = [tokenizer(p) for p in predictions]
         score = compute_bleu(

--- a/metrics/bleu/bleu.py
+++ b/metrics/bleu/bleu.py
@@ -18,8 +18,8 @@ import datasets
 import evaluate
 
 from .nmt_bleu import compute_bleu  # From: https://github.com/tensorflow/nmt/blob/master/nmt/scripts/bleu.py
-
 from .tokenizer_13a import Tokenizer13a
+
 
 _CITATION = """\
 @INPROCEEDINGS{Papineni02bleu:a,
@@ -93,8 +93,8 @@ class Bleu(evaluate.Metric):
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                "predictions" : datasets.Value("string", id="sequence"),
-                "references" : datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
+                    "predictions": datasets.Value("string", id="sequence"),
+                    "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
                 }
             ),
             codebase_urls=["https://github.com/tensorflow/nmt/blob/master/nmt/scripts/bleu.py"],

--- a/metrics/bleu/tokenizer_13a.py
+++ b/metrics/bleu/tokenizer_13a.py
@@ -1,0 +1,86 @@
+### Source: https://github.com/mjpost/sacrebleu/blob/master/sacrebleu/tokenizers/tokenizer_13a.py
+
+from functools import lru_cache
+import re
+
+class BaseTokenizer:
+    """A base dummy tokenizer to derive from."""
+
+    def signature(self):
+        """
+        Returns a signature for the tokenizer.
+        :return: signature string
+        """
+        return 'none'
+
+    def __call__(self, line):
+        """
+        Tokenizes an input line with the tokenizer.
+        :param line: a segment to tokenize
+        :return: the tokenized line
+        """
+        return line
+
+class TokenizerRegexp(BaseTokenizer):
+
+    def signature(self):
+        return 're'
+
+    def __init__(self):
+        self._re = [
+            # language-dependent part (assuming Western languages)
+            (re.compile(r'([\{-\~\[-\` -\&\(-\+\:-\@\/])'), r' \1 '),
+            # tokenize period and comma unless preceded by a digit
+            (re.compile(r'([^0-9])([\.,])'), r'\1 \2 '),
+            # tokenize period and comma unless followed by a digit
+            (re.compile(r'([\.,])([^0-9])'), r' \1 \2'),
+            # tokenize dash when preceded by a digit
+            (re.compile(r'([0-9])(-)'), r'\1 \2 '),
+            # one space only between words
+            # NOTE: Doing this in Python (below) is faster
+            # (re.compile(r'\s+'), r' '),
+        ]
+
+    @lru_cache(maxsize=2**16)
+    def __call__(self, line):
+        """Common post-processing tokenizer for `13a` and `zh` tokenizers.
+        :param line: a segment to tokenize
+        :return: the tokenized line
+        """
+        for (_re, repl) in self._re:
+            line = _re.sub(repl, line)
+
+        # no leading or trailing spaces, single space within words
+        #return ' '.join(line.split())
+        # This line is changed with regards to the original tokenizer (seen above) to return individual words
+        return line.split()
+
+class Tokenizer13a(BaseTokenizer):
+
+    def signature(self):
+        return '13a'
+
+    def __init__(self):
+        self._post_tokenizer = TokenizerRegexp()
+
+    @lru_cache(maxsize=2**16)
+    def __call__(self, line):
+        """Tokenizes an input line using a relatively minimal tokenization
+        that is however equivalent to mteval-v13a, used by WMT.
+
+        :param line: a segment to tokenize
+        :return: the tokenized line
+        """
+
+        # language-independent part:
+        line = line.replace('<skipped>', '')
+        line = line.replace('-\n', '')
+        line = line.replace('\n', ' ')
+
+        if '&' in line:
+            line = line.replace('&quot;', '"')
+            line = line.replace('&amp;', '&')
+            line = line.replace('&lt;', '<')
+            line = line.replace('&gt;', '>')
+
+        return self._post_tokenizer(f' {line} ')

--- a/metrics/bleu/tokenizer_13a.py
+++ b/metrics/bleu/tokenizer_13a.py
@@ -1,7 +1,9 @@
-### Source: https://github.com/mjpost/sacrebleu/blob/master/sacrebleu/tokenizers/tokenizer_13a.py
+# Source: https://github.com/mjpost/sacrebleu/blob/master/sacrebleu/tokenizers/tokenizer_13a.py
+# Under the Apache 2.0. License: https://github.com/mjpost/sacrebleu/blob/master/LICENSE.txt
 
-from functools import lru_cache
 import re
+from functools import lru_cache
+
 
 class BaseTokenizer:
     """A base dummy tokenizer to derive from."""
@@ -11,7 +13,7 @@ class BaseTokenizer:
         Returns a signature for the tokenizer.
         :return: signature string
         """
-        return 'none'
+        return "none"
 
     def __call__(self, line):
         """
@@ -21,21 +23,21 @@ class BaseTokenizer:
         """
         return line
 
-class TokenizerRegexp(BaseTokenizer):
 
+class TokenizerRegexp(BaseTokenizer):
     def signature(self):
-        return 're'
+        return "re"
 
     def __init__(self):
         self._re = [
             # language-dependent part (assuming Western languages)
-            (re.compile(r'([\{-\~\[-\` -\&\(-\+\:-\@\/])'), r' \1 '),
+            (re.compile(r"([\{-\~\[-\` -\&\(-\+\:-\@\/])"), r" \1 "),
             # tokenize period and comma unless preceded by a digit
-            (re.compile(r'([^0-9])([\.,])'), r'\1 \2 '),
+            (re.compile(r"([^0-9])([\.,])"), r"\1 \2 "),
             # tokenize period and comma unless followed by a digit
-            (re.compile(r'([\.,])([^0-9])'), r' \1 \2'),
+            (re.compile(r"([\.,])([^0-9])"), r" \1 \2"),
             # tokenize dash when preceded by a digit
-            (re.compile(r'([0-9])(-)'), r'\1 \2 '),
+            (re.compile(r"([0-9])(-)"), r"\1 \2 "),
             # one space only between words
             # NOTE: Doing this in Python (below) is faster
             # (re.compile(r'\s+'), r' '),
@@ -51,14 +53,14 @@ class TokenizerRegexp(BaseTokenizer):
             line = _re.sub(repl, line)
 
         # no leading or trailing spaces, single space within words
-        #return ' '.join(line.split())
+        # return ' '.join(line.split())
         # This line is changed with regards to the original tokenizer (seen above) to return individual words
         return line.split()
 
-class Tokenizer13a(BaseTokenizer):
 
+class Tokenizer13a(BaseTokenizer):
     def signature(self):
-        return '13a'
+        return "13a"
 
     def __init__(self):
         self._post_tokenizer = TokenizerRegexp()
@@ -73,14 +75,14 @@ class Tokenizer13a(BaseTokenizer):
         """
 
         # language-independent part:
-        line = line.replace('<skipped>', '')
-        line = line.replace('-\n', '')
-        line = line.replace('\n', ' ')
+        line = line.replace("<skipped>", "")
+        line = line.replace("-\n", "")
+        line = line.replace("\n", " ")
 
-        if '&' in line:
-            line = line.replace('&quot;', '"')
-            line = line.replace('&amp;', '&')
-            line = line.replace('&lt;', '<')
-            line = line.replace('&gt;', '>')
+        if "&" in line:
+            line = line.replace("&quot;", '"')
+            line = line.replace("&amp;", "&")
+            line = line.replace("&lt;", "<")
+            line = line.replace("&gt;", ">")
 
-        return self._post_tokenizer(f' {line} ')
+        return self._post_tokenizer(f" {line} ")

--- a/metrics/bleu/tokenizer_13a.py
+++ b/metrics/bleu/tokenizer_13a.py
@@ -1,5 +1,17 @@
 # Source: https://github.com/mjpost/sacrebleu/blob/master/sacrebleu/tokenizers/tokenizer_13a.py
-# Under the Apache 2.0. License: https://github.com/mjpost/sacrebleu/blob/master/LICENSE.txt
+# Copyright 2020 SacreBLEU Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import re
 from functools import lru_cache


### PR DESCRIPTION
As it was previously discussed [in an issue from 2020](https://github.com/huggingface/datasets/issues/137), inconsistent tokenization in BLEU can cause reproducibility issues. The proposed solution was to use tokenizer `13a`, such as is the default case for SacreBLEU and WMT.

After discussion with @lhoestq , I made this the default dehavior of the BLEU implementation, however making it possible to use other tokeniizers such as NLTK's `word_tokenize`.

I also updated the README to reflect these changes and to further discuss the impact that tokenization can have on reproducibility of BLEU scores.

Please let me know what you think, @lvwerra and @lhoestq !

cc @thomwolf cause you were involved in the original discussion in the issue I linked above. 