### PR TITLE
FIX `pip install evaluate[evaluator]`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ TEMPLATE_REQUIRE = [
 ]
 
 EVALUATOR_REQUIRE = [
-   "transformers"
+   "transformers",
    # for bootstrap computations in Evaluator
    "scipy>=1.7.1",
 ]


### PR DESCRIPTION
Fixes `pip install evaluate[evaluator]`

error currently is 
```
ERROR: No matching distribution found for transformersscipy>=1.7.1; extra == "evaluator"
```
due to missing `,`