### PR TITLE
add `save` function to store results

### DIFF
--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -30,5 +30,6 @@ from .info import EvaluationModuleInfo
 from .inspect import inspect_metric, list_metrics
 from .loading import load
 from .module import EvaluationModule
+from .saving import save
 from .utils import *
 from .utils import gradio, logging

--- a/src/evaluate/saving.py
+++ b/src/evaluate/saving.py
@@ -4,6 +4,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from datasets.utils.filelock import FileLock
+
 from . import __version__
 
 
@@ -34,8 +36,9 @@ def save(path_or_file, **data):
     data["_python_version"] = sys.version
     data["_interpreter_path"] = sys.executable
 
-    with open(file_path, "w") as f:
-        json.dump(data, f)
+    with FileLock(str(file_path) + ".lock"):
+        with open(file_path, "w") as f:
+            json.dump(data, f)
 
     return file_path
 

--- a/src/evaluate/saving.py
+++ b/src/evaluate/saving.py
@@ -1,0 +1,62 @@
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from . import __version__
+
+
+def save(path_or_file, **data):
+    """
+    Saves results to a JSON file. Also saves system information such as current time, current commit
+    hash if inside a repository, and Python system information.
+
+    Args:
+        path_or_file (``str``): Path or file to store the file. If only a folder is provided
+            the results file will be saved in the format `"result-%Y_%m_%d-%H_%M_%S.json"`.
+
+    Example:
+        ```py
+        >>> import evaluate
+        >>> result = {"bleu", 0.7}
+        >>> params = {"model", "gpt-2"}
+        >>> evaluate.save("./results/", **result, **params)
+        ```
+    """
+    current_time = datetime.now()
+
+    file_path = _setup_path(path_or_file, current_time)
+
+    data["_timestamp"] = current_time.isoformat()
+    data["_git_commit_hash"] = _git_commit_hash()
+    data["_evaluate_version"] = __version__
+    data["_python_version"] = sys.version
+    data["_interpreter_path"] = sys.executable
+
+    with open(file_path, "w") as f:
+        json.dump(data, f)
+
+    return file_path
+
+
+def _setup_path(path_or_file, current_time):
+    path_or_file = Path(path_or_file)
+    is_file = len(path_or_file.suffix) > 0
+    if is_file:
+        folder = path_or_file.parent
+        file_name = path_or_file.name
+    else:
+        folder = path_or_file
+        file_name = "result-" + current_time.strftime("%Y_%m_%d-%H_%M_%S") + ".json"
+    folder.mkdir(parents=True, exist_ok=True)
+    return folder / file_name
+
+
+def _git_commit_hash():
+    res = subprocess.run("git rev-parse --is-inside-work-tree".split(), cwd="./", stdout=subprocess.PIPE)
+    if res.stdout.decode().strip() == "true":
+        res = subprocess.run("git rev-parse HEAD".split(), cwd="./", stdout=subprocess.PIPE)
+        return res.stdout.decode().strip()
+    else:
+        return None

--- a/src/evaluate/saving.py
+++ b/src/evaluate/saving.py
@@ -66,7 +66,7 @@ def _setup_path(path_or_file, current_time):
 def _git_commit_hash():
     res = subprocess.run("git rev-parse --is-inside-work-tree".split(), cwd="./", stdout=subprocess.PIPE)
     if res.stdout.decode().strip() == "true":
-        res = subprocess.run("git rev-parse HEAD".split(), cwd="./", stdout=subprocess.PIPE)
+        res = subprocess.run("git rev-parse HEAD".split(), cwd=os.getcwd(), stdout=subprocess.PIPE)
         return res.stdout.decode().strip()
     else:
         return None

--- a/src/evaluate/saving.py
+++ b/src/evaluate/saving.py
@@ -40,13 +40,13 @@ def save(path_or_file, **data):
     with FileLock(str(file_path) + ".lock"):
         with open(file_path, "w") as f:
             json.dump(data, f)
-    
+
     # cleanup lock file
     try:
         os.remove(str(file_path) + ".lock")
     except FileNotFoundError:
         pass
-    
+
     return file_path
 
 

--- a/src/evaluate/saving.py
+++ b/src/evaluate/saving.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime
@@ -39,7 +40,13 @@ def save(path_or_file, **data):
     with FileLock(str(file_path) + ".lock"):
         with open(file_path, "w") as f:
             json.dump(data, f)
-
+    
+    # cleanup lock file
+    try:
+        os.remove(str(file_path) + ".lock")
+    except FileNotFoundError:
+        pass
+    
     return file_path
 
 

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -1,0 +1,44 @@
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+import evaluate
+
+
+result_dict = {"metric": 1.0, "model_name": "x"}
+
+SAVE_EXTRA_KEYS = ["_timestamp", "_git_commit_hash", "_evaluate_version", "_python_version", "_interpreter_path"]
+
+
+class TestSave(TestCase):
+    def setUp(self):
+        self.save_path = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.save_path)
+
+    def test_save_to_folder(self):
+        file_path = evaluate.save(self.save_path, **result_dict)
+        with open(file_path, "r") as f:
+            loaded_result_dict = json.load(f)
+        for key in SAVE_EXTRA_KEYS:
+            _ = loaded_result_dict.pop(key)
+        self.assertDictEqual(result_dict, loaded_result_dict)
+
+    def test_save_to_folder_nested(self):
+        file_path = evaluate.save(self.save_path / "sub_dir1/sub_dir2", **result_dict)
+        with open(file_path, "r") as f:
+            loaded_result_dict = json.load(f)
+        for key in SAVE_EXTRA_KEYS:
+            _ = loaded_result_dict.pop(key)
+        self.assertDictEqual(result_dict, loaded_result_dict)
+
+    def test_save_to_file(self):
+        _ = evaluate.save(self.save_path / "test.json", **result_dict)
+        with open(self.save_path / "test.json", "r") as f:
+            loaded_result_dict = json.load(f)
+        for key in SAVE_EXTRA_KEYS:
+            _ = loaded_result_dict.pop(key)
+        self.assertDictEqual(result_dict, loaded_result_dict)


### PR DESCRIPTION
This adds a utility function to quickly save the results in a standard way. Works as follows 

```Python
import evaluate
results = {"bleu": 1.0, "rouge": 0.0}
params = {"model": "gpt-2", "temperateure": 0.5}

evaluate.save("./results/", **results, **params)
>>> file saved at: PosixPath('results/result-2022_05_19-17_35_38.json')
```

One can also explicitly pass a filename if one does not want the automatically generated timestamp. The file `results/result-2022_05_19-17_35_38.json` contains the following:

```json
{
    "bleu": 1,
    "rouge": 0,
    "model": "gpt-2",
    "temperateure": 0.5,
    "_timestamp": "2022-05-19T17:35:38.580167",
    "_git_commit_hash": "0f6f96f4dc6868239db91baaff93ae4deed3260b",
    "_evaluate_version": "0.0.1.dev0",
    "_python_version": "3.9.12 (main, Mar 26 2022, 15:51:15) \n[Clang 13.1.6 (clang-1316.0.21.2)]",
    "_interpreter_path": "/Users/leandro/git/evaluate/env/bin/python"
}
```

 In addition to the passed key/value pairs it also saves an additional information that could be useful for reproducability. A format like that with several stored json files could easily be loaded e.g. into a `DataFrame` for comparison.

What do you think?

This closes #7.