### PR TITLE
add `list_evaluation_modules` function

### DIFF
--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -27,7 +27,7 @@ SCRIPTS_VERSION = "main" if version.parse(__version__).is_devrelease else __vers
 del version
 
 from .info import EvaluationModuleInfo
-from .inspect import inspect_metric, list_metrics
+from .inspect import inspect_evaluation_module, list_evaluation_modules
 from .loading import load
 from .module import EvaluationModule
 from .saving import save

--- a/src/evaluate/config.py
+++ b/src/evaluate/config.py
@@ -21,6 +21,7 @@ REPO_COMPARISONS_URL = "https://raw.githubusercontent.com/huggingface/evaluate/{
 
 # Hub
 HF_ENDPOINT = os.environ.get("HF_ENDPOINT", "https://huggingface.co")
+HF_LIST_ENDPOINT = HF_ENDPOINT + "/api/spaces?filter={type}"
 HUB_EVALUATE_URL = HF_ENDPOINT + "/spaces/{path}/resolve/{revision}/{name}"
 HUB_DEFAULT_VERSION = "main"
 

--- a/src/evaluate/config.py
+++ b/src/evaluate/config.py
@@ -18,6 +18,8 @@ REPO_METRICS_URL = "https://raw.githubusercontent.com/huggingface/evaluate/{revi
 REPO_MEASUREMENTS_URL = "https://raw.githubusercontent.com/huggingface/evaluate/{revision}/measurements/{path}/{name}"
 REPO_COMPARISONS_URL = "https://raw.githubusercontent.com/huggingface/evaluate/{revision}/comparisons/{path}/{name}"
 
+# Evaluation module types
+EVALUATION_MODULE_TYPES = ["metric", "comparison", "measurement"]
 
 # Hub
 HF_ENDPOINT = os.environ.get("HF_ENDPOINT", "https://huggingface.co")

--- a/src/evaluate/inspect.py
+++ b/src/evaluate/inspect.py
@@ -36,7 +36,7 @@ def list_evaluation_modules(module_type=None, include_community=True, with_detai
     """List all evaluation modules available on the Hugging Face Hub.
 
     Args:
-        module_type (`str`, *optional*, default `None`): Type of evaluation modules to list. Has to be one of `'metric'`, `'comparison'`, or `'measurement'`. If `None` all types are listed.
+        module_type (`str`, *optional*, default `None`): Type of evaluation modules to list. Has to be one of `'metric'`, `'comparison'`, or `'measurement'`. If `None`, all types are listed.
         include_community (`bool`, *optional*, default `True`): Include community modules in the list.
         with_details (`bool`, *optional*, default `False`): Return the full details on the metrics instead of only the ID.
 

--- a/src/evaluate/inspect.py
+++ b/src/evaluate/inspect.py
@@ -33,6 +33,16 @@ class SplitsNotFoundError(ValueError):
 
 
 def list_evaluation_modules(type=None, include_community=True, with_details=False):
+    """List all the metrics script available on the Hugging Face Hub.
+
+    Args:
+        type (:obj:`string`, optional, default ``None``): Type of evaluation modules to list. If ``None`` all types are listed.
+        include_community (:obj:`bool`, optional, default ``True``): Include community modules in the list.
+        with_details (:obj:`bool`, optional, default ``False``): Return the full details on the metrics instead of only the ID.
+    
+    Returns:
+        `list`
+    """
     if type is None:
         evaluations_list = []
         for type in ["metric", "comparison", "measurement"]:

--- a/src/evaluate/inspect.py
+++ b/src/evaluate/inspect.py
@@ -39,7 +39,7 @@ def list_evaluation_modules(type=None, include_community=True, with_details=Fals
         type (:obj:`string`, optional, default ``None``): Type of evaluation modules to list. If ``None`` all types are listed.
         include_community (:obj:`bool`, optional, default ``True``): Include community modules in the list.
         with_details (:obj:`bool`, optional, default ``False``): Return the full details on the metrics instead of only the ID.
-    
+
     Returns:
         `list`
     """

--- a/src/evaluate/inspect.py
+++ b/src/evaluate/inspect.py
@@ -70,8 +70,24 @@ def _list_evaluation_modules_type(module_type, include_community=True, with_deta
     if not include_community:
         d = [element for element in d if element["id"].split("/")[0] == f"evaluate-{module_type}"]
 
+    # remove namespace for canonical modules and add community tag
+    for element in d:
+        if element["id"].split("/")[0] == f"evaluate-{module_type}":
+            element["id"] = element["id"].split("/")[1]
+            element["community"] = False
+        else:
+            element["community"] = True
+
     if with_details:
-        return [{"name": element["id"], "type": type, "likes": element.get("likes", 0)} for element in d]
+        return [
+            {
+                "name": element["id"],
+                "type": module_type,
+                "community": element["community"],
+                "likes": element.get("likes", 0),
+            }
+            for element in d
+        ]
     else:
         return [element["id"] for element in d]
 


### PR DESCRIPTION
Updates the `list_metrics` function to `list_evaluation_modules`. It uses the `https://huggingface.co/api/spaces?filter={type}` endpoint to query all available modules from the hub. 

cc @julien-c 