### PR TITLE
fix meta info in readme

### DIFF
--- a/comparisons/mcnemar/README.md
+++ b/comparisons/mcnemar/README.md
@@ -1,16 +1,16 @@
 ---
- title: McNemar
- emoji: 🤗 
- colorFrom: blue
- colorTo: green
- sdk: gradio
- sdk_version: 3.0.2
- app_file: app.py
- pinned: false
- tags:
- - evaluate
- - comparison
- ---
+title: McNemar
+emoji: 🤗 
+colorFrom: blue
+colorTo: green
+sdk: gradio
+sdk_version: 3.0.2
+app_file: app.py
+pinned: false
+tags:
+- evaluate
+- comparison
+---
 
 
 # Comparison Card for McNemar

--- a/measurements/word_length/README.md
+++ b/measurements/word_length/README.md
@@ -1,3 +1,17 @@
+---
+title: Word Length
+emoji: 🤗 
+colorFrom: green
+colorTo: purple
+sdk: gradio
+sdk_version: 3.0.2
+app_file: app.py
+pinned: false
+tags:
+- evaluate
+- measurement
+---
+
 # Measurement Card for Word Length
 
 


### PR DESCRIPTION
The McNemar had a wrong space in the config and TextLength was missing the meta info in the README (caused space not to start).

cc @sashavor 