### PR TITLE
test string casting only on first element

### DIFF
--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -687,7 +687,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
                     # obj is a list of dict
                     for k, dict_tuples in zip_dict(schema.feature, *obj):
                         for sub_obj in dict_tuples[1:]:
-                            if sub_obj is not None:
+                            if _check_non_null_non_empty_recursive(sub_obj, dict_tuples[0]):
                                 self._enforce_nested_string_type(dict_tuples[0], sub_obj)
                                 break
                     return None
@@ -695,7 +695,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
                     # obj is a single dict
                     for k, (sub_schema, sub_objs) in zip_dict(schema.feature, obj):
                         for sub_obj in sub_objs:
-                            if sub_obj is not None:
+                            if _check_non_null_non_empty_recursive(sub_obj, dict_tuples[0]):
                                 self._enforce_nested_string_type(sub_schema, sub_obj)
                                 break
                     return None

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -686,11 +686,19 @@ class EvaluationModule(EvaluationModuleInfoMixin):
                 if isinstance(obj, (list, tuple)):
                     # obj is a list of dict
                     for k, dict_tuples in zip_dict(schema.feature, *obj):
-                        return [self._enforce_nested_string_type(dict_tuples[0], o) for o in dict_tuples[1:]]
+                        for sub_obj in dict_tuples[1:]:
+                            if sub_obj is not None:
+                                self._enforce_nested_string_type(dict_tuples[0], sub_obj)
+                                break
+                    return None
                 else:
                     # obj is a single dict
                     for k, (sub_schema, sub_objs) in zip_dict(schema.feature, obj):
-                        return [self._enforce_nested_string_type(sub_schema, o) for o in sub_objs]
+                        for sub_obj in sub_objs:
+                            if sub_obj is not None:
+                                self._enforce_nested_string_type(sub_schema, sub_obj)
+                                break
+                    return None
             # schema.feature is not a dict
             if isinstance(obj, str):  # don't interpret a string as a list
                 raise ValueError(f"Got a string but expected a list instead: '{obj}'")
@@ -702,7 +710,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
                         if _check_non_null_non_empty_recursive(first_elmt, schema.feature):
                             break
                     if not isinstance(first_elmt, list):
-                        return [self._enforce_nested_string_type(schema.feature, o) for o in obj]
+                        return self._enforce_nested_string_type(schema.feature, first_elmt)
 
         elif isinstance(schema, Value):
             if pa.types.is_string(schema.pa_type) and not isinstance(obj, str):

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -474,7 +474,8 @@ class EvaluationModule(EvaluationModuleInfoMixin):
             self._init_writer()
         try:
             for key, column in batch.items():
-                [self._enforce_nested_string_type(self.current_features[key], obj) for obj in column]
+                if len(column)>0:
+                    self._enforce_nested_string_type(self.current_features[key], column[0])
             batch = self.current_features.encode_batch(batch)
             self.writer.write_batch(batch)
         except (pa.ArrowInvalid, TypeError):

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -695,7 +695,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
                     # obj is a single dict
                     for k, (sub_schema, sub_objs) in zip_dict(schema.feature, obj):
                         for sub_obj in sub_objs:
-                            if _check_non_null_non_empty_recursive(sub_obj, dict_tuples[0]):
+                            if _check_non_null_non_empty_recursive(sub_obj, sub_schema):
                                 self._enforce_nested_string_type(sub_schema, sub_obj)
                                 break
                     return None

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -474,7 +474,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
             self._init_writer()
         try:
             for key, column in batch.items():
-                if len(column)>0:
+                if len(column) > 0:
                     self._enforce_nested_string_type(self.current_features[key], column[0])
             batch = self.current_features.encode_batch(batch)
             self.writer.write_batch(batch)

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -3,7 +3,7 @@ import pickle
 import tempfile
 import time
 from multiprocessing import Pool
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pytest
 from datasets.features import Features, Sequence, Value
@@ -498,6 +498,29 @@ class TestMetric(TestCase):
         metric.compute(predictions=[["a"]], references=[["a"]])
         with self.assertRaises(ValueError):
             metric.compute(predictions=["a"], references=["a"])
+
+    def test_string_casting_tested_once(self):
+
+        self.counter = 0
+        def checked_fct(fct):  # wrapper function that increases a counter on each call
+            def wrapped(*args, **kwargs):
+                self.counter += 1
+                return fct(*args, **kwargs)
+            return wrapped
+
+        with mock.patch('evaluate.EvaluationModule._enforce_nested_string_type', checked_fct(DummyMetric._enforce_nested_string_type)):
+            metric = DummyMetric(experiment_id="test_string_casting_called_once")
+            metric.info.features = Features({"references": Sequence(Value("string")), "predictions": Sequence(Value("string"))})
+            refs = [["test"]*10]*10
+            preds = [["test"]*10]*10
+            
+            metric.add_batch(references=refs, predictions=preds)
+            metric.add_batch(references=refs, predictions=preds)
+
+        # the function is called twice for every batch's input: once on the
+        # sequence and then recursively agin on the first input of the sequence
+        self.assertEqual(self.counter, 8)
+        
 
     def test_multiple_features(self):
         metric = DummyMetric()

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -502,25 +502,31 @@ class TestMetric(TestCase):
     def test_string_casting_tested_once(self):
 
         self.counter = 0
+
         def checked_fct(fct):  # wrapper function that increases a counter on each call
             def wrapped(*args, **kwargs):
                 self.counter += 1
                 return fct(*args, **kwargs)
+
             return wrapped
 
-        with mock.patch('evaluate.EvaluationModule._enforce_nested_string_type', checked_fct(DummyMetric._enforce_nested_string_type)):
+        with mock.patch(
+            "evaluate.EvaluationModule._enforce_nested_string_type",
+            checked_fct(DummyMetric._enforce_nested_string_type),
+        ):
             metric = DummyMetric(experiment_id="test_string_casting_called_once")
-            metric.info.features = Features({"references": Sequence(Value("string")), "predictions": Sequence(Value("string"))})
-            refs = [["test"]*10]*10
-            preds = [["test"]*10]*10
-            
+            metric.info.features = Features(
+                {"references": Sequence(Value("string")), "predictions": Sequence(Value("string"))}
+            )
+            refs = [["test"] * 10] * 10
+            preds = [["test"] * 10] * 10
+
             metric.add_batch(references=refs, predictions=preds)
             metric.add_batch(references=refs, predictions=preds)
 
         # the function is called twice for every batch's input: once on the
         # sequence and then recursively agin on the first input of the sequence
         self.assertEqual(self.counter, 8)
-        
 
     def test_multiple_features(self):
         metric = DummyMetric()


### PR DESCRIPTION
This addresses #153: Instead of testing on every element of a batch we only test on the first. This should reduce the latency for adding batches. 

This makes the assumption that the user would pass the same type in the rest of the batch which is a fair one IMO.