### PR TITLE
extend features to list of features for metrics with multiple types

### DIFF
--- a/src/evaluate/info.py
+++ b/src/evaluate/info.py
@@ -20,7 +20,7 @@ import dataclasses
 import json
 import os
 from dataclasses import asdict, dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from datasets.features import Features, Value
 
@@ -44,7 +44,7 @@ class MetricInfo:
     # Set in the dataset scripts
     description: str
     citation: str
-    features: Features
+    features: Union[Features, List[Features]]
     inputs_description: str = field(default_factory=str)
     homepage: str = field(default_factory=str)
     license: str = field(default_factory=str)

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -36,6 +36,10 @@ class DummyMetric(Metric):
         return ([1, 2, 3, 4], [1, 2, 4, 3])
 
     @classmethod
+    def predictions_and_references_strings(cls):
+        return (["a", "b", "c", "d"], ["a", "b", "d", "c"])
+
+    @classmethod
     def expected_results(cls):
         return {"accuracy": 0.5, "set_equality": True}
 
@@ -476,6 +480,18 @@ class TestMetric(TestCase):
         for pred, ref in zip(preds, refs):
             metric.add(prediction=pred, reference=ref)
         self.assertDictEqual(expected_results, metric.compute())
+        del metric
+
+    def test_multiple_features(self):
+        metric = DummyMetric()
+        metric.info.features = [
+            Features({"predictions": Value("int64"), "references": Value("int64")}),
+            Features({"predictions": Value("string"), "references": Value("string")}),
+        ]
+
+        preds, refs = DummyMetric.predictions_and_references()
+        expected_results = DummyMetric.expected_results()
+        self.assertDictEqual(expected_results, metric.compute(predictions=preds, references=refs))
         del metric
 
 


### PR DESCRIPTION
This PR enables having multiple `Features` listed in a `Metric` for metrics that can have different kinds of inputs. On the first element or batch which feature is used is inferred from the data. It assumes that fields of each feature are the same but their values can differ (i.e. they all have the same column names). 

This is related to #10 and #15.