### PR TITLE
Pass metric-specific parameters to TextClassificationEvaluator

### DIFF
--- a/src/evaluate/evaluator.py
+++ b/src/evaluate/evaluator.py
@@ -157,7 +157,6 @@ class TextClassificationEvaluator(Evaluator):
         input_column: str = "text",
         label_column: str = "label",
         label_mapping: Optional[Dict[str, Number]] = None,
-        **compute_parameters: Dict
     ) -> Tuple[Dict[str, float], Any]:
         """
         Compute the metric for a given pipeline and dataset combination.

--- a/src/evaluate/evaluator.py
+++ b/src/evaluate/evaluator.py
@@ -158,6 +158,7 @@ class TextClassificationEvaluator(Evaluator):
         input_column: str = "text",
         label_column: str = "label",
         label_mapping: Optional[Dict[str, Number]] = None,
+        **compute_parameters: Dict
     ) -> Tuple[Dict[str, float], Any]:
         """
         Compute the metric for a given pipeline and dataset combination.
@@ -275,7 +276,7 @@ class TextClassificationEvaluator(Evaluator):
         # Core computations.
         references = data[label_column]
         predictions = self._compute_predictions(pipe, data[input_column], label_mapping=label_mapping)
-        result = metric.compute(predictions=predictions, references=references)
+        result = metric.compute(predictions=predictions, references=references, **compute_parameters)
 
         if strategy == "bootstrap":
             metric_keys = result.keys()

--- a/src/evaluate/evaluator.py
+++ b/src/evaluate/evaluator.py
@@ -115,7 +115,6 @@ class Evaluator(ABC):
         strategy: Literal["simple", "bootstrap"] = "simple",
         confidence_level: float = 0.95,
         n_resamples: int = 9999,
-        **compute_parameters: Dict,
     ):
         """
         A core method of the `Evaluator` class, computes the metric value for a pipeline and dataset compatible
@@ -276,7 +275,7 @@ class TextClassificationEvaluator(Evaluator):
         # Core computations.
         references = data[label_column]
         predictions = self._compute_predictions(pipe, data[input_column], label_mapping=label_mapping)
-        result = metric.compute(predictions=predictions, references=references, **compute_parameters)
+        result = metric.compute(predictions=predictions, references=references)
 
         if strategy == "bootstrap":
             metric_keys = result.keys()

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -203,6 +203,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
         else:
             self.seed: int = seed
         self.timeout: Union[int, float] = timeout
+        self.kwargs = kwargs
 
         # Update 'compute' and 'add' docstring
         # methods need to be copied otherwise it changes the docstrings of every instance
@@ -409,7 +410,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
             - Dictionary with the results if this evaluation module is run on the main process (``process_id == 0``).
             - None if the evaluation module is not run on the main process (``process_id != 0``).
         """
-        all_kwargs = {"predictions": predictions, "references": references, **kwargs}
+        all_kwargs = {"predictions": predictions, "references": references, **kwargs, **self.kwargs}
         if predictions is None and references is None:
             missing_kwargs = {k: None for k in self._feature_names() if k not in all_kwargs}
             all_kwargs.update(missing_kwargs)
@@ -421,6 +422,8 @@ class EvaluationModule(EvaluationModuleInfoMixin):
                 )
         inputs = {input_name: all_kwargs[input_name] for input_name in self._feature_names()}
         compute_kwargs = {k: kwargs[k] for k in kwargs if k not in self._feature_names()}
+        self_kwargs = {k: self.kwargs[k] for k in self.kwargs if k not in self._feature_names()}
+        compute_kwargs.update(self_kwargs)
 
         if any(v is not None for v in inputs.values()):
             self.add_batch(**inputs)


### PR DESCRIPTION
Although ```Evaluator.compute()``` has a ```**compute_parameters``` argument for metric-specific parameters, it's not passed to ```TextClassificationEvaluator.compute()```, e.g.:

```
eval = evaluator("text-classification")
results = eval.compute(
    model_or_pipeline=model,
    tokenizer=tokenizer,
    data=eval_dataset, 
    metric=evaluate.load("f1"), 
    label_column=label_column,
    label_mapping=label_mapping,
    average=None
)
results

TypeError: compute() got an unexpected keyword argument 'average'
```
This PR fixes this, e.g.:

```
results = eval.compute(
    model_or_pipeline=model,
    tokenizer=tokenizer,
    data=eval_dataset, 
    metric=evaluate.load("f1"), 
    label_column=label_column,
    label_mapping=label_mapping,
    average=None
)
results

{'f1': array([0.61904762, 0.55172414, 0.64705882, 0.50574713, 0.80978261])}
```
