### PR TITLE
update metrics to allow for lists and lists of lists as inputs

### DIFF
--- a/metrics/bleu/bleu.py
+++ b/metrics/bleu/bleu.py
@@ -57,7 +57,7 @@ _KWARGS_DESCRIPTION = """
 Computes BLEU score of translated segments against one or more references.
 Args:
     predictions: list of translations to score.
-    references: list of lists of references for each translation.
+    references: list of lists of or just a list of references for each translation.
     tokenizer : approach used for tokenizing `predictions` and `references`.
         The default tokenizer is `tokenizer_13a`, a minimal tokenization approach that is equivalent to `mteval-v13a`, used by WMT.
         This can be replaced by any function that takes a string as input and returns a list of tokens as output.
@@ -91,12 +91,20 @@ class Bleu(evaluate.EvaluationModule):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=datasets.Features(
-                {
-                    "predictions": datasets.Value("string", id="sequence"),
-                    "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
-                }
-            ),
+            features=[
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
+                    }
+                ),
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Value("string", id="sequence"),
+                    }
+                ),
+            ],
             codebase_urls=["https://github.com/tensorflow/nmt/blob/master/nmt/scripts/bleu.py"],
             reference_urls=[
                 "https://en.wikipedia.org/wiki/BLEU",
@@ -105,6 +113,10 @@ class Bleu(evaluate.EvaluationModule):
         )
 
     def _compute(self, predictions, references, tokenizer=Tokenizer13a(), max_order=4, smooth=False):
+        # if only one reference is provided make sure we still use list of lists
+        if isinstance(references[0], str):
+            references = [[ref] for ref in references]
+
         references = [[tokenizer(r) for r in ref] for ref in references]
         predictions = [tokenizer(p) for p in predictions]
         score = compute_bleu(

--- a/metrics/chrf/chrf.py
+++ b/metrics/chrf/chrf.py
@@ -136,12 +136,20 @@ class ChrF(evaluate.EvaluationModule):
             citation=_CITATION,
             homepage="https://github.com/mjpost/sacreBLEU#chrf--chrf",
             inputs_description=_KWARGS_DESCRIPTION,
-            features=datasets.Features(
-                {
-                    "predictions": datasets.Value("string", id="sequence"),
-                    "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
-                }
-            ),
+            features=[
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
+                    }
+                ),
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Value("string", id="sequence"),
+                    }
+                ),
+            ],
             codebase_urls=["https://github.com/mjpost/sacreBLEU#chrf--chrf"],
             reference_urls=[
                 "https://github.com/m-popovic/chrF",
@@ -159,6 +167,10 @@ class ChrF(evaluate.EvaluationModule):
         whitespace: bool = False,
         eps_smoothing: bool = False,
     ):
+        # if only one reference is provided make sure we still use list of lists
+        if isinstance(references[0], str):
+            references = [[ref] for ref in references]
+
         references_per_prediction = len(references[0])
         if any(len(refs) != references_per_prediction for refs in references):
             raise ValueError("Sacrebleu requires the same number of references for each prediction")

--- a/metrics/google_bleu/google_bleu.py
+++ b/metrics/google_bleu/google_bleu.py
@@ -131,12 +131,20 @@ class GoogleBleu(evaluate.EvaluationModule):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=datasets.Features(
-                {
-                    "predictions": datasets.Value("string", id="sequence"),
-                    "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
-                }
-            ),
+            features=[
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
+                    }
+                ),
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Value("string", id="sequence"),
+                    }
+                ),
+            ],
         )
 
     def _compute(
@@ -147,6 +155,10 @@ class GoogleBleu(evaluate.EvaluationModule):
         min_len: int = 1,
         max_len: int = 4,
     ) -> Dict[str, float]:
+        # if only one reference is provided make sure we still use list of lists
+        if isinstance(references[0], str):
+            references = [[ref] for ref in references]
+
         references = [[tokenizer(r) for r in ref] for ref in references]
         predictions = [tokenizer(p) for p in predictions]
         return {

--- a/metrics/sacrebleu/sacrebleu.py
+++ b/metrics/sacrebleu/sacrebleu.py
@@ -115,12 +115,20 @@ class Sacrebleu(evaluate.EvaluationModule):
             citation=_CITATION,
             homepage="https://github.com/mjpost/sacreBLEU",
             inputs_description=_KWARGS_DESCRIPTION,
-            features=datasets.Features(
-                {
-                    "predictions": datasets.Value("string", id="sequence"),
-                    "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
-                }
-            ),
+            features=[
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
+                    }
+                ),
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Value("string", id="sequence"),
+                    }
+                ),
+            ],
             codebase_urls=["https://github.com/mjpost/sacreBLEU"],
             reference_urls=[
                 "https://github.com/mjpost/sacreBLEU",
@@ -140,6 +148,10 @@ class Sacrebleu(evaluate.EvaluationModule):
         tokenize=None,
         use_effective_order=False,
     ):
+        # if only one reference is provided make sure we still use list of lists
+        if isinstance(references[0], str):
+            references = [[ref] for ref in references]
+
         references_per_prediction = len(references[0])
         if any(len(refs) != references_per_prediction for refs in references):
             raise ValueError("Sacrebleu requires the same number of references for each prediction")

--- a/metrics/ter/ter.py
+++ b/metrics/ter/ter.py
@@ -163,12 +163,20 @@ class Ter(evaluate.EvaluationModule):
             citation=_CITATION,
             homepage="http://www.cs.umd.edu/~snover/tercom/",
             inputs_description=_KWARGS_DESCRIPTION,
-            features=datasets.Features(
-                {
-                    "predictions": datasets.Value("string", id="sequence"),
-                    "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
-                }
-            ),
+            features=[
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
+                    }
+                ),
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Value("string", id="sequence"),
+                    }
+                ),
+            ],
             codebase_urls=["https://github.com/mjpost/sacreBLEU#ter"],
             reference_urls=[
                 "https://github.com/jhclark/tercom",
@@ -184,6 +192,10 @@ class Ter(evaluate.EvaluationModule):
         support_zh_ja_chars: bool = False,
         case_sensitive: bool = False,
     ):
+        # if only one reference is provided make sure we still use list of lists
+        if isinstance(references[0], str):
+            references = [[ref] for ref in references]
+
         references_per_prediction = len(references[0])
         if any(len(refs) != references_per_prediction for refs in references):
             raise ValueError("Sacrebleu requires the same number of references for each prediction")

--- a/metrics/wiki_split/wiki_split.py
+++ b/metrics/wiki_split/wiki_split.py
@@ -327,12 +327,20 @@ class WikiSplit(evaluate.EvaluationModule):
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
-            features=datasets.Features(
-                {
-                    "predictions": datasets.Value("string", id="sequence"),
-                    "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
-                }
-            ),
+            features=[
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
+                    }
+                ),
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Value("string", id="sequence"),
+                    }
+                ),
+            ],
             codebase_urls=[
                 "https://github.com/huggingface/transformers/blob/master/src/transformers/data/metrics/squad_metrics.py",
                 "https://github.com/cocoxu/simplification/blob/master/SARI.py",
@@ -348,6 +356,9 @@ class WikiSplit(evaluate.EvaluationModule):
         )
 
     def _compute(self, sources, predictions, references):
+        # if only one reference is provided make sure we still use list of lists
+        if isinstance(references[0], str):
+            references = [[ref] for ref in references]
         result = {}
         result.update({"sari": compute_sari(sources=sources, predictions=predictions, references=references)})
         result.update({"sacrebleu": compute_sacrebleu(predictions=predictions, references=references)})

--- a/src/evaluate/utils/gradio.py
+++ b/src/evaluate/utils/gradio.py
@@ -97,8 +97,11 @@ def launch_gradio_widget(metric):
         raise error
 
     local_path = Path(sys.path[0])
-
-    (feature_names, feature_types) = zip(*metric.features.items())
+    # if there are several input types, use first as default.
+    if isinstance(metric.features, list):
+        (feature_names, feature_types) = zip(*metric.features[0].items())
+    else:
+        (feature_names, feature_types) = zip(*metric.features.items())
     gradio_input_types = infer_gradio_input_types(feature_types)
 
     def compute(data):


### PR DESCRIPTION
Related to #15 this PR adds the option to just pass a list of references instead of requiring a list of lists of reference (several per sample) for the following metrics: `bleu`, `chrf`, `google_bleu`, `sacrebleu`, `ter`, and `wikisplit`.

This makes use of the #37 to allow for multiple input types and standardizes the format internally.