### PR TITLE
fix cookiecutter path to repository

### DIFF
--- a/src/evaluate/commands/evaluate_cli.py
+++ b/src/evaluate/commands/evaluate_cli.py
@@ -95,7 +95,14 @@ def main():
         local_dir=output_dir / module_slug,
     )
 
-    cookiecutter("./templates", no_input=True, extra_context=args, output_dir=output_dir, overwrite_if_exists=True)
+    cookiecutter(
+        "https://github.com/huggingface/evaluate/",
+        directory="templates",
+        no_input=True,
+        extra_context=args,
+        output_dir=output_dir,
+        overwrite_if_exists=True,
+    )
 
     repo.git_add()
     repo.git_commit("add module default template")


### PR DESCRIPTION
Fixes absolute local path to repository path for the cookiecutter template so the `evalute-cli` does not need to be executed inside the repo folder.