### PR TITLE
rename `input_texts` to `predictions` in perplexity

### DIFF
--- a/metrics/perplexity/README.md
+++ b/metrics/perplexity/README.md
@@ -37,13 +37,13 @@ The metric takes a list of text as input, as well as the name of the model used 
 ```python
 from evaluate import load
 perplexity = load("perplexity", module_type="metric")
-results = perplexity.compute(input_texts=input_texts, model_id='gpt2')
+results = perplexity.compute(predictions=predictions, model_id='gpt2')
 ```
 
 ### Inputs
 - **model_id** (str): model used for calculating Perplexity. NOTE: Perplexity can only be calculated for causal language models.
     - This includes models such as gpt2, causal variations of bert, causal versions of t5, and more (the full list can be found in the AutoModelForCausalLM documentation here: https://huggingface.co/docs/transformers/master/en/model_doc/auto#transformers.AutoModelForCausalLM )
-- **input_texts** (list of str): input text, each separate text snippet is one list entry.
+- **predictions** (list of str): input text, each separate text snippet is one list entry.
 - **batch_size** (int): the batch size to run texts through the model. Defaults to 16.
 - **add_start_token** (bool): whether to add the start token to the texts, so the perplexity can include the probability of the first word. Defaults to True.
 - **device** (str): device to run on, defaults to 'cuda' when available
@@ -62,13 +62,13 @@ This metric's range is 0 and up. A lower score is better.
 
 
 ### Examples
-Calculating perplexity on input_texts defined here:
+Calculating perplexity on predictions defined here:
 ```python
-perplexity = evaluate.load("perplexity", module_type="metric")
-input_texts = ["lorem ipsum", "Happy Birthday!", "Bienvenue"]
+input_texts = evaluate.load("perplexity", module_type="metric")
+predictions = ["lorem ipsum", "Happy Birthday!", "Bienvenue"]
 results = perplexity.compute(model_id='gpt2',
                              add_start_token=False,
-                             input_texts=input_texts)
+                             predictions=input_texts)
 print(list(results.keys()))
 >>>['perplexities', 'mean_perplexity']
 print(round(results["mean_perplexity"], 2))
@@ -76,7 +76,7 @@ print(round(results["mean_perplexity"], 2))
 print(round(results["perplexities"][0], 2))
 >>>11.11
 ```
-Calculating perplexity on input_texts loaded in from a dataset:
+Calculating perplexity on predictions loaded in from a dataset:
 ```python
 perplexity = evaluate.load("perplexity", module_type="metric")
 input_texts = datasets.load_dataset("wikitext",
@@ -84,7 +84,7 @@ input_texts = datasets.load_dataset("wikitext",
                                     split="test")["text"][:50]
 input_texts = [s for s in input_texts if s!='']
 results = perplexity.compute(model_id='gpt2',
-                             input_texts=input_texts)
+                             predictions=input_texts)
 print(list(results.keys()))
 >>>['perplexities', 'mean_perplexity']
 print(round(results["mean_perplexity"], 2))

--- a/metrics/perplexity/perplexity.py
+++ b/metrics/perplexity/perplexity.py
@@ -43,7 +43,7 @@ Args:
                     in the AutoModelForCausalLM documentation here:
                     https://huggingface.co/docs/transformers/master/en/model_doc/auto#transformers.AutoModelForCausalLM )
 
-    input_texts (list of str): input text, each separate text snippet
+    predictions (list of str): input text, each separate text snippet
         is one list entry.
     batch_size (int): the batch size to run texts through the model. Defaults to 16.
     add_start_token (bool): whether to add the start token to the texts,
@@ -60,7 +60,7 @@ Examples:
         >>> input_texts = ["lorem ipsum", "Happy Birthday!", "Bienvenue"]
         >>> results = perplexity.compute(model_id='gpt2',
         ...                              add_start_token=False,
-        ...                              input_texts=input_texts) # doctest:+ELLIPSIS
+        ...                              predictions=input_texts) # doctest:+ELLIPSIS
         >>> print(list(results.keys()))
         ['perplexities', 'mean_perplexity']
         >>> print(round(results["mean_perplexity"], 2))
@@ -74,7 +74,7 @@ Examples:
         >>> input_texts = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")["text"][:10] # doctest: +SKIP
         >>> input_texts = [s for s in input_texts if s!='']
         >>> results = perplexity.compute(model_id='gpt2',
-        ...                              input_texts=input_texts)
+        ...                              predictions=input_texts)
         >>> print(list(results.keys()))
         ['perplexities', 'mean_perplexity']
         >>> print(round(results["mean_perplexity"], 2)) # doctest: +SKIP
@@ -94,13 +94,13 @@ class Perplexity(evaluate.EvaluationModule):
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                    "input_texts": datasets.Value("string"),
+                    "predictions": datasets.Value("string"),
                 }
             ),
             reference_urls=["https://huggingface.co/docs/transformers/perplexity"],
         )
 
-    def _compute(self, input_texts, model_id, batch_size: int = 16, add_start_token: bool = True, device=None):
+    def _compute(self, predictions, model_id, batch_size: int = 16, add_start_token: bool = True, device=None):
 
         if device is not None:
             assert device in ["gpu", "cpu", "cuda"], "device should be either gpu or cpu."
@@ -136,7 +136,7 @@ class Perplexity(evaluate.EvaluationModule):
             max_tokenized_len = model.config.max_length
 
         encodings = tokenizer(
-            input_texts,
+            predictions,
             add_special_tokens=False,
             padding=True,
             truncation=True,


### PR DESCRIPTION
This PR adresses #149 and renames the input to the perplexity metric to match the format used by other metrics. This makes the usage more uniform and will also allow to easily combine it with other NLP metrics.