### PR TITLE
fix description field in metric template readme

### DIFF
--- a/templates/{{ cookiecutter.module_slug }}/README.md
+++ b/templates/{{ cookiecutter.module_slug }}/README.md
@@ -5,7 +5,7 @@ datasets:
 tags:
 - evaluate
 - {{ cookiecutter.module_type }}
-description: TODO: add a description here
+description: "TODO: add a description here"
 sdk: gradio
 sdk_version: 3.0.2
 app_file: app.py


### PR DESCRIPTION
Fixes a formatting issue when creating a new metric with the `evaluate-cli`. The hub would refuse the initial push due to the misformatted placeholder in `description` in the `README.md` metadata.