### PR TITLE
update to gradio 3.0.2

### DIFF
--- a/src/evaluate/utils/gradio.py
+++ b/src/evaluate/utils/gradio.py
@@ -108,7 +108,7 @@ def launch_gradio_widget(metric):
         fn=compute,
         inputs=gr.inputs.Dataframe(
             headers=feature_names,
-            col_width=len(feature_names),
+            col_count=len(feature_names),
             row_count=2,
             datatype=json_to_string_type(gradio_input_types),
         ),

--- a/templates/{{ cookiecutter.module_slug }}/README.md
+++ b/templates/{{ cookiecutter.module_slug }}/README.md
@@ -6,7 +6,7 @@ tags:
 - evaluate
 - {{ cookiecutter.module_name }}
 sdk: gradio
-sdk_version: 2.8.13
+sdk_version: 3.0.2
 app_file: app.py
 pinned: false
 ---

--- a/templates/{{ cookiecutter.module_slug }}/requirements.txt
+++ b/templates/{{ cookiecutter.module_slug }}/requirements.txt
@@ -1,3 +1,3 @@
 # TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@metrics-template
+git+https://github.com/huggingface/evaluate.git@main
 datasets~=2.0


### PR DESCRIPTION
Upgrades to Gradio 3.0.2 as the SDK for spaces and fixes change in `Dataframe`.