### PR TITLE
Standardizing the tokenizer of GoogleBLEU and making it 13a

### DIFF
--- a/metrics/google_bleu/README.md
+++ b/metrics/google_bleu/README.md
@@ -106,7 +106,7 @@ Example with multiple references for the first sample, with `min_len` adjusted t
 
 ## Limitations and Bias
 
-The GoogleBLEU metric does not come with a predefined tokenization function; previous versions simply used `split()` to split the input strings into tokens. Using a tokenizer such as the default one, `tokenizer_13a`, makes results more standardized and reproducible. 
+The GoogleBLEU metric does not come with a predefined tokenization function; previous versions simply used `split()` to split the input strings into tokens. Using a tokenizer such as the default one, `tokenizer_13a`, makes results more standardized and reproducible. The BLEU and sacreBLEU metrics also use this default tokenizer.
 
 ## Citation
 ```bibtex

--- a/metrics/google_bleu/README.md
+++ b/metrics/google_bleu/README.md
@@ -1,9 +1,8 @@
-# Metric Card for Google BLEU (GLEU)
+# Metric Card for Google BLEU
 
 
 ## Metric Description
-The BLEU score has some undesirable properties when used for single
-sentences, as it was designed to be a corpus measure. The Google BLEU score, also known as GLEU score, is designed to limit these undesirable properties when used for single sentences.
+The BLEU score has some undesirable properties when used for single sentences, as it was designed to be a corpus measure. The Google BLEU score is designed to limit these undesirable properties when used for single sentences.
 
 To calculate this score, all sub-sequences of 1, 2, 3 or 4 tokens in output and target sequence (n-grams) are recorded. The precision and recall, described below, are then computed.
 
@@ -19,20 +18,22 @@ This metric is generally used to evaluate machine translation models. It is espe
 Because it performs better on individual sentence pairs as compared to BLEU, Google BLEU has also been used in RL experiments.
 
 ## How to Use
-This metric takes a list of predicted sentences, as well as a list of references. 
+This metric takes a list of predicted sentences, as well as a list of references.
 
 ```python
 sentence1 = "the cat sat on the mat"
 sentence2 = "the cat ate the mat"
 google_bleu = evaluate.load_metric("google_bleu")
-result = google_bleu.compute(predictions=[sentence1], references=[sentence2])
+result = google_bleu.compute(predictions=[sentence1], references=[[sentence2]])
 print(result)
->>> True
+>>> {'google_bleu': 0.3333333333333333}
 ```
 
 ### Inputs
-- **predictions** (list of str): list of translations to score. Each translation should be tokenized into a list of tokens.
-- **references** (list of list of str): list of lists of references for each translation. Each reference should be tokenized into a list of tokens.
+- **predictions** (list of str): list of translations to score.
+- **references** (list of list of str): list of lists of references for each translation.
+- **tokenizer** : approach used for tokenizing `predictions` and `references`.
+The default tokenizer is `tokenizer_13a`, a minimal tokenization approach that is equivalent to `mteval-v13a`, used by WMT. This can be replaced by any function that takes a string as input and returns a list of tokens as output.
 - **min_len** (int): The minimum order of n-gram this function should extract. Defaults to 1.
 - **max_len** (int): The maximum order of n-gram this function should extract. Defaults to 4.
 
@@ -45,13 +46,13 @@ The output format is as follows:
 {'google_bleu': google_bleu score}
 ```
 
-This metric can take on values from 0 to 1, inclusive. Higher scores are better, with 0 indicating no matches, and 1 indicating a perfect match. 
+This metric can take on values from 0 to 1, inclusive. Higher scores are better, with 0 indicating no matches, and 1 indicating a perfect match.
 
 Note that this score is symmetrical when switching output and target. This means that, given two sentences, `sentence1` and `sentence2`, whatever score is output when `sentence1` is the predicted sentence and  `sencence2` is the reference sentence will be the same as when the sentences are swapped and `sentence2` is the predicted sentence while `sentence1` is the reference sentence. In code, this looks like:
 
 ```python
-sentence1 = "the cat sat on the mat".split()
-sentence2 = "the cat ate the mat".split()
+sentence1 = "the cat sat on the mat"
+sentence2 = "the cat ate the mat"
 google_bleu = evaluate.load_metric("google_bleu")
 result_a = google_bleu.compute(predictions=[sentence1], references=[[sentence2]])
 result_b = google_bleu.compute(predictions=[sentence2], references=[[sentence1]])
@@ -65,112 +66,47 @@ print(result_a == result_b)
 ### Examples
 Example with one reference per sample:
 ```python
-hyp1 = ['It', 'is', 'a', 'guide', 'to', 'action', 'which',
-        'ensures', 'that', 'the', 'rubber', 'duck', 'always',
-        'disobeys', 'the', 'commands', 'of', 'the', 'cat']
-ref1a = ['It', 'is', 'the', 'guiding', 'principle', 'which',
-         'guarantees', 'the', 'rubber', 'duck', 'forces', 'never',
-         'being', 'under', 'the', 'command', 'of', 'the', 'cat']
-
-hyp2 = ['he', 'read', 'the', 'book', 'because', 'he', 'was',
-        'interested', 'in', 'world', 'history']
-ref2a = ['he', 'was', 'interested', 'in', 'world', 'history',
-         'because', 'he', 'read', 'the', 'book']
-
-list_of_references = [[ref1a], [ref2a]]
-hypotheses = [hyp1, hyp2]
-google_bleu = evaluate.load_metric("google_bleu")
-results = google_bleu.compute(predictions=hypotheses, references=list_of_references)
-print(round(results["google_bleu"], 2))
->>> 0.44
+>>> predictions = ['It is a guide to action which ensures that the rubber duck always disobeys the commands of the cat', 'he read the book because he was interested in world history']
+>>> references = [['It is the guiding principle which guarantees the rubber duck forces never being under the command of the cat'], ['he was interested in world history because he read the book']]
+>>> google_bleu = evaluate.load_metric("google_bleu")
+>>> results = google_bleu.compute(predictions=predictions, references=references)
+>>> print(round(results["google_bleu"], 2))
+0.44
 ```
 
 Example with multiple references for the first sample:
 ```python
-hyp1 = ['It', 'is', 'a', 'guide', 'to', 'action', 'which',
-        'ensures', 'that', 'the', 'rubber', 'duck', 'always',
-        'disobeys', 'the', 'commands', 'of', 'the', 'cat']
-ref1a = ['It', 'is', 'the', 'guiding', 'principle', 'which',
-         'guarantees', 'the', 'rubber', 'duck', 'forces', 'never',
-         'being', 'under', 'the', 'command', 'of', 'the', 'cat']
-ref1b = ['It', 'is', 'a', 'guide', 'to', 'action', 'that',
-         'ensures', 'that', 'the', 'rubber', 'duck', 'will', 'never',
-         'heed', 'the', 'cat', 'commands']
-ref1c = ['It', 'is', 'the', 'practical', 'guide', 'for', 'the',
-         'rubber', 'duck', 'army', 'never', 'to', 'heed', 'the',
-         'directions', 'of', 'the', 'cat']
-
-hyp2 = ['he', 'read', 'the', 'book', 'because', 'he', 'was',
-        'interested', 'in', 'world', 'history']
-ref2a = ['he', 'was', 'interested', 'in', 'world', 'history',
-         'because', 'he', 'read', 'the', 'book']
-
-list_of_references = [[ref1a, ref1b, ref1c], [ref2a]]
-hypotheses = [hyp1, hyp2]
-google_bleu = evaluate.load_metric("google_bleu")
-results = google_bleu.compute(predictions=hypotheses, references=list_of_references)
-print(round(results["google_bleu"], 2))
->>> 0.61
+>>> predictions = ['It is a guide to action which ensures that the rubber duck always disobeys the commands of the cat', 'he read the book because he was interested in world history']
+>>> references  = [['It is the guiding principle which guarantees the rubber duck forces never being under the command of the cat', 'It is a guide to action that ensures that the rubber duck will never heed the cat commands', 'It is the practical guide for the rubber duck army never to heed the directions of the cat'], ['he was interested in world history because he read the book']]
+>>> google_bleu = evaluate.load_metric("google_bleu")
+>>> results = google_bleu.compute(predictions=hypotheses, references=list_of_references)
+>>> print(round(results["google_bleu"], 2))
+0.61
 ```
 
-Example with multiple references for the first sample, and with `min_len` adjusted to `2`, instead of the default `1`:
+Example with multiple references for the first sample, and with `min_len` adjusted to `2`, instead of the default `1`, which means that the function extracts n-grams of length `2`:
 ```python
-hyp1 = ['It', 'is', 'a', 'guide', 'to', 'action', 'which',
-        'ensures', 'that', 'the', 'rubber', 'duck', 'always',
-        'disobeys', 'the', 'commands', 'of', 'the', 'cat']
-ref1a = ['It', 'is', 'the', 'guiding', 'principle', 'which',
-         'guarantees', 'the', 'rubber', 'duck', 'forces', 'never',
-         'being', 'under', 'the', 'command', 'of', 'the', 'cat']
-ref1b = ['It', 'is', 'a', 'guide', 'to', 'action', 'that',
-         'ensures', 'that', 'the', 'rubber', 'duck', 'will', 'never',
-         'heed', 'the', 'cat', 'commands']
-ref1c = ['It', 'is', 'the', 'practical', 'guide', 'for', 'the',
-         'rubber', 'duck', 'army', 'never', 'to', 'heed', 'the',
-         'directions', 'of', 'the', 'cat']
-
-hyp2 = ['he', 'read', 'the', 'book', 'because', 'he', 'was',
-        'interested', 'in', 'world', 'history']
-ref2a = ['he', 'was', 'interested', 'in', 'world', 'history',
-         'because', 'he', 'read', 'the', 'book']
-
-list_of_references = [[ref1a, ref1b, ref1c], [ref2a]]
-hypotheses = [hyp1, hyp2]
-google_bleu = evaluate.load_metric("google_bleu")
-results = google_bleu.compute(predictions=hypotheses, references=list_of_references, min_len=2)
-print(results["google_bleu"])
->>> 0.53
+>>> predictions = ['It is a guide to action which ensures that the rubber duck always disobeys the commands of the cat', 'he read the book because he was interested in world history']
+>>> references = [['It is the guiding principle which guarantees the rubber duck forces never being under the command of the cat', 'It is a guide to action that ensures that the rubber duck will never heed the cat commands', 'It is the practical guide for the rubber duck army never to heed the directions of the cat'], ['he was interested in world history because he read the book']]
+>>> google_bleu = evaluate.load_metric("google_bleu")
+>>> results = google_bleu.compute(predictions=hypotheses, references=list_of_references, min_len=2)
+>>> print(round(results["google_bleu"], 2))
+0.53
 ```
 
 Example with multiple references for the first sample, with `min_len` adjusted to `2`, instead of the default `1`, and `max_len` adjusted to `6` instead of the default `4`:
 ```python
-hyp1 = ['It', 'is', 'a', 'guide', 'to', 'action', 'which',
-        'ensures', 'that', 'the', 'rubber', 'duck', 'always',
-        'disobeys', 'the', 'commands', 'of', 'the', 'cat']
-ref1a = ['It', 'is', 'the', 'guiding', 'principle', 'which',
-         'guarantees', 'the', 'rubber', 'duck', 'forces', 'never',
-         'being', 'under', 'the', 'command', 'of', 'the', 'cat']
-ref1b = ['It', 'is', 'a', 'guide', 'to', 'action', 'that',
-         'ensures', 'that', 'the', 'rubber', 'duck', 'will', 'never',
-         'heed', 'the', 'cat', 'commands']
-ref1c = ['It', 'is', 'the', 'practical', 'guide', 'for', 'the',
-         'rubber', 'duck', 'army', 'never', 'to', 'heed', 'the',
-         'directions', 'of', 'the', 'cat']
-
-hyp2 = ['he', 'read', 'the', 'book', 'because', 'he', 'was',
-        'interested', 'in', 'world', 'history']
-ref2a = ['he', 'was', 'interested', 'in', 'world', 'history',
-         'because', 'he', 'read', 'the', 'book']
-
-list_of_references = [[ref1a, ref1b, ref1c], [ref2a]]
-hypotheses = [hyp1, hyp2]
-google_bleu = evaluate.load_metric("google_bleu")
-results = google_bleu.compute(predictions=hypotheses, references=list_of_references, min_len=2, max_len=6)
-print(results["google_bleu"])
->>> 0.4
+>>> predictions = ['It is a guide to action which ensures that the rubber duck always disobeys the commands of the cat', 'he read the book because he was interested in world history']
+>>> references = [['It is the guiding principle which guarantees the rubber duck forces never being under the command of the cat', 'It is a guide to action that ensures that the rubber duck will never heed the cat commands', 'It is the practical guide for the rubber duck army never to heed the directions of the cat'], ['he was interested in world history because he read the book']]
+>>> google_bleu = evaluate.load_metric("google_bleu")
+>>> results = google_bleu.compute(predictions=hypotheses,references=list_of_references, min_len=2, max_len=6)
+>>> print(round(results["google_bleu"], 2))
+0.4
 ```
 
 ## Limitations and Bias
 
+The GoogleBLEU metric does not come with a predefined tokenization function; previous versions simply used `split()` to split the input strings into tokens. Using a tokenizer such as the default one, `tokenizer_13a`, makes results more standardized and reproducible. 
 
 ## Citation
 ```bibtex

--- a/metrics/google_bleu/tokenizer_13a.py
+++ b/metrics/google_bleu/tokenizer_13a.py
@@ -1,0 +1,100 @@
+# Source: https://github.com/mjpost/sacrebleu/blob/master/sacrebleu/tokenizers/tokenizer_13a.py
+# Copyright 2020 SacreBLEU Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from functools import lru_cache
+
+
+class BaseTokenizer:
+    """A base dummy tokenizer to derive from."""
+
+    def signature(self):
+        """
+        Returns a signature for the tokenizer.
+        :return: signature string
+        """
+        return "none"
+
+    def __call__(self, line):
+        """
+        Tokenizes an input line with the tokenizer.
+        :param line: a segment to tokenize
+        :return: the tokenized line
+        """
+        return line
+
+
+class TokenizerRegexp(BaseTokenizer):
+    def signature(self):
+        return "re"
+
+    def __init__(self):
+        self._re = [
+            # language-dependent part (assuming Western languages)
+            (re.compile(r"([\{-\~\[-\` -\&\(-\+\:-\@\/])"), r" \1 "),
+            # tokenize period and comma unless preceded by a digit
+            (re.compile(r"([^0-9])([\.,])"), r"\1 \2 "),
+            # tokenize period and comma unless followed by a digit
+            (re.compile(r"([\.,])([^0-9])"), r" \1 \2"),
+            # tokenize dash when preceded by a digit
+            (re.compile(r"([0-9])(-)"), r"\1 \2 "),
+            # one space only between words
+            # NOTE: Doing this in Python (below) is faster
+            # (re.compile(r'\s+'), r' '),
+        ]
+
+    @lru_cache(maxsize=2**16)
+    def __call__(self, line):
+        """Common post-processing tokenizer for `13a` and `zh` tokenizers.
+        :param line: a segment to tokenize
+        :return: the tokenized line
+        """
+        for (_re, repl) in self._re:
+            line = _re.sub(repl, line)
+
+        # no leading or trailing spaces, single space within words
+        # return ' '.join(line.split())
+        # This line is changed with regards to the original tokenizer (seen above) to return individual words
+        return line.split()
+
+
+class Tokenizer13a(BaseTokenizer):
+    def signature(self):
+        return "13a"
+
+    def __init__(self):
+        self._post_tokenizer = TokenizerRegexp()
+
+    @lru_cache(maxsize=2**16)
+    def __call__(self, line):
+        """Tokenizes an input line using a relatively minimal tokenization
+        that is however equivalent to mteval-v13a, used by WMT.
+
+        :param line: a segment to tokenize
+        :return: the tokenized line
+        """
+
+        # language-independent part:
+        line = line.replace("<skipped>", "")
+        line = line.replace("-\n", "")
+        line = line.replace("\n", " ")
+
+        if "&" in line:
+            line = line.replace("&quot;", '"')
+            line = line.replace("&amp;", "&")
+            line = line.replace("&lt;", "<")
+            line = line.replace("&gt;", ">")
+
+        return self._post_tokenizer(f" {line} ")


### PR DESCRIPTION
I did the same thing for `google BLEU` as I did for BLEU (see the [PR](https://github.com/huggingface/evaluate/pull/20)).

I triple-checked the examples and they give the same values as before! cc @lhoestq  :wink: 

I think this is the last metric that takes tokenized inputs, so we should be good in this sense.