### PR TITLE
bump `evaluate` dependency in spaces

### DIFF
--- a/comparisons/exact_match/requirements.txt
+++ b/comparisons/exact_match/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 scipy

--- a/comparisons/mcnemar/requirements.txt
+++ b/comparisons/mcnemar/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 scipy

--- a/measurements/perplexity/requirements.txt
+++ b/measurements/perplexity/requirements.txt
@@ -1,5 +1,4 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 torch
 torch

--- a/metrics/accuracy/requirements.txt
+++ b/metrics/accuracy/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 sklearn
 datasets~=2.0

--- a/metrics/bertscore/requirements.txt
+++ b/metrics/bertscore/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 bert_score

--- a/metrics/bleu/requirements.txt
+++ b/metrics/bleu/requirements.txt
@@ -1,3 +1,2 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0

--- a/metrics/bleurt/requirements.txt
+++ b/metrics/bleurt/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 git+https://github.com/google-research/bleurt.git

--- a/metrics/cer/requirements.txt
+++ b/metrics/cer/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 jiwer

--- a/metrics/chrf/requirements.txt
+++ b/metrics/chrf/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sacrebleu

--- a/metrics/code_eval/requirements.txt
+++ b/metrics/code_eval/requirements.txt
@@ -1,3 +1,2 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0

--- a/metrics/comet/requirements.txt
+++ b/metrics/comet/requirements.txt
@@ -1,5 +1,4 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 unbabel-comet
 torch

--- a/metrics/competition_math/requirements.txt
+++ b/metrics/competition_math/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 git+https://github.com/hendrycks/math.git

--- a/metrics/coval/requirements.txt
+++ b/metrics/coval/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 git+https://github.com/ns-moosavi/coval.git

--- a/metrics/cuad/requirements.txt
+++ b/metrics/cuad/requirements.txt
@@ -1,3 +1,2 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0

--- a/metrics/exact_match/requirements.txt
+++ b/metrics/exact_match/requirements.txt
@@ -1,3 +1,2 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0

--- a/metrics/f1/requirements.txt
+++ b/metrics/f1/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sklearn

--- a/metrics/frugalscore/requirements.txt
+++ b/metrics/frugalscore/requirements.txt
@@ -1,5 +1,4 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 torch
 transformers

--- a/metrics/glue/requirements.txt
+++ b/metrics/glue/requirements.txt
@@ -1,5 +1,4 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 scipy
 sklearn

--- a/metrics/google_bleu/requirements.txt
+++ b/metrics/google_bleu/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 nltk

--- a/metrics/indic_glue/requirements.txt
+++ b/metrics/indic_glue/requirements.txt
@@ -1,5 +1,4 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 scipy
 sklearn

--- a/metrics/mae/requirements.txt
+++ b/metrics/mae/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sklearn

--- a/metrics/mahalanobis/requirements.txt
+++ b/metrics/mahalanobis/requirements.txt
@@ -1,3 +1,2 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0

--- a/metrics/matthews_correlation/requirements.txt
+++ b/metrics/matthews_correlation/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sklearn

--- a/metrics/mauve/requirements.txt
+++ b/metrics/mauve/requirements.txt
@@ -1,5 +1,4 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 faiss-cpu
 sklearn

--- a/metrics/mean_iou/requirements.txt
+++ b/metrics/mean_iou/requirements.txt
@@ -1,3 +1,2 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0

--- a/metrics/meteor/requirements.txt
+++ b/metrics/meteor/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 nltk

--- a/metrics/mse/requirements.txt
+++ b/metrics/mse/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sklearn

--- a/metrics/pearsonr/requirements.txt
+++ b/metrics/pearsonr/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 scipy

--- a/metrics/perplexity/requirements.txt
+++ b/metrics/perplexity/requirements.txt
@@ -1,5 +1,4 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 torch
 torch

--- a/metrics/precision/requirements.txt
+++ b/metrics/precision/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sklearn

--- a/metrics/recall/requirements.txt
+++ b/metrics/recall/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sklearn

--- a/metrics/rl_reliability/README.md
+++ b/metrics/rl_reliability/README.md
@@ -1,7 +1,8 @@
 ---
 title: RL Reliability
-datasets:
--  
+emoji: 🤗 
+colorFrom: blue
+colorTo: red
 tags:
 - evaluate
 - metric

--- a/metrics/rl_reliability/requirements.txt
+++ b/metrics/rl_reliability/requirements.txt
@@ -1,5 +1,4 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@main
+evaluate==0.1.0
 datasets~=2.0
 git+https://github.com/google-research/rl-reliability-metrics
 scipy

--- a/metrics/roc_auc/requirements.txt
+++ b/metrics/roc_auc/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sklearn

--- a/metrics/rouge/requirements.txt
+++ b/metrics/rouge/requirements.txt
@@ -1,5 +1,4 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 absl-py
 nltk

--- a/metrics/sacrebleu/requirements.txt
+++ b/metrics/sacrebleu/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sacrebleu

--- a/metrics/sari/requirements.txt
+++ b/metrics/sari/requirements.txt
@@ -1,5 +1,4 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sacrebleu
 sacremoses

--- a/metrics/seqeval/requirements.txt
+++ b/metrics/seqeval/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 seqeval

--- a/metrics/spearmanr/requirements.txt
+++ b/metrics/spearmanr/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 scipy

--- a/metrics/squad/requirements.txt
+++ b/metrics/squad/requirements.txt
@@ -1,3 +1,2 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0

--- a/metrics/squad_v2/requirements.txt
+++ b/metrics/squad_v2/requirements.txt
@@ -1,3 +1,2 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0

--- a/metrics/super_glue/requirements.txt
+++ b/metrics/super_glue/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sklearn

--- a/metrics/ter/requirements.txt
+++ b/metrics/ter/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sacrebleu

--- a/metrics/trec_eval/README.md
+++ b/metrics/trec_eval/README.md
@@ -1,7 +1,8 @@
 ---
 title: TREC Eval
-datasets:
--  
+emoji: 🤗 
+colorFrom: blue
+colorTo: red
 tags:
 - evaluate
 - metric

--- a/metrics/trec_eval/requirements.txt
+++ b/metrics/trec_eval/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@main
+evaluate==0.1.0
 datasets~=2.0
 trectools

--- a/metrics/wer/requirements.txt
+++ b/metrics/wer/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 jiwer

--- a/metrics/wiki_split/requirements.txt
+++ b/metrics/wiki_split/requirements.txt
@@ -1,5 +1,4 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sacrebleu
 sacremoses

--- a/metrics/xnli/requirements.txt
+++ b/metrics/xnli/requirements.txt
@@ -1,3 +1,2 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0

--- a/metrics/xtreme_s/requirements.txt
+++ b/metrics/xtreme_s/requirements.txt
@@ -1,4 +1,3 @@
-# TODO: fix github to release
-git+https://github.com/huggingface/evaluate.git@505123230059f9605da8951880eddc9d1fbf4278
+evaluate==0.1.0
 datasets~=2.0
 sklearn


### PR DESCRIPTION
Sets the version of all evaluate spaces to `0.1.0`. Merge after release!