### PR TITLE
Model comparisons with McNemar test as first example

### DIFF
--- a/comparisons/mcnemar/mcnemar.py
+++ b/comparisons/mcnemar/mcnemar.py
@@ -1,0 +1,90 @@
+# Copyright 2022 The HuggingFace Evaluate Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""McNemar test for model comparison."""
+
+import datasets
+from scipy.stats import chi2
+
+import evaluate
+
+
+_DESCRIPTION = """
+McNemar's test is a diagnostic test over a contingency table resulting from the predictions of two classifiers. The test compares the sensitivity and specificity of the diagnostic tests on the same group reference labels. It can be computed with:
+McNemar = (SE - SP)**2 / SE + SP
+ Where:
+SE: Sensitivity (Test 1 positive; Test 2 negative)
+SP: Specificity (Test 1 negative; Test 2 positive)
+"""
+
+
+_KWARGS_DESCRIPTION = """
+Args:
+    predictions1 (`list` of `int`): Predicted labels for model 1.
+    predictions2 (`list` of `int`): Predicted labels for model 2.
+    references (`list` of `int`): Ground truth labels.
+
+Returns:
+    p (`float` or `int`): McNemar test score. Minimum possible value is 0. Maximum possible value is 1.0. A lower p value means a more significant difference.
+
+Examples:
+    >>> mcnemar_comparison = evaluate.load_comparison("mcnemar")
+    >>> results = mcnemar_comparison.compute(references=np.random.randint(1, size=10), predictions1=np.random.randint(1, size=10), predictions2=np.random.randint(1, size=10))
+    >>> print(results)
+    {'stat': 0.123, 'p': 0.321}
+"""
+
+
+_CITATION = """
+@article{mcnemar1947note,
+  title={Note on the sampling error of the difference between correlated proportions or percentages},
+  author={McNemar, Quinn},
+  journal={Psychometrika},
+  volume={12},
+  number={2},
+  pages={153--157},
+  year={1947},
+  publisher={Springer-Verlag}
+}
+"""
+
+
+@evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
+class McNemar(evaluate.Comparison):
+    def _info(self):
+        return evaluate.ComparisonInfo(
+            description=_DESCRIPTION,
+            citation=_CITATION,
+            inputs_description=_KWARGS_DESCRIPTION,
+        )
+
+    def _compute(self, predictions1, predictions2, references):
+        # construct contingency table
+        tbl = [[0, 0], [0, 0]]
+        for gt, p1, p2 in zip(references, predictions1, predictions2):
+            if p1 == gt and p2 == gt:
+                tbl[0][0] += 1
+            elif p1 == gt:
+                tbl[0][1] += 1
+            elif p2 == gt:
+                tbl[1][0] += 1
+            else:
+                tbl[1][1] += 1
+
+        # compute statistic
+        b, c = tbl[0][1], tbl[1][0]
+        statistic = abs(b - c) ** 2 / (1.0 * (b + c))
+        df = 1
+        pvalue = chi2.sf(statistic, df)
+
+        return {"stat": statistic, "p": pvalue}

--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -26,9 +26,10 @@ SCRIPTS_VERSION = "main" if version.parse(__version__).is_devrelease else __vers
 
 del version
 
-from .info import MetricInfo
+from .comparison import Comparison
+from .info import ComparisonInfo, MetricInfo
 from .inspect import inspect_metric, list_metrics
-from .load import load_metric
+from .load import load_comparison, load_metric
 from .metric import Metric
 from .utils import *
 from .utils import gradio, logging

--- a/src/evaluate/comparison.py
+++ b/src/evaluate/comparison.py
@@ -1,0 +1,109 @@
+# Copyright 2022 The HuggingFace Evaluate Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+""" Comparisons base class."""
+import types
+from typing import Optional
+
+from datasets.utils.py_utils import copyfunc
+
+from .info import ComparisonInfo
+from .naming import camelcase_to_snakecase
+
+
+class ComparisonInfoMixin:
+    """Base class for exposing ComparisonInfo attributes"""
+
+    def __init__(self, info: ComparisonInfo):
+        self._comparison_info = info
+
+    @property
+    def info(self):
+        """:class:`evaluate.ComparisonInfo` object containing all the comparison metadata."""
+        return self._comparison_info
+
+    @property
+    def name(self) -> str:
+        return self._comparison_info.comparison_name
+
+    @property
+    def description(self) -> str:
+        return self._comparison_info.description
+
+    @property
+    def citation(self) -> str:
+        return self._comparison_info.citation
+
+    @property
+    def inputs_description(self) -> str:
+        return self._comparison_info.inputs_description
+
+
+class Comparison(ComparisonInfoMixin):
+    """A Comparison is the base class for comparing two models.
+
+    Args:
+        config_name (``str``): Overwritten by comparison loading script.
+    """
+
+    def __init__(
+        self,
+        config_name: Optional[str] = None,
+        **kwargs,
+    ):
+        # prepare info
+        self.config_name = config_name or "default"
+        info = self._info()
+        info.comparison_name = camelcase_to_snakecase(self.__class__.__name__)
+        info.config_name = self.config_name
+        ComparisonInfoMixin.__init__(self, info)
+
+        self.compute = types.MethodType(copyfunc(self.compute), self)
+        self.compute.__func__.__doc__ += self.info.inputs_description
+
+    def __repr__(self):
+        return f'Comparison(name: "{self.name}", ' f'usage: """{self.inputs_description}""")'
+
+    def compute(self, *, predictions1=None, predictions2=None, references=None, **kwargs) -> Optional[dict]:
+        """Compute the comparison.
+
+        Usage of positional arguments is not allowed to prevent mistakes.
+
+        Args:
+            predictions1 (list/array/tensor, optional): Predictions of model 1.
+            predictions2 (list/array/tensor, optional): Predictions of model 2.
+            references (list/array/tensor, optional): References.
+            **kwargs (optional): Keyword arguments that will be forwarded to the metrics :meth:`_compute`
+                method (see details in the docstring).
+
+        Return:
+            dict or None
+        """
+        all_kwargs = {"predictions1": predictions1, "predictions2": predictions2, "references": references, **kwargs}
+        required_kwargs = ["predictions1", "predictions2", "references"]
+        if predictions1 is None and predictions2 is None and references is None:
+            missing_kwargs = {k: None for k in required_kwargs if k not in all_kwargs}
+            all_kwargs.update(missing_kwargs)
+        else:
+            missing_inputs = [k for k in required_kwargs if k not in all_kwargs]
+            if missing_inputs:
+                raise ValueError(
+                    f"Metric inputs are missing: {missing_inputs}. All required inputs are {required_kwargs}"
+                )
+        inputs = {input_name: all_kwargs[input_name] for input_name in required_kwargs}
+        compute_kwargs = {k: kwargs[k] for k in kwargs if k not in required_kwargs}
+
+        output = self._compute(**inputs, **compute_kwargs)
+        return output

--- a/src/evaluate/info.py
+++ b/src/evaluate/info.py
@@ -97,3 +97,23 @@ class MetricInfo:
     def from_dict(cls, metric_info_dict: dict) -> "MetricInfo":
         field_names = {f.name for f in dataclasses.fields(cls)}
         return cls(**{k: v for k, v in metric_info_dict.items() if k in field_names})
+
+
+@dataclass
+class ComparisonInfo:
+    """Information about a comparison.
+
+    `ComparisonInfo` documents a comparison, including its name and inputs.
+    See the constructor arguments and properties for a full list.
+
+    Note: Not all fields are known on construction and may be updated later.
+    """
+
+    # Set in the comparison scripts
+    description: str
+    citation: str
+    inputs_description: str = field(default_factory=str)
+
+    # Set later by the builder
+    comparison_name: Optional[str] = None
+    config_name: Optional[str] = None

--- a/src/evaluate/inspect.py
+++ b/src/evaluate/inspect.py
@@ -20,7 +20,7 @@ from typing import Optional
 import huggingface_hub
 from datasets.utils import DownloadConfig
 
-from .load import metric_module_factory
+from .load import evaluate_module_factory
 from .utils.logging import get_logger
 
 
@@ -61,8 +61,12 @@ def inspect_metric(path: str, local_path: str, download_config: Optional[Downloa
         download_config (Optional ``datasets.DownloadConfig``: specific download configuration parameters.
         **download_kwargs: optional attributes for DownloadConfig() which will override the attributes in download_config if supplied.
     """
-    metric_module = metric_module_factory(
-        path, download_config=download_config, force_local_path=local_path, **download_kwargs
+    metric_module = evaluate_module_factory(
+        path,
+        module_namespace="metrics",
+        download_config=download_config,
+        force_local_path=local_path,
+        **download_kwargs,
     )
     print(
         f"The processing scripts for metric {path} can be inspected at {local_path}. "

--- a/tests/test_metric_common.py
+++ b/tests/test_metric_common.py
@@ -76,7 +76,9 @@ class LocalMetricTest(parameterized.TestCase):
     def test_load_metric(self, metric_name):
         doctest.ELLIPSIS_MARKER = "[...]"
         metric_module = importlib.import_module(
-            evaluate.load.metric_module_factory(os.path.join("metrics", metric_name)).module_path
+            evaluate.load.evaluate_module_factory(
+                os.path.join("metrics", metric_name), module_namespace="metrics"
+            ).module_path
         )
         metric = evaluate.load.import_main_class(metric_module.__name__, dataset=False)
         # check parameters
@@ -96,7 +98,9 @@ class LocalMetricTest(parameterized.TestCase):
     def test_load_real_metric(self, metric_name):
         doctest.ELLIPSIS_MARKER = "[...]"
         metric_module = importlib.import_module(
-            evaluate.load.metric_module_factory(os.path.join("metrics", metric_name)).module_path
+            evaluate.load.evaluate_module_factory(
+                os.path.join("metrics", metric_name), module_namespace="metrics"
+            ).module_path
         )
         # run doctest
         with self.use_local_metrics():


### PR DESCRIPTION
As discussed, it would be nice to add more evaluation-related things to the library so that we go beyond just metrics.

I had a bit of free time so I figured I'd have a quick go at adding model comparisons, e.g. [McNemar](https://en.wikipedia.org/wiki/McNemar%27s_test), so that we can start a discussion on what this would look like. We'll need a similar thing for `measurements` like `npmi` potentially.

Basic example:

```
import numpy as np
from evaluate import load_metric, load_comparison

preds1 = np.random.randint(2, size=100)
preds2 = np.random.randint(2, size=100)
refs = np.random.randint(2, size=100)
accuracy = load_metric("accuracy")
print(accuracy.compute(predictions=preds1, references=refs))
print(accuracy.compute(predictions=preds2, references=refs))
mcnemar = load_comparison("evaluate/comparisons/mcnemar/mcnemar.py")
print(mcnemar.compute(predictions1=preds1, predictions2=preds2, references=refs))
```

I had to refactor the loader's module factory to be namespace-agnostic, not sure if that's the best solution here.

Wdyt @lvwerra @lhoestq? (cc @sashavor)