### PR TITLE
Add `combine` to compose multiple evaluations

### DIFF
--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -31,7 +31,7 @@ from .hub import push_to_hub
 from .info import EvaluationModuleInfo
 from .inspect import inspect_evaluation_module, list_evaluation_modules
 from .loading import load
-from .module import EvaluationModule
+from .module import EvaluationEnsemble, EvaluationModule
 from .saving import save
 from .utils import *
 from .utils import gradio, logging

--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -31,7 +31,7 @@ from .hub import push_to_hub
 from .info import EvaluationModuleInfo
 from .inspect import inspect_evaluation_module, list_evaluation_modules
 from .loading import load
-from .module import AggregateEvaluation, EvaluationModule, combine
+from .module import CombinedEvaluations, EvaluationModule, combine
 from .saving import save
 from .utils import *
 from .utils import gradio, logging

--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -31,7 +31,7 @@ from .hub import push_to_hub
 from .info import EvaluationModuleInfo
 from .inspect import inspect_evaluation_module, list_evaluation_modules
 from .loading import load
-from .module import EvaluationEnsemble, EvaluationModule
+from .module import AggregateEvaluation, EvaluationModule, combine
 from .saving import save
 from .utils import *
 from .utils import gradio, logging

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -470,7 +470,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
                 f"Bad inputs for evaluation module: {bad_inputs}. All required inputs are {list(self._feature_names())}"
             )
         batch = {"predictions": predictions, "references": references, **kwargs}
-        batch = {intput_name: batch[intput_name] for intput_name in self._feature_names()}
+        batch = {input_name: batch[input_name] for input_name in self._feature_names()}
         if self.writer is None:
             self.current_features = self._infer_feature_from_batch(batch)
             self._init_writer()
@@ -517,7 +517,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
                 f"Bad inputs for evaluation module: {bad_inputs}. All required inputs are {list(self._feature_names())}"
             )
         example = {"predictions": prediction, "references": reference, **kwargs}
-        example = {intput_name: example[intput_name] for intput_name in self._feature_names()}
+        example = {input_name: example[input_name] for input_name in self._feature_names()}
         if self.writer is None:
             self.current_features = self._infer_feature_from_example(example)
             self._init_writer()
@@ -742,7 +742,7 @@ class AggregateEvaluation:
         """
         for evaluation_module in self.evaluation_modules:
             batch = {"predictions": prediction, "references": reference, **kwargs}
-            batch = {intput_name: batch[intput_name] for intput_name in evaluation_module._feature_names()}
+            batch = {input_name: batch[input_name] for input_name in evaluation_module._feature_names()}
             evaluation_module.add(**batch)
 
     def add_batch(self, predictions=None, references=None, **kwargs):
@@ -754,7 +754,7 @@ class AggregateEvaluation:
         """
         for evaluation_module in self.evaluation_modules:
             batch = {"predictions": predictions, "references": references, **kwargs}
-            batch = {intput_name: batch[intput_name] for intput_name in evaluation_module._feature_names()}
+            batch = {input_name: batch[input_name] for input_name in evaluation_module._feature_names()}
             evaluation_module.add_batch(**batch)
 
     def compute(self, predictions=None, references=None, **kwargs):
@@ -778,7 +778,7 @@ class AggregateEvaluation:
 
         for evaluation_module in self.evaluation_modules:
             batch = {"predictions": predictions, "references": references, **kwargs}
-            batch = {intput_name: batch[intput_name] for intput_name in evaluation_module._feature_names()}
+            batch = {input_name: batch[input_name] for input_name in evaluation_module._feature_names()}
             results.append(evaluation_module.compute(**batch))
 
         return self._merge_results(results)
@@ -809,12 +809,12 @@ class AggregateEvaluation:
 
 
 def combine(evaluation_modules, force_prefix=False):
-    """A function to comine several metrics, comparisons, and measurements into a single `AggregateEvalution` that
+    """A function to combine several metrics, comparisons, and measurements into a single `AggregateEvaluation` that
     can be used like a single evaluation module.
 
     Args:
         evaluation_modules (``Union[list, dict]``): A list or dictionary of evaluation modules. The modules can either be passed
-            as strings or loaded `EvaluationMoudule`s. If a dictionary is passed its keys are the names used and the values the modules.
+            as strings or loaded `EvaluationModule`s. If a dictionary is passed its keys are the names used and the values the modules.
             The names are used as prefix in case there are name overlaps in the returned results of each module or if `force_prefix=True`.
         force_prefix (``bool``, optional, defaults to `False`): If `True` all scores from the modules are prefixed with their name. If
             a dictionary is passed the keys are used as name otherwise the module's name.

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -710,22 +710,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
                 raise TypeError(f"Expected type str but got {type(obj)}.")
 
 
-class EvaluationEnsemble:
-    """A EvaluationModule is the base class and common API for metrics, comparisons, and measurements.
-
-    Args:
-        evaluation_modules (``Union[list, dict]``): A list or dictionary of evaluation modules. The modules can either be passed
-            as strings or loaded `EvaluationMoudule`s. If a dictionary is passed its keys are the names used and the values the modules.
-            The names are used as prefix in case there are name overlaps in the returned results of each module or if `force_prefix=True`.
-        force_prefix (``bool``, optional, defaults to `False`): If `True` all scores from the modules are prefixed with their name. If
-            a dictionary is passed the keys are used as name otherwise the module's name.
-
-    Examples:
-        >>> clf_metrics = EvaluationEnsemble(["accuracy", "f1", "precision","recall"])
-        >>> clf_metrics.compute(predictions=[0,1], references=[1,1])
-        {'accuracy': 0.5, 'f1': 0.66, 'precision': 1.0, 'recall': 0.5}
-    """
-
+class AggregateEvaluation:
     def __init__(self, evaluation_modules, force_prefix=False):
         from .loading import load  # avoid circular imports
 
@@ -821,3 +806,23 @@ class EvaluationEnsemble:
                 duplicate_counter[module_name] += 1
 
         return merged_results
+
+
+def combine(evaluation_modules, force_prefix=False):
+    """A function to comine several metrics, comparisons, and measurements into a single `AggregateEvalution` that
+    can be used like a single evaluation module.
+
+    Args:
+        evaluation_modules (``Union[list, dict]``): A list or dictionary of evaluation modules. The modules can either be passed
+            as strings or loaded `EvaluationMoudule`s. If a dictionary is passed its keys are the names used and the values the modules.
+            The names are used as prefix in case there are name overlaps in the returned results of each module or if `force_prefix=True`.
+        force_prefix (``bool``, optional, defaults to `False`): If `True` all scores from the modules are prefixed with their name. If
+            a dictionary is passed the keys are used as name otherwise the module's name.
+
+    Examples:
+        >>> clf_metrics = combine(["accuracy", "f1", "precision","recall"])
+        >>> clf_metrics.compute(predictions=[0,1], references=[1,1])
+        {'accuracy': 0.5, 'f1': 0.66, 'precision': 1.0, 'recall': 0.5}
+    """
+
+    return AggregateEvaluation(evaluation_modules, force_prefix=force_prefix)

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -811,6 +811,9 @@ class CombinedEvaluations:
 def combine(evaluations, force_prefix=False):
     """Combines several metrics, comparisons, or measurements into a single `CombinedEvaluations` object that
     can be used like a single evaluation module.
+    
+    If two scores have the same name, then they are prefixed with their module names.
+    And if two modules have the same name, please use a dictionary to give them different names, otherwise an integer id is appended to the prefix.
 
     Args:
         evaluations (``Union[list, dict]``): A list or dictionary of evaluation modules. The modules can either be passed

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -710,7 +710,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
                 raise TypeError(f"Expected type str but got {type(obj)}.")
 
 
-class AggregateEvaluation:
+class CombinedEvaluations:
     def __init__(self, evaluation_modules, force_prefix=False):
         from .loading import load  # avoid circular imports
 
@@ -825,4 +825,4 @@ def combine(evaluation_modules, force_prefix=False):
         {'accuracy': 0.5, 'f1': 0.66, 'precision': 1.0, 'recall': 0.5}
     """
 
-    return AggregateEvaluation(evaluation_modules, force_prefix=force_prefix)
+    return CombinedEvaluations(evaluations, force_prefix=force_prefix)

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -808,12 +808,12 @@ class CombinedEvaluations:
         return merged_results
 
 
-def combine(evaluation_modules, force_prefix=False):
-    """A function to combine several metrics, comparisons, and measurements into a single `AggregateEvaluation` that
+def combine(evaluations, force_prefix=False):
+    """Combines several metrics, comparisons, or measurements into a single `CombinedEvaluations` object that
     can be used like a single evaluation module.
 
     Args:
-        evaluation_modules (``Union[list, dict]``): A list or dictionary of evaluation modules. The modules can either be passed
+        evaluations (``Union[list, dict]``): A list or dictionary of evaluation modules. The modules can either be passed
             as strings or loaded `EvaluationModule`s. If a dictionary is passed its keys are the names used and the values the modules.
             The names are used as prefix in case there are name overlaps in the returned results of each module or if `force_prefix=True`.
         force_prefix (``bool``, optional, defaults to `False`): If `True` all scores from the modules are prefixed with their name. If

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -811,7 +811,7 @@ class CombinedEvaluations:
 def combine(evaluations, force_prefix=False):
     """Combines several metrics, comparisons, or measurements into a single `CombinedEvaluations` object that
     can be used like a single evaluation module.
-    
+
     If two scores have the same name, then they are prefixed with their module names.
     And if two modules have the same name, please use a dictionary to give them different names, otherwise an integer id is appended to the prefix.
 

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 import pytest
 from datasets.features import Features, Sequence, Value
 
-from evaluate.module import EvaluationModule, EvaluationModuleInfo
+from evaluate.module import EvaluationEnsemble, EvaluationModule, EvaluationModuleInfo
 
 from .utils import require_tf, require_torch
 
@@ -68,6 +68,22 @@ class DummyMetric(EvaluationModule):
     @classmethod
     def separate_expected_results(cls):
         return [{"accuracy": 1.0, "set_equality": True}, {"accuracy": 0.5, "set_equality": False}]
+
+
+class AnotherDummyMetric(EvaluationModule):
+    def _info(self):
+        return EvaluationModuleInfo(
+            description="another dummy metric for tests",
+            citation="insert citation here",
+            features=Features({"predictions": Value("int64"), "references": Value("int64")}),
+        )
+
+    def _compute(self, predictions, references):
+        return {"set_equality": False}
+
+    @classmethod
+    def expected_results(cls):
+        return {"set_equality": False}
 
 
 def properly_del_metric(metric):
@@ -612,3 +628,80 @@ def test_metric_with_non_standard_feature_names_compute(tmp_path):
     metric = AccuracyWithNonStandardFeatureNames(cache_dir=cache_dir)
     results = metric.compute(inputs=inputs, targets=targets)
     assert results == AccuracyWithNonStandardFeatureNames.expected_results()
+
+
+class TestEvaluationEnsemble(TestCase):
+    def test_single_module(self):
+        preds, refs = DummyMetric.predictions_and_references()
+        expected_results = DummyMetric.expected_results()
+
+        ensemble = EvaluationEnsemble([DummyMetric()])
+
+        self.assertDictEqual(expected_results, ensemble.compute(predictions=preds, references=refs))
+
+    def test_add(self):
+        preds, refs = DummyMetric.predictions_and_references()
+        expected_results = DummyMetric.expected_results()
+
+        ensemble = EvaluationEnsemble([DummyMetric()])
+
+        for pred, ref in zip(preds, refs):
+            ensemble.add(pred, ref)
+        self.assertDictEqual(expected_results, ensemble.compute())
+
+    def test_add_batch(self):
+        preds, refs = DummyMetric.predictions_and_references()
+        expected_results = DummyMetric.expected_results()
+
+        ensemble = EvaluationEnsemble([DummyMetric()])
+
+        ensemble.add_batch(predictions=preds, references=refs)
+        self.assertDictEqual(expected_results, ensemble.compute())
+
+    def test_force_prefix_with_dict(self):
+        prefix = "test_prefix"
+        preds, refs = DummyMetric.predictions_and_references()
+
+        expected_results = DummyMetric.expected_results()
+        expected_results[f"{prefix}_accuracy"] = expected_results.pop("accuracy")
+        expected_results[f"{prefix}_set_equality"] = expected_results.pop("set_equality")
+
+        ensemble = EvaluationEnsemble({prefix: DummyMetric()}, force_prefix=True)
+
+        self.assertDictEqual(expected_results, ensemble.compute(predictions=preds, references=refs))
+
+    def test_duplicate_module(self):
+        preds, refs = DummyMetric.predictions_and_references()
+        dummy_metric = DummyMetric()
+        dummy_result = DummyMetric.expected_results()
+        ensemble = EvaluationEnsemble([dummy_metric, dummy_metric])
+
+        expected_results = {}
+        for i in range(2):
+            for k in dummy_result:
+                expected_results[f"{dummy_metric.name}_{i}_{k}"] = dummy_result[k]
+        self.assertDictEqual(expected_results, ensemble.compute(predictions=preds, references=refs))
+
+    def test_two_modules_with_same_score_name(self):
+        preds, refs = DummyMetric.predictions_and_references()
+        dummy_metric = DummyMetric()
+        another_dummy_metric = AnotherDummyMetric()
+
+        dummy_result_1 = DummyMetric.expected_results()
+        dummy_result_2 = AnotherDummyMetric.expected_results()
+
+        dummy_result_1[dummy_metric.name + "_set_equality"] = dummy_result_1.pop("set_equality")
+        dummy_result_1[another_dummy_metric.name + "_set_equality"] = dummy_result_2["set_equality"]
+
+        ensemble = EvaluationEnsemble([dummy_metric, another_dummy_metric])
+
+        self.assertDictEqual(dummy_result_1, ensemble.compute(predictions=preds, references=refs))
+
+    def test_modules_from_string(self):
+        expected_result = {"accuracy": 0.5, "recall": 0.5, "precision": 1.0}
+        predictions = [0, 1]
+        references = [1, 1]
+
+        ensemble = EvaluationEnsemble(["accuracy", "recall", "precision"])
+
+        self.assertDictEqual(expected_result, ensemble.compute(predictions=predictions, references=references))


### PR DESCRIPTION
This PR adds the `EvaluationEnsemble` class that lets users combine several `EvaluationModule`s into a single, compact object that behaves like a single module. Here's how it works:

```py
from evaluate import EvaluationEnsemble

clf_metrics = EvaluationEnsemble(["accuracy", "f1", "precision","recall"])
clf_metrics.compute(predictions=[0,1], references=[1,1])

{
    'accuracy': 0.5, 
    'f1': 0.666, 
    'precision': 1.0,
    'recall': 0.5
}
```

Under the hood the `add`, `add_batch`, and `compute` function iteratively call the methods with the same name for each module.

There are a few scenarios for the returned dict:
- if there are name clashes in the score names the module name is prefixed
- if there are name clashes in the modules the prefixes are additionally enumerated
- one can force the prefix with `force_prefix=True` at initialization
- for the name the module names are used except if the modules are passed as a dict in which case the keys are used.

Here an example to illustrate forced prefixing with custom names:
```py
bleu_metrics = EvaluationEnsemble({
    "bleu_simple": evaluate.load("bleu"),
    "bleu_complex": evaluate.load("bleu")}
)

{
 'bleu_simple_bleu': 0.0,
 'bleu_simple_precisions': [0.75, 0.5, 0.0, 0.0],
 'bleu_simple_brevity_penalty': 1.0,
 'bleu_simple_length_ratio': 1.0,
 'bleu_simple_translation_length': 4,
 'bleu_simple_reference_length': 4,
 'bleu_complex_bleu': 0.0,
 'bleu_complex_precisions': [0.75, 0.5, 0.0, 0.0],
 'bleu_complex_brevity_penalty': 1.0,
 'bleu_complex_length_ratio': 1.0,
 'bleu_complex_translation_length': 4,
 'bleu_complex_reference_length': 4
}
```
This should be especially useful if the same metric with different configs is used in one ensemble.

I am not married to the name `EvaluationEnsemble` so if there are any better suggestions I am happy to hear them.