### PR TITLE
Adding text lengths measurement

### DIFF
--- a/measurements/textlengths/textlengths.py
+++ b/measurements/textlengths/textlengths.py
@@ -1,0 +1,65 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nltk import word_tokenize
+import evaluate
+import datasets
+from statistics import mean
+
+_DESCRIPTION = """
+Returns the length (in words) of each instance in the text fields.
+"""
+
+_KWARGS_DESCRIPTION = """
+Args:
+
+Returns:
+
+Examples:
+
+
+"""
+
+# TODO: Add BibTeX citation
+_CITATION = """\
+@InProceedings{huggingface:module,
+title = {A great new module},
+authors={huggingface, Inc.},
+year={2020}
+}
+"""
+
+@evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
+class TestMeasurement(evaluate.EvaluationModule):
+    """TODO: Short description of my evaluation module."""
+
+    def _info(self):
+        # TODO: Specifies the evaluate.EvaluationModuleInfo object
+        return evaluate.EvaluationModuleInfo(
+            # This is the description that will appear on the modules page.
+            type="measurement",
+            description=_DESCRIPTION,
+            citation=_CITATION,
+            inputs_description=_KWARGS_DESCRIPTION,
+            # This defines the format of each prediction and reference
+            features=datasets.Features({
+                'data': datasets.Value('string'),
+            })
+        )
+
+    def _compute(self, texts):
+        """Returns the lengths"""
+        lengths = [len(word_tokenize(text)) for text in texts]
+        average_length = mean(lengths)
+        return {"average_length": average_length, "all lengths":lengths}

--- a/measurements/word_length/README.md
+++ b/measurements/word_length/README.md
@@ -1,0 +1,57 @@
+# Measurement Card for Word Length
+
+
+## Metric Description
+
+The `word_length` measurement returns the word count of the input string, based on tokenization using [NLTK word_tokenize](https://www.nltk.org/api/nltk.tokenize.html).
+
+## How to Use
+
+This measurement requires a list of strings as input:
+
+```python
+>>> data = ["hello world"]
+>>> wordlength = evaluate.load("word_length", type="measurement")
+>>> results = wordlength.compute(data=data)
+```
+
+### Inputs
+- **data** (list of `str`): The input list of strings for which the word length is calculated.
+- **tokenizer** (`str`) : approach used for tokenizing `data` (optional). The default tokenizer is [NLTK's `word_tokenize`](https://www.nltk.org/api/nltk.tokenize.html). This can be replaced by any function that takes a string as input and returns a list of tokens as output.
+
+### Output Values
+- **average_word_length**(`int`): the average number of words in the input string(s).
+
+Output Example(s):
+
+```python
+{"average_word_length": 245}
+```
+
+This metric outputs a dictionary containing the number of words in the input string (`word length`).
+
+### Examples
+
+Example for a single string
+
+```python
+>>> data = ["hello sun and goodbye moon"]
+>>> wordlength = evaluate.load("word_length", type="measurement")
+>>> results = wordlength.compute(data=data)
+>>> print(results)
+{'average_length': 5}
+```
+
+Example for a multiple strings
+```python
+>>> data = ["hello sun and goodbye moon", "foo bar foo bar"]
+>>> wordlength = evaluate.load("word_length", type="measurement")
+>>> results = wordlength.compute(data=text)
+{'average_length': 4.5}
+```
+
+## Citation(s)
+
+
+## Further References
+- [NLTK's `word_tokenize`](https://www.nltk.org/api/nltk.tokenize.html)

--- a/measurements/word_length/README.md
+++ b/measurements/word_length/README.md
@@ -17,7 +17,7 @@ This measurement requires a list of strings as input:
 
 ### Inputs
 - **data** (list of `str`): The input list of strings for which the word length is calculated.
-- **tokenizer** (`str`) : approach used for tokenizing `data` (optional). The default tokenizer is [NLTK's `word_tokenize`](https://www.nltk.org/api/nltk.tokenize.html). This can be replaced by any function that takes a string as input and returns a list of tokens as output.
+- **tokenizer** (`Callable`) : approach used for tokenizing `data` (optional). The default tokenizer is [NLTK's `word_tokenize`](https://www.nltk.org/api/nltk.tokenize.html). This can be replaced by any function that takes a string as input and returns a list of tokens as output.
 
 ### Output Values
 - **average_word_length**(`int`): the average number of words in the input string(s).

--- a/measurements/word_length/README.md
+++ b/measurements/word_length/README.md
@@ -20,7 +20,7 @@ This measurement requires a list of strings as input:
 - **tokenizer** (`Callable`) : approach used for tokenizing `data` (optional). The default tokenizer is [NLTK's `word_tokenize`](https://www.nltk.org/api/nltk.tokenize.html). This can be replaced by any function that takes a string as input and returns a list of tokens as output.
 
 ### Output Values
-- **average_word_length**(`int`): the average number of words in the input string(s).
+- **average_word_length**(`float`): the average number of words in the input string(s).
 
 Output Example(s):
 

--- a/measurements/word_length/app.py
+++ b/measurements/word_length/app.py
@@ -1,0 +1,6 @@
+import evaluate
+from evaluate.utils import launch_gradio_widget
+
+
+module = evaluate.load("word_length", type="measurement")
+launch_gradio_widget(module)

--- a/measurements/word_length/requirements.txt
+++ b/measurements/word_length/requirements.txt
@@ -1,0 +1,3 @@
+git+https://github.com/huggingface/evaluate.git@main
+datasets~=2.0
+nltk~=3.7

--- a/measurements/word_length/word_length.py
+++ b/measurements/word_length/word_length.py
@@ -24,7 +24,7 @@ Returns the average length (in terms of the number of words) of the input data.
 _KWARGS_DESCRIPTION = """
 Args:
     `data`: a list of `str` for which the word length is calculated.
-    `tokenizer` : approach used for tokenizing `data` (optional).
+    `tokenizer` : (`Callable`) - the approach used for tokenizing `data` (optional).
         The default tokenizer is `word_tokenize` from NLTK: https://www.nltk.org/api/nltk.tokenize.html
         This can be replaced by any function that takes a string as input and returns a list of tokens as output.
 

--- a/measurements/word_length/word_length.py
+++ b/measurements/word_length/word_length.py
@@ -66,5 +66,5 @@ class WordLength(evaluate.EvaluationModule):
 
     def _compute(self, data):
         """Returns the word length of the input data"""
-        length = len(word_tokenize(data)
+        length = len(word_tokenize(data))
         return {"word length": length}

--- a/measurements/word_length/word_length.py
+++ b/measurements/word_length/word_length.py
@@ -33,7 +33,7 @@ Examples:
     >>> data = ["hello world"]
     >>> wordlength = evaluate.load("word_length", type="measurement")
     >>> results = wordlength.compute(data=data)
-    >>> print(results["bleu"])
+    >>> print(results)
     {"word length": 2}
 """
 

--- a/measurements/word_length/word_length.py
+++ b/measurements/word_length/word_length.py
@@ -18,13 +18,15 @@ import datasets
 from statistics import mean
 
 _DESCRIPTION = """
-Returns the length (in words) of the input data.
-The tokenizer used is `word_tokenize` from NLTK: https://www.nltk.org/api/nltk.tokenize.html
+Returns the average length (in terms of the number of words) of the input data.
 """
 
 _KWARGS_DESCRIPTION = """
 Args:
-    data: a `str` for which the word length is calculated.
+    data: a list of `str` for which the word length is calculated.
+    tokenizer : approach used for tokenizing `data` (optional).
+        The default tokenizer is `word_tokenize` from NLTK: https://www.nltk.org/api/nltk.tokenize.html
+        This can be replaced by any function that takes a string as input and returns a list of tokens as output.
 
 Returns:
     'word length' : the number of words in the input string.
@@ -48,7 +50,7 @@ year={2020}
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class WordLength(evaluate.EvaluationModule):
-    """This measurement returns the number of words in the input string."""
+    """This measurement returns the average number of words in the input string(s)."""
 
     def _info(self):
         # TODO: Specifies the evaluate.EvaluationModuleInfo object
@@ -64,7 +66,8 @@ class WordLength(evaluate.EvaluationModule):
             })
         )
 
-    def _compute(self, data):
-        """Returns the word length of the input data"""
-        length = len(word_tokenize(data))
-        return {"word length": length}
+    def _compute(self, data, tokenizer=word_tokenize):
+        """Returns the average word length of the input data"""
+        lengths = [len(tokenizer(d)) for d in data]
+        average_length = mean(lengths)
+        return {"average_word_length": average_length}

--- a/measurements/word_length/word_length.py
+++ b/measurements/word_length/word_length.py
@@ -24,12 +24,12 @@ Returns the average length (in terms of the number of words) of the input data.
 _KWARGS_DESCRIPTION = """
 Args:
     `data`: a list of `str` for which the word length is calculated.
-    `tokenizer` : (`Callable`) - the approach used for tokenizing `data` (optional).
+    `tokenizer` (`Callable`) : the approach used for tokenizing `data` (optional).
         The default tokenizer is `word_tokenize` from NLTK: https://www.nltk.org/api/nltk.tokenize.html
         This can be replaced by any function that takes a string as input and returns a list of tokens as output.
 
 Returns:
-    `average_word_length` : the average number of words in the input list of strings.
+    `average_word_length` (`float`) : the average number of words in the input list of strings.
 
 Examples:
     >>> data = ["hello world"]

--- a/measurements/word_length/word_length.py
+++ b/measurements/word_length/word_length.py
@@ -23,20 +23,20 @@ Returns the average length (in terms of the number of words) of the input data.
 
 _KWARGS_DESCRIPTION = """
 Args:
-    data: a list of `str` for which the word length is calculated.
-    tokenizer : approach used for tokenizing `data` (optional).
+    `data`: a list of `str` for which the word length is calculated.
+    `tokenizer` : approach used for tokenizing `data` (optional).
         The default tokenizer is `word_tokenize` from NLTK: https://www.nltk.org/api/nltk.tokenize.html
         This can be replaced by any function that takes a string as input and returns a list of tokens as output.
 
 Returns:
-    'word length' : the number of words in the input string.
+    `average_word_length` : the average number of words in the input list of strings.
 
 Examples:
     >>> data = ["hello world"]
     >>> wordlength = evaluate.load("word_length", type="measurement")
     >>> results = wordlength.compute(data=data)
     >>> print(results)
-    {"word length": 2}
+    {"average_word_length": 2}
 """
 
 # TODO: Add BibTeX citation

--- a/measurements/word_length/word_length.py
+++ b/measurements/word_length/word_length.py
@@ -18,17 +18,23 @@ import datasets
 from statistics import mean
 
 _DESCRIPTION = """
-Returns the length (in words) of each instance in the text fields.
+Returns the length (in words) of the input data.
+The tokenizer used is `word_tokenize` from NLTK: https://www.nltk.org/api/nltk.tokenize.html
 """
 
 _KWARGS_DESCRIPTION = """
 Args:
+    data: a `str` for which the word length is calculated.
 
 Returns:
+    'word length' : the number of words in the input string.
 
 Examples:
-
-
+    >>> data = ["hello world"]
+    >>> wordlength = evaluate.load("word_length", type="measurement")
+    >>> results = wordlength.compute(data=data)
+    >>> print(results["bleu"])
+    {"word length": 2}
 """
 
 # TODO: Add BibTeX citation
@@ -41,8 +47,8 @@ year={2020}
 """
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class TestMeasurement(evaluate.EvaluationModule):
-    """TODO: Short description of my evaluation module."""
+class WordLength(evaluate.EvaluationModule):
+    """This measurement returns the number of words in the input string."""
 
     def _info(self):
         # TODO: Specifies the evaluate.EvaluationModuleInfo object
@@ -58,8 +64,7 @@ class TestMeasurement(evaluate.EvaluationModule):
             })
         )
 
-    def _compute(self, texts):
-        """Returns the lengths"""
-        lengths = [len(word_tokenize(text)) for text in texts]
-        average_length = mean(lengths)
-        return {"average_length": average_length, "all lengths":lengths}
+    def _compute(self, data):
+        """Returns the word length of the input data"""
+        length = len(word_tokenize(data)
+        return {"word length": length}


### PR DESCRIPTION
.... but there's a bug that's driving me mad, @lvwerra can you help? it's probably something silly but I can't figure it out :see_no_evil: 

When I call `compute()`, it says:
```
>>> lengths.compute('hello')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: compute() takes 1 positional argument but 2 were given
```
But there is a single argument, why is it saying I'm giving 2?...
