### PR TITLE
docs: make metric cards more prominent

### DIFF
--- a/docs/source/a_quick_tour.mdx
+++ b/docs/source/a_quick_tour.mdx
@@ -10,6 +10,10 @@ There are different aspects of a typical machine learning pipeline that can be e
 - **Comparison**: A comparison is used to compare two models. This can for example be done by comparing their predictions to ground truth labels and computing their agreement. You can find all integrated comparisons at [evaluate-comparison](https://huggingface.co/evaluate-comparison).
 - **Measurement**: The dataset is as important as the model trained on it. With measurements one can investigate a dataset's properties. You can find all integrated measurements at [evaluate-measurement](https://huggingface.co/evaluate-measurement).
 
+Each of these evaluation modules live on Hugging Face Hub as a Space. They come with an interactive widget and a metric card documenting its use and limitations. For example [accuracy](https://huggingface.co/spaces/evaluate-metric/accuracy):
+
+![Metric widget](https://huggingface.co/datasets/evaluate/media/resolve/main/metric-widget.png)
+
 Each metric, comparison, and measurement is a separate Python module, but for using any of them, there is a single entry point: [`evaluate.load`]!
 
 ## Load

--- a/docs/source/a_quick_tour.mdx
+++ b/docs/source/a_quick_tour.mdx
@@ -12,7 +12,9 @@ There are different aspects of a typical machine learning pipeline that can be e
 
 Each of these evaluation modules live on Hugging Face Hub as a Space. They come with an interactive widget and a metric card documenting its use and limitations. For example [accuracy](https://huggingface.co/spaces/evaluate-metric/accuracy):
 
-![Metric widget](https://huggingface.co/datasets/evaluate/media/resolve/main/metric-widget.png)
+<div class="flex justify-center">
+    <img src="https://huggingface.co/datasets/evaluate/media/resolve/main/metric-widget.png" width="300"/>
+</div>
 
 Each metric, comparison, and measurement is a separate Python module, but for using any of them, there is a single entry point: [`evaluate.load`]!
 

--- a/docs/source/a_quick_tour.mdx
+++ b/docs/source/a_quick_tour.mdx
@@ -13,7 +13,7 @@ There are different aspects of a typical machine learning pipeline that can be e
 Each of these evaluation modules live on Hugging Face Hub as a Space. They come with an interactive widget and a metric card documenting its use and limitations. For example [accuracy](https://huggingface.co/spaces/evaluate-metric/accuracy):
 
 <div class="flex justify-center">
-    <img src="https://huggingface.co/datasets/evaluate/media/resolve/main/metric-widget.png" width="300"/>
+    <img src="https://huggingface.co/datasets/evaluate/media/resolve/main/metric-widget.png" width="400"/>
 </div>
 
 Each metric, comparison, and measurement is a separate Python module, but for using any of them, there is a single entry point: [`evaluate.load`]!

--- a/docs/source/a_quick_tour.mdx
+++ b/docs/source/a_quick_tour.mdx
@@ -10,7 +10,7 @@ There are different aspects of a typical machine learning pipeline that can be e
 - **Comparison**: A comparison is used to compare two models. This can for example be done by comparing their predictions to ground truth labels and computing their agreement. You can find all integrated comparisons at [evaluate-comparison](https://huggingface.co/evaluate-comparison).
 - **Measurement**: The dataset is as important as the model trained on it. With measurements one can investigate a dataset's properties. You can find all integrated measurements at [evaluate-measurement](https://huggingface.co/evaluate-measurement).
 
-Each of these evaluation modules live on Hugging Face Hub as a Space. They come with an interactive widget and a metric card documenting its use and limitations. For example [accuracy](https://huggingface.co/spaces/evaluate-metric/accuracy):
+Each of these evaluation modules live on Hugging Face Hub as a Space. They come with an interactive widget and a documentation card documenting its use and limitations. For example [accuracy](https://huggingface.co/spaces/evaluate-metric/accuracy):
 
 <div class="flex justify-center">
     <img src="https://huggingface.co/datasets/evaluate/media/resolve/main/metric-widget.png" width="400"/>

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -8,7 +8,7 @@
 
 A library for easily evaluating machine learning models and datasets.
 
-With a single line of code, you get access to dozens of evaluation methods for different domains (NLP, Computer Vision, Reinforcement Learning, and more!). Be it on your local machine or in a distributed training setup, you can evaluate your models in a consistent and reproducible way! All evaluation methods come with an interactive widget to try it out directly in the [browser](https://huggingface.co/evaluate-metric) and documentation about its use and limitations. 
+With a single line of code, you get access to dozens of evaluation methods for different domains (NLP, Computer Vision, Reinforcement Learning, and more!). Be it on your local machine or in a distributed training setup, you can evaluate your models in a consistent and reproducible way! All evaluation methods come with an interactive widget to try it out directly in the [browser](https://huggingface.co/evaluate-metric) and a metric card that documents its use and limitations (see for example [BLEU](https://huggingface.co/spaces/evaluate-metric/bleu)). 
 
 <div class="mt-10">
   <div class="w-full flex flex-col space-y-4 md:space-y-0 md:grid md:grid-cols-2 md:gap-y-4 md:gap-x-5">

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -8,7 +8,7 @@
 
 A library for easily evaluating machine learning models and datasets.
 
-With a single line of code, you get access to dozens of evaluation methods for different domains (NLP, Computer Vision, Reinforcement Learning, and more!). Be it on your local machine or in a distributed training setup, you can evaluate your models in a consistent and reproducible way! All evaluation methods come with an interactive widget to try it out directly in the [browser](https://huggingface.co/evaluate-metric) and a metric card that documents its use and limitations (see for example [BLEU](https://huggingface.co/spaces/evaluate-metric/bleu)). 
+With a single line of code, you get access to dozens of evaluation methods for different domains (NLP, Computer Vision, Reinforcement Learning, and more!). Be it on your local machine or in a distributed training setup, you can evaluate your models in a consistent and reproducible way! All evaluation methods come with an interactive widget to try it out directly in the [browser](https://huggingface.co/evaluate-metric) and a documentation card that documents its use and limitations (see for example [BLEU](https://huggingface.co/spaces/evaluate-metric/bleu)). 
 
 <div class="mt-10">
   <div class="w-full flex flex-col space-y-4 md:space-y-0 md:grid md:grid-cols-2 md:gap-y-4 md:gap-x-5">


### PR DESCRIPTION
As discussed internally, metric cards are not so visible in the documentation, yet. This PR aims at changing this.