### PR TITLE
Fix typos in Evaluator docstrings

### DIFF
--- a/src/evaluate/evaluator.py
+++ b/src/evaluate/evaluator.py
@@ -210,7 +210,7 @@ class TextClassificationEvaluator(Evaluator):
         Examples:
 
         ```python
-        >>> from evaluation import evaluator
+        >>> from evaluate import evaluator
         >>> from datasets import Dataset, load_dataset
 
         >>> e = evaluator("text-classification")
@@ -354,7 +354,7 @@ def evaluator(task: str = None) -> Evaluator:
     Examples:
 
     ```python
-    >>> from evaluation import evaluator
+    >>> from evaluate import evaluator
 
     >>> # Sentiment analysis evaluator
     >>> evaluator("sentiment-analysis")


### PR DESCRIPTION
This PR fixes two typos in the imports of the `Evaluator` examples.