### PR TITLE
Use accuracy as default metric for text classification Evaluator

### DIFF
--- a/src/evaluate/evaluator.py
+++ b/src/evaluate/evaluator.py
@@ -299,7 +299,7 @@ class TextClassificationEvaluator(Evaluator):
 SUPPORTED_EVALUATOR_TASKS = {
     "text-classification": {
         "implementation": TextClassificationEvaluator,
-        "default_metric_name": "f1",
+        "default_metric_name": "accuracy",
     }
 }
 

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -16,15 +16,15 @@
 
 from unittest import TestCase
 
-from datasets import Dataset, load_dataset, load_metric
-from transformers import AutoTokenizer, BertForSequenceClassification, pipeline
+from datasets import load_dataset
+from transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline
 
-from evaluate import TextClassificationEvaluator, evaluator
+from evaluate import TextClassificationEvaluator, evaluator, load
 
 
 class TestEvaluator(TestCase):
     def setUp(self):
-        self.data = Dataset.from_dict(load_dataset("imdb")["test"][:2])
+        self.data = load_dataset("imdb", split="test[:2]")
         self.input_column = "text"
         self.label_column = "label"
         self.pipe = pipeline("text-classification")
@@ -39,7 +39,7 @@ class TestEvaluator(TestCase):
             label_column="label",
             label_mapping=self.label_mapping,
         )
-        self.assertEqual(scores, {"f1": 0.0})
+        self.assertEqual(scores, {"accuracy": 1.0})
 
     def test_model_init(self):
         scores = self.evaluator.compute(
@@ -51,7 +51,7 @@ class TestEvaluator(TestCase):
             label_mapping={"LABEL_0": 0.0, "LABEL_1": 1.0},
         )
         self.assertEqual(scores, {"accuracy": 0.5})
-        model = BertForSequenceClassification.from_pretrained(
+        model = AutoModelForSequenceClassification.from_pretrained(
             "huggingface/prunebert-base-uncased-6-finepruned-w-distil-mnli"
         )
         tokenizer = AutoTokenizer.from_pretrained("huggingface/prunebert-base-uncased-6-finepruned-w-distil-mnli")
@@ -88,10 +88,10 @@ class TestEvaluator(TestCase):
             label_column=self.label_column,
             label_mapping=self.label_mapping,
         )
-        self.assertEqual(scores, {"f1": 0.0})
+        self.assertEqual(scores, {"accuracy": 1.0})
 
     def test_overwrite_default_metric(self):
-        accuracy = load_metric("accuracy")
+        accuracy = load("accuracy")
         scores = self.evaluator.compute(
             model_or_pipeline=self.pipe,
             data=self.data,
@@ -112,7 +112,7 @@ class TestEvaluator(TestCase):
         self.assertEqual(scores, {"accuracy": 1.0})
 
     def test_bootstrap(self):
-        model = BertForSequenceClassification.from_pretrained(
+        model = AutoModelForSequenceClassification.from_pretrained(
             "huggingface/prunebert-base-uncased-6-finepruned-w-distil-mnli"
         )
         tokenizer = AutoTokenizer.from_pretrained("huggingface/prunebert-base-uncased-6-finepruned-w-distil-mnli")


### PR DESCRIPTION
This PR replaces the current default metric in the text classification `Evaluator` from `f1` to `accuracy`. 

The reason for doing so is that the `Evaluator` fails when the dataset is multiclass because the default average in `f1` is `binary`. Although there are well known limitations with using accuracy as the only metric, I think it's better to have defaults that "just work"

Remark: it probably would make sense to expand the unit tests to test the evaluator on binary / multiclass / multilabel datasets. I'm happy to implement that if you think that's useful.