### PR TITLE
Add automatic pypi release for evaluate

### DIFF
--- a/.github/workflows/python-release
+++ b/.github/workflows/python-release
@@ -1,0 +1,31 @@
+name: Python release
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  PYPI_TOKEN: ${{ secrets.PYPI_TOKEN_DIST }}
+
+jobs:
+  python_release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        pip install setuptools wheel
+    - run: python setup.py sdist bdist_wheel
+
+    - run: |
+        pip install twine
+    - name: Upload to PyPi
+      run: |
+          twine upload dist/* -u __token__ -p "$PYPI_TOKEN"


### PR DESCRIPTION
This GH actions workflow will do an automatic pypi release as soon as you push a tag in GitHub that begins with v*. This requires setting the PYPI_TOKEN secret in GitHub. Example from `huggingface_hub`: https://github.com/huggingface/huggingface_hub/tags (one tag per release is also a good idea since that helps draft automatic release notes).