### PR TITLE
Remove implicit input casting to strings

### DIFF
--- a/src/evaluate/info.py
+++ b/src/evaluate/info.py
@@ -22,8 +22,7 @@ import os
 from dataclasses import asdict, dataclass, field
 from typing import List, Optional
 
-import pyarrow as pa
-from datasets.features import Features, Sequence, Value
+from datasets.features import Features, Value
 
 from . import config
 from .utils.logging import get_logger
@@ -67,7 +66,6 @@ class MetricInfo:
                         f"When using 'numpy' format, all features should be a `datasets.Value` feature. "
                         f"Here {key} is an instance of {value.__class__.__name__}"
                     )
-        self.features = Features(self._patch_nested_features(self.features))
 
     def write_to_directory(self, metric_info_dir):
         """Write `MetricInfo` as JSON to `metric_info_dir`.
@@ -99,37 +97,3 @@ class MetricInfo:
     def from_dict(cls, metric_info_dict: dict) -> "MetricInfo":
         field_names = {f.name for f in dataclasses.fields(cls)}
         return cls(**{k: v for k, v in metric_info_dict.items() if k in field_names})
-
-    def _patch_nested_features(self, schema):
-        """Patches feature types of nested Features. This overwrites the default `encode_example` method of `Value` to not cast to string."""
-        # Nested structures: we allow dict, list, tuples, sequences
-        if isinstance(schema, dict):
-            return {k: self._patch_nested_features(sub_schema) for k, sub_schema in schema.items()}
-        elif isinstance(schema, list):
-            return [self._patch_nested_features(sub_schema) for sub_schema in schema]
-        elif isinstance(schema, tuple):
-            return tuple(self._patch_nested_features(sub_schema) for sub_schema in schema)
-        elif isinstance(schema, Sequence):
-            return Sequence(self._patch_nested_features(schema.feature))
-        # patch Value `encode_example` method with function that does not cast to string
-        elif isinstance(schema, Value):
-            schema.encode_example = _encode_example.__get__(schema, Value)
-        # Other object should be directly convertible to a native Arrow type (like Translation and Translation)
-        return schema
-
-
-def _encode_example(self, value):
-    if pa.types.is_boolean(self.pa_type):
-        return bool(value)
-    elif pa.types.is_integer(self.pa_type):
-        return int(value)
-    elif pa.types.is_floating(self.pa_type):
-        return float(value)
-    elif pa.types.is_string(self.pa_type):
-        # patched case:
-        if isinstance(value, str):
-            return value
-        else:
-            raise TypeError(f"Expected type str but got {type(value)}.")
-    else:
-        return value

--- a/src/evaluate/metric.py
+++ b/src/evaluate/metric.py
@@ -25,10 +25,11 @@ from datasets import DatasetInfo
 from datasets.arrow_dataset import Dataset
 from datasets.arrow_reader import ArrowReader
 from datasets.arrow_writer import ArrowWriter
-from datasets.features import Features
+from datasets.features import Features, Sequence, Value
+from datasets.features.features import _check_non_null_non_empty_recursive
 from datasets.utils.download_manager import DownloadManager
 from datasets.utils.filelock import BaseFileLock, FileLock, Timeout
-from datasets.utils.py_utils import copyfunc, temp_seed
+from datasets.utils.py_utils import copyfunc, temp_seed, zip_dict
 
 from . import config
 from .info import MetricInfo
@@ -464,6 +465,8 @@ class Metric(MetricInfoMixin):
         if self.writer is None:
             self._init_writer()
         try:
+            for key, column in batch.items():
+                [self._enforce_nested_string_type(self.info.features[key], obj) for obj in column]
             batch = self.info.features.encode_batch(batch)
             self.writer.write_batch(batch)
         except (pa.ArrowInvalid, TypeError):
@@ -503,6 +506,7 @@ class Metric(MetricInfoMixin):
         if self.writer is None:
             self._init_writer()
         try:
+            self._enforce_nested_string_type(self.info.features, example)
             example = self.info.features.encode_example(example)
             self.writer.write(example)
         except (pa.ArrowInvalid, TypeError):
@@ -610,3 +614,44 @@ class Metric(MetricInfoMixin):
             del self.writer
         if hasattr(self, "data"):  # in case it was already deleted
             del self.data
+
+    def _enforce_nested_string_type(self, schema, obj):
+        """
+        Recursively checks if there is any Value feature of type string and throws TypeError if corresponding object is not a string.
+        Since any Python object can be cast to string this avoids implicitly casting wrong input types (e.g. lists) to string without error.
+        """
+        # Nested structures: we allow dict, list, tuples, sequences
+        if isinstance(schema, dict):
+            return [self._enforce_nested_string_type(sub_schema, o) for k, (sub_schema, o) in zip_dict(schema, obj)]
+
+        elif isinstance(schema, (list, tuple)):
+            sub_schema = schema[0]
+            return [self._enforce_nested_string_type(sub_schema, o) for o in obj]
+        elif isinstance(schema, Sequence):
+            # We allow to reverse list of dict => dict of list for compatiblity with tfds
+            if isinstance(schema.feature, dict):
+                if isinstance(obj, (list, tuple)):
+                    # obj is a list of dict
+                    for k, dict_tuples in zip_dict(schema.feature, *obj):
+                        return [self._enforce_nested_string_type(dict_tuples[0], o) for o in dict_tuples[1:]]
+                else:
+                    # obj is a single dict
+                    for k, (sub_schema, sub_objs) in zip_dict(schema.feature, obj):
+                        return [self._enforce_nested_string_type(sub_schema, o) for o in sub_objs]
+            # schema.feature is not a dict
+            if isinstance(obj, str):  # don't interpret a string as a list
+                raise ValueError(f"Got a string but expected a list instead: '{obj}'")
+            if obj is None:
+                return None
+            else:
+                if len(obj) > 0:
+                    for first_elmt in obj:
+                        if _check_non_null_non_empty_recursive(first_elmt, schema.feature):
+                            break
+                    if not isinstance(first_elmt, list):
+                        return [self._enforce_nested_string_type(schema.feature, o) for o in obj]
+
+        # patch Value `encode_example` method with function that does not cast to string
+        elif isinstance(schema, Value):
+            if pa.types.is_string(schema.pa_type) and not isinstance(obj, str):
+                raise TypeError(f"Expected type str but got {type(obj)}.")

--- a/src/evaluate/metric.py
+++ b/src/evaluate/metric.py
@@ -651,7 +651,6 @@ class Metric(MetricInfoMixin):
                     if not isinstance(first_elmt, list):
                         return [self._enforce_nested_string_type(schema.feature, o) for o in obj]
 
-        # patch Value `encode_example` method with function that does not cast to string
         elif isinstance(schema, Value):
             if pa.types.is_string(schema.pa_type) and not isinstance(obj, str):
                 raise TypeError(f"Expected type str but got {type(obj)}.")

--- a/src/evaluate/metric.py
+++ b/src/evaluate/metric.py
@@ -461,12 +461,12 @@ class Metric(MetricInfoMixin):
             raise ValueError(f"Bad inputs for metric: {bad_inputs}. All required inputs are {list(self.features)}")
         batch = {"predictions": predictions, "references": references, **kwargs}
         batch = {intput_name: batch[intput_name] for intput_name in self.features}
-        batch = self.info.features.encode_batch(batch)
         if self.writer is None:
             self._init_writer()
         try:
+            batch = self.info.features.encode_batch(batch)
             self.writer.write_batch(batch)
-        except pa.ArrowInvalid:
+        except (pa.ArrowInvalid, TypeError):
             if any(len(batch[c]) != len(next(iter(batch.values()))) for c in batch):
                 col0 = next(iter(batch))
                 bad_col = [c for c in batch if len(batch[c]) != len(batch[col0])][0]
@@ -500,12 +500,12 @@ class Metric(MetricInfoMixin):
             raise ValueError(f"Bad inputs for metric: {bad_inputs}. All required inputs are {list(self.features)}")
         example = {"predictions": prediction, "references": reference, **kwargs}
         example = {intput_name: example[intput_name] for intput_name in self.features}
-        example = self.info.features.encode_example(example)
         if self.writer is None:
             self._init_writer()
         try:
+            example = self.info.features.encode_example(example)
             self.writer.write(example)
-        except pa.ArrowInvalid:
+        except (pa.ArrowInvalid, TypeError):
             error_msg = f"Metric inputs don't match the expected format.\n" f"Expected format: {self.features},\n"
             error_msg_inputs = ",\n".join(
                 f"Input {input_name}: {summarize_if_long_list(example[input_name])}" for input_name in self.features


### PR DESCRIPTION
This PR addresses an issue discussed in #15 where any input type can be converted to string if the feature type is string.

Example: `rouge` expects a single string as reference. If a list of strings is passed instead (like for `bleu`) the list is currently converted to a string without an error.

Since `pa.array` casts to the provided input types we need to throw an error before that. The method `Value.encode_example` could be a good place. This PR applies a patch to the `Value` objects in the metrics features.

However, there is an issue with pickling the patched object. Any ideas @lhoestq @albertvillanova?