### PR TITLE
Removing the type from the apps of measurements

### DIFF
--- a/measurements/text_duplicates/app.py
+++ b/measurements/text_duplicates/app.py
@@ -2,5 +2,5 @@ import evaluate
 from evaluate.utils import launch_gradio_widget
 
 
-module = evaluate.load("text_duplicates", type="measurement")
+module = evaluate.load("text_duplicates")
 launch_gradio_widget(module)

--- a/measurements/word_count/app.py
+++ b/measurements/word_count/app.py
@@ -2,5 +2,5 @@ import evaluate
 from evaluate.utils import launch_gradio_widget
 
 
-module = evaluate.load("word_count", type="measurement")
+module = evaluate.load("word_count")
 launch_gradio_widget(module)

--- a/measurements/word_length/app.py
+++ b/measurements/word_length/app.py
@@ -2,5 +2,5 @@ import evaluate
 from evaluate.utils import launch_gradio_widget
 
 
-module = evaluate.load("word_length", module_type="measurement")
+module = evaluate.load("word_length")
 launch_gradio_widget(module)


### PR DESCRIPTION
Removing `type` from the apps of measurements, otherwise it will break the space