### PR TITLE
Download from hub

### DIFF
--- a/src/evaluate/config.py
+++ b/src/evaluate/config.py
@@ -18,7 +18,7 @@ REPO_METRICS_URL = "https://raw.githubusercontent.com/huggingface/evaluate/{revi
 
 # Hub
 HF_ENDPOINT = os.environ.get("HF_ENDPOINT", "https://huggingface.co")
-HUB_DATASETS_URL = HF_ENDPOINT + "/datasets/{path}/resolve/{revision}/{name}"
+HUB_EVALUATE_URL = HF_ENDPOINT + "/spaces/{path}/resolve/{revision}/{name}"
 HUB_DEFAULT_VERSION = "main"
 
 PY_VERSION = version.parse(platform.python_version())

--- a/src/evaluate/utils/file_utils.py
+++ b/src/evaluate/utils/file_utils.py
@@ -108,7 +108,7 @@ def hf_github_url(path: str, name: str, dataset=True, revision: Optional[str] = 
 
 def hf_hub_url(path: str, name: str, revision: Optional[str] = None) -> str:
     revision = revision or config.HUB_DEFAULT_VERSION
-    return config.HUB_DATASETS_URL.format(path=path, name=name, revision=revision)
+    return config.HUB_EVALUATE_URL.format(path=path, name=name, revision=revision)
 
 
 def url_or_path_join(base_name: str, *pathnames: str) -> str:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -6,11 +6,18 @@ from unittest import TestCase
 import pytest
 
 import evaluate
-from evaluate.load import CachedMetricModuleFactory, GithubMetricModuleFactory, LocalMetricModuleFactory
+from evaluate.load import (
+    CachedMetricModuleFactory,
+    GithubMetricModuleFactory,
+    HubMetricModuleFactory,
+    LocalMetricModuleFactory,
+)
 from evaluate.utils.file_utils import DownloadConfig
 
 from .utils import OfflineSimulationMode, offline
 
+
+SAMPLE_METRIC_IDENTIFIER = "lvwerra/test"
 
 METRIC_LOADING_SCRIPT_NAME = "__dummy_metric1__"
 
@@ -66,6 +73,15 @@ class ModuleFactoryTest(TestCase):
         # "bleu" requires additional imports (external from github)
         factory = GithubMetricModuleFactory(
             "bleu", download_config=self.download_config, dynamic_modules_path=self.dynamic_modules_path
+        )
+        module_factory_result = factory.get_module()
+        assert importlib.import_module(module_factory_result.module_path) is not None
+
+    def test_HubDatasetModuleFactoryWithScript(self):
+        factory = HubMetricModuleFactory(
+            SAMPLE_METRIC_IDENTIFIER,
+            download_config=self.download_config,
+            dynamic_modules_path=self.dynamic_modules_path,
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None


### PR DESCRIPTION
This PR adds the logic to load metrics on spaces introduce in #14 with `evaluate`. 

After running:

```bash
evaluate-cli create test
```

With this PR you can then:

```python
from evaluate import load_metrics

metric = load_metric("lvwerra/test")
```

At the moment you can still load "canonical" metrics from the hub. These are the metrics without a `"/"` in their name. Once we can push all of them to the hub we can remove that functionality, too.