### PR TITLE
Rename evaluation modules

### DIFF
--- a/comparisons/exact_match/exact_match.py
+++ b/comparisons/exact_match/exact_match.py
@@ -45,9 +45,9 @@ _CITATION = """
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class ExactMatch(evaluate.EvaluationModule):
+class ExactMatch(evaluate.Comparison):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.ComparisonInfo(
             module_type="comparison",
             description=_DESCRIPTION,
             citation=_CITATION,

--- a/comparisons/mcnemar/mcnemar.py
+++ b/comparisons/mcnemar/mcnemar.py
@@ -61,9 +61,9 @@ _CITATION = """
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class McNemar(evaluate.EvaluationModule):
+class McNemar(evaluate.Comparison):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.ComparisonInfo(
             module_type="comparison",
             description=_DESCRIPTION,
             citation=_CITATION,

--- a/docs/source/package_reference/main_classes.mdx
+++ b/docs/source/package_reference/main_classes.mdx
@@ -2,10 +2,24 @@
 
 ## EvaluationModuleInfo
 
+The base class `EvaluationModuleInfo` implements a the logic for the subclasses `MetricInfo`, `ComparisonInfo`, and `MeasurementInfo`.
+
 [[autodoc]] evaluate.EvaluationModuleInfo
+
+[[autodoc]] evaluate.MetricInfo
+
+[[autodoc]] evaluate.ComparisonInfo
+
+[[autodoc]] evaluate.MeasurementInfo
 
 ## EvaluationModule
 
-The base class `Metric` implements a Metric backed by one or several [`Dataset`].
+The base class `EvaluationModule` implements a the logic for the subclasses `Metric`, `Comparison`, and `Measurement`.
 
 [[autodoc]] evaluate.EvaluationModule
+
+[[autodoc]] evaluate.Metric
+
+[[autodoc]] evaluate.Comparison
+
+[[autodoc]] evaluate.Measurement

--- a/measurements/perplexity/perplexity.py
+++ b/measurements/perplexity/perplexity.py
@@ -85,9 +85,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Perplexity(evaluate.EvaluationModule):
+class Perplexity(evaluate.Measurement):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MeasurementInfo(
             module_type="measurement",
             description=_DESCRIPTION,
             citation=_CITATION,

--- a/measurements/text_duplicates/text_duplicates.py
+++ b/measurements/text_duplicates/text_duplicates.py
@@ -52,12 +52,12 @@ def get_hash(example):
     return hashlib.md5(example.strip().encode("utf-8")).hexdigest()
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class TextDuplicates(evaluate.EvaluationModule):
+class TextDuplicates(evaluate.Measurement):
     """This measurement returns the duplicate strings contained in the input(s)."""
 
     def _info(self):
-        # TODO: Specifies the evaluate.EvaluationModuleInfo object
-        return evaluate.EvaluationModuleInfo(
+        # TODO: Specifies the evaluate.MeasurementInfo object
+        return evaluate.MeasurementInfo(
             # This is the description that will appear on the modules page.
             module_type="measurement",
             description=_DESCRIPTION,

--- a/measurements/word_count/word_count.py
+++ b/measurements/word_count/word_count.py
@@ -39,12 +39,12 @@ Examples:
 _CITATION = ""
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class WordCount(evaluate.EvaluationModule):
+class WordCount(evaluate.Measurement):
     """This measurement returns the total number of words and the number of unique words
      in the input string(s)."""
 
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MeasurementInfo(
             # This is the description that will appear on the modules page.
             module_type="measurement",
             description=_DESCRIPTION,

--- a/measurements/word_length/word_length.py
+++ b/measurements/word_length/word_length.py
@@ -50,12 +50,12 @@ year={2020}
 """
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class WordLength(evaluate.EvaluationModule):
+class WordLength(evaluate.Measurement):
     """This measurement returns the average number of words in the input string(s)."""
 
     def _info(self):
-        # TODO: Specifies the evaluate.EvaluationModuleInfo object
-        return evaluate.EvaluationModuleInfo(
+        # TODO: Specifies the evaluate.MeasurementInfo object
+        return evaluate.MeasurementInfo(
             # This is the description that will appear on the modules page.
             module_type="measurement",
             description=_DESCRIPTION,

--- a/metrics/accuracy/accuracy.py
+++ b/metrics/accuracy/accuracy.py
@@ -78,9 +78,9 @@ _CITATION = """
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Accuracy(evaluate.EvaluationModule):
+class Accuracy(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -98,9 +98,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class BERTScore(evaluate.EvaluationModule):
+class BERTScore(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             homepage="https://github.com/Tiiiger/bert_score",

--- a/metrics/bleu/bleu.py
+++ b/metrics/bleu/bleu.py
@@ -85,9 +85,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Bleu(evaluate.EvaluationModule):
+class Bleu(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -77,10 +77,10 @@ CHECKPOINT_URLS = {
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class BLEURT(evaluate.EvaluationModule):
+class BLEURT(evaluate.Metric):
     def _info(self):
 
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             homepage="https://github.com/google-research/bleurt",

--- a/metrics/cer/cer.py
+++ b/metrics/cer/cer.py
@@ -116,9 +116,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class CER(evaluate.EvaluationModule):
+class CER(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/chrf/chrf.py
+++ b/metrics/chrf/chrf.py
@@ -124,14 +124,14 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class ChrF(evaluate.EvaluationModule):
+class ChrF(evaluate.Metric):
     def _info(self):
         if version.parse(scb.__version__) < version.parse("1.4.12"):
             raise ImportWarning(
                 "To use `sacrebleu`, the module `sacrebleu>=1.4.12` is required, and the current version of `sacrebleu` doesn't match this condition.\n"
                 'You can install it with `pip install "sacrebleu>=1.4.12"`.'
             )
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             homepage="https://github.com/mjpost/sacreBLEU#chrf--chrf",

--- a/metrics/code_eval/code_eval.py
+++ b/metrics/code_eval/code_eval.py
@@ -132,9 +132,9 @@ THE SOFTWARE."""
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class CodeEval(evaluate.EvaluationModule):
+class CodeEval(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             # This is the description that will appear on the metrics page.
             description=_DESCRIPTION,
             citation=_CITATION,

--- a/metrics/comet/comet.py
+++ b/metrics/comet/comet.py
@@ -107,10 +107,10 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class COMET(evaluate.EvaluationModule):
+class COMET(evaluate.Metric):
     def _info(self):
 
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             homepage="https://unbabel.github.io/COMET/html/index.html",

--- a/metrics/competition_math/competition_math.py
+++ b/metrics/competition_math/competition_math.py
@@ -64,11 +64,11 @@ Examples:
 
 
 @datasets.utils.file_utils.add_end_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class CompetitionMathMetric(evaluate.EvaluationModule):
+class CompetitionMathMetric(evaluate.Metric):
     """Accuracy metric for the MATH dataset."""
 
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/coval/coval.py
+++ b/metrics/coval/coval.py
@@ -270,9 +270,9 @@ def check_gold_parse_annotation(key_lines):
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Coval(evaluate.EvaluationModule):
+class Coval(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/cuad/cuad.py
+++ b/metrics/cuad/cuad.py
@@ -69,9 +69,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class CUAD(evaluate.EvaluationModule):
+class CUAD(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/exact_match/exact_match.py
+++ b/metrics/exact_match/exact_match.py
@@ -84,9 +84,9 @@ _CITATION = """
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class ExactMatch(evaluate.EvaluationModule):
+class ExactMatch(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -97,9 +97,9 @@ _CITATION = """
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class F1(evaluate.EvaluationModule):
+class F1(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/frugalscore/frugalscore.py
+++ b/metrics/frugalscore/frugalscore.py
@@ -55,9 +55,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class FRUGALSCORE(evaluate.EvaluationModule):
+class FRUGALSCORE(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/glue/glue.py
+++ b/metrics/glue/glue.py
@@ -103,7 +103,7 @@ def pearson_and_spearman(preds, labels):
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Glue(evaluate.EvaluationModule):
+class Glue(evaluate.Metric):
     def _info(self):
         if self.config_name not in [
             "sst2",
@@ -124,7 +124,7 @@ class Glue(evaluate.EvaluationModule):
                 '["sst2", "mnli", "mnli_mismatched", "mnli_matched", '
                 '"cola", "stsb", "mrpc", "qqp", "qnli", "rte", "wnli", "hans"]'
             )
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/google_bleu/google_bleu.py
+++ b/metrics/google_bleu/google_bleu.py
@@ -19,7 +19,7 @@ import datasets
 from nltk.translate import gleu_score
 
 import evaluate
-from evaluate import EvaluationModuleInfo
+from evaluate import MetricInfo
 
 from .tokenizer_13a import Tokenizer13a
 
@@ -125,9 +125,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class GoogleBleu(evaluate.EvaluationModule):
-    def _info(self) -> EvaluationModuleInfo:
-        return evaluate.EvaluationModuleInfo(
+class GoogleBleu(evaluate.Metric):
+    def _info(self) -> MetricInfo:
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/indic_glue/indic_glue.py
+++ b/metrics/indic_glue/indic_glue.py
@@ -103,7 +103,7 @@ def precision_at_10(en_sentvecs, in_sentvecs):
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class IndicGlue(evaluate.EvaluationModule):
+class IndicGlue(evaluate.Metric):
     def _info(self):
         if self.config_name not in [
             "wnli",
@@ -126,7 +126,7 @@ class IndicGlue(evaluate.EvaluationModule):
                 '"cvit-mkb-clsr", "iitp-mr", "iitp-pr", "actsa-sc", "md", '
                 '"wiki-ner"]'
             )
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/mae/mae.py
+++ b/metrics/mae/mae.py
@@ -82,9 +82,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Mae(evaluate.EvaluationModule):
+class Mae(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -58,9 +58,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Mahalanobis(evaluate.EvaluationModule):
+class Mahalanobis(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/matthews_correlation/matthews_correlation.py
+++ b/metrics/matthews_correlation/matthews_correlation.py
@@ -80,9 +80,9 @@ _CITATION = """\
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class MatthewsCorrelation(evaluate.EvaluationModule):
+class MatthewsCorrelation(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/mauve/mauve.py
+++ b/metrics/mauve/mauve.py
@@ -86,9 +86,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Mauve(evaluate.EvaluationModule):
+class Mauve(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             homepage="https://github.com/krishnap25/mauve",

--- a/metrics/mean_iou/mean_iou.py
+++ b/metrics/mean_iou/mean_iou.py
@@ -274,9 +274,9 @@ def mean_iou(
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class MeanIoU(evaluate.EvaluationModule):
+class MeanIoU(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -83,9 +83,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Meteor(evaluate.EvaluationModule):
+class Meteor(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/mse/mse.py
+++ b/metrics/mse/mse.py
@@ -86,9 +86,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Mse(evaluate.EvaluationModule):
+class Mse(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/pearsonr/pearsonr.py
+++ b/metrics/pearsonr/pearsonr.py
@@ -84,9 +84,9 @@ doi = {10.1038/s41592-019-0686-2},
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Pearsonr(evaluate.EvaluationModule):
+class Pearsonr(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/perplexity/perplexity.py
+++ b/metrics/perplexity/perplexity.py
@@ -85,9 +85,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Perplexity(evaluate.EvaluationModule):
+class Perplexity(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             module_type="metric",
             description=_DESCRIPTION,
             citation=_CITATION,

--- a/metrics/precision/precision.py
+++ b/metrics/precision/precision.py
@@ -103,9 +103,9 @@ _CITATION = """
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Precision(evaluate.EvaluationModule):
+class Precision(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/recall/recall.py
+++ b/metrics/recall/recall.py
@@ -93,9 +93,9 @@ _CITATION = """
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Recall(evaluate.EvaluationModule):
+class Recall(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/rl_reliability/rl_reliability.py
+++ b/metrics/rl_reliability/rl_reliability.py
@@ -82,14 +82,14 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class RLReliability(evaluate.EvaluationModule):
+class RLReliability(evaluate.Metric):
     """Computes the RL Reliability Metrics."""
 
     def _info(self):
         if self.config_name not in ["online", "offline"]:
             raise KeyError("""You should supply a configuration name selected in '["online", "offline"]'""")
 
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             module_type="metric",
             description=_DESCRIPTION,
             citation=_CITATION,

--- a/metrics/roc_auc/roc_auc.py
+++ b/metrics/roc_auc/roc_auc.py
@@ -143,9 +143,9 @@ year={2011}
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class ROCAUC(evaluate.EvaluationModule):
+class ROCAUC(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/rouge/rouge.py
+++ b/metrics/rouge/rouge.py
@@ -85,9 +85,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Rouge(evaluate.EvaluationModule):
+class Rouge(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/sacrebleu/sacrebleu.py
+++ b/metrics/sacrebleu/sacrebleu.py
@@ -103,14 +103,14 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Sacrebleu(evaluate.EvaluationModule):
+class Sacrebleu(evaluate.Metric):
     def _info(self):
         if version.parse(scb.__version__) < version.parse("1.4.12"):
             raise ImportWarning(
                 "To use `sacrebleu`, the module `sacrebleu>=1.4.12` is required, and the current version of `sacrebleu` doesn't match this condition.\n"
                 'You can install it with `pip install "sacrebleu>=1.4.12"`.'
             )
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             homepage="https://github.com/mjpost/sacreBLEU",

--- a/metrics/sari/sari.py
+++ b/metrics/sari/sari.py
@@ -258,9 +258,9 @@ def normalize(sentence, lowercase: bool = True, tokenizer: str = "13a", return_s
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Sari(evaluate.EvaluationModule):
+class Sari(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/seqeval/seqeval.py
+++ b/metrics/seqeval/seqeval.py
@@ -100,9 +100,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Seqeval(evaluate.EvaluationModule):
+class Seqeval(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             homepage="https://github.com/chakki-works/seqeval",

--- a/metrics/spearmanr/spearmanr.py
+++ b/metrics/spearmanr/spearmanr.py
@@ -97,9 +97,9 @@ _CITATION = r"""\
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Spearmanr(evaluate.EvaluationModule):
+class Spearmanr(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/squad/squad.py
+++ b/metrics/squad/squad.py
@@ -66,9 +66,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Squad(evaluate.EvaluationModule):
+class Squad(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/squad_v2/squad_v2.py
+++ b/metrics/squad_v2/squad_v2.py
@@ -88,9 +88,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class SquadV2(evaluate.EvaluationModule):
+class SquadV2(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/super_glue/super_glue.py
+++ b/metrics/super_glue/super_glue.py
@@ -145,7 +145,7 @@ def evaluate_multirc(ids_preds, labels):
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class SuperGlue(evaluate.EvaluationModule):
+class SuperGlue(evaluate.Metric):
     def _info(self):
         if self.config_name not in [
             "boolq",
@@ -164,7 +164,7 @@ class SuperGlue(evaluate.EvaluationModule):
                 "You should supply a configuration name selected in "
                 '["boolq", "cb", "copa", "multirc", "record", "rte", "wic", "wsc", "wsc.fixed", "axb", "axg",]'
             )
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/ter/ter.py
+++ b/metrics/ter/ter.py
@@ -151,14 +151,14 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Ter(evaluate.EvaluationModule):
+class Ter(evaluate.Metric):
     def _info(self):
         if version.parse(scb.__version__) < version.parse("1.4.12"):
             raise ImportWarning(
                 "To use `sacrebleu`, the module `sacrebleu>=1.4.12` is required, and the current version of `sacrebleu` doesn't match this condition.\n"
                 'You can install it with `pip install "sacrebleu>=1.4.12"`.'
             )
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             homepage="http://www.cs.umd.edu/~snover/tercom/",

--- a/metrics/trec_eval/trec_eval.py
+++ b/metrics/trec_eval/trec_eval.py
@@ -68,11 +68,11 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class TRECEval(evaluate.EvaluationModule):
+class TRECEval(evaluate.Metric):
     """Compute TREC evaluation scores."""
 
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             module_type="metric",
             description=_DESCRIPTION,
             citation=_CITATION,

--- a/metrics/wer/wer.py
+++ b/metrics/wer/wer.py
@@ -75,9 +75,9 @@ Examples:
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class WER(evaluate.EvaluationModule):
+class WER(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/wiki_split/wiki_split.py
+++ b/metrics/wiki_split/wiki_split.py
@@ -321,9 +321,9 @@ def compute_sacrebleu(
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class WikiSplit(evaluate.EvaluationModule):
+class WikiSplit(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/xnli/xnli.py
+++ b/metrics/xnli/xnli.py
@@ -67,9 +67,9 @@ def simple_accuracy(preds, labels):
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class Xnli(evaluate.EvaluationModule):
+class Xnli(evaluate.Metric):
     def _info(self):
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/metrics/xtreme_s/xtreme_s.py
+++ b/metrics/xtreme_s/xtreme_s.py
@@ -219,14 +219,14 @@ def wer_and_cer(preds, labels, concatenate_texts, config_name):
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class XtremeS(evaluate.EvaluationModule):
+class XtremeS(evaluate.Metric):
     def _info(self):
         if self.config_name not in _CONFIG_NAMES:
             raise KeyError(f"You should supply a configuration name selected in {_CONFIG_NAMES}")
 
         pred_type = "int64" if self.config_name in ["fleurs-lang_id", "minds14"] else "string"
 
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.MetricInfo(
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -28,10 +28,10 @@ del version
 
 from .evaluator import Evaluator, TextClassificationEvaluator, evaluator
 from .hub import push_to_hub
-from .info import EvaluationModuleInfo, MetricInfo, ComparisonInfo, MeasurementInfo
+from .info import ComparisonInfo, EvaluationModuleInfo, MeasurementInfo, MetricInfo
 from .inspect import inspect_evaluation_module, list_evaluation_modules
 from .loading import load
-from .module import EvaluationModule, Metric, Comparison, Measurement
+from .module import Comparison, EvaluationModule, Measurement, Metric
 from .saving import save
 from .utils import *
 from .utils import gradio, logging

--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -28,10 +28,10 @@ del version
 
 from .evaluator import Evaluator, TextClassificationEvaluator, evaluator
 from .hub import push_to_hub
-from .info import EvaluationModuleInfo
+from .info import EvaluationModuleInfo, MetricInfo, ComparisonInfo, MeasurementInfo
 from .inspect import inspect_evaluation_module, list_evaluation_modules
 from .loading import load
-from .module import EvaluationModule
+from .module import EvaluationModule, Metric, Comparison, Measurement
 from .saving import save
 from .utils import *
 from .utils import gradio, logging

--- a/src/evaluate/info.py
+++ b/src/evaluate/info.py
@@ -52,7 +52,7 @@ class EvaluationModuleInfo:
     reference_urls: List[str] = field(default_factory=list)
     streamable: bool = False
     format: Optional[str] = None
-    module_type: str = "metric"
+    module_type: str = "metric" # deprecate this in the future
 
     # Set later by the builder
     module_name: Optional[str] = None

--- a/src/evaluate/info.py
+++ b/src/evaluate/info.py
@@ -98,3 +98,19 @@ class EvaluationModuleInfo:
     def from_dict(cls, metric_info_dict: dict) -> "EvaluationModuleInfo":
         field_names = {f.name for f in dataclasses.fields(cls)}
         return cls(**{k: v for k, v in metric_info_dict.items() if k in field_names})
+
+
+@dataclass
+class MetricInfo(EvaluationModuleInfo):
+    """MetricInfo"""
+    module_type: str = "metric"
+
+@dataclass
+class ComparisonInfo(EvaluationModuleInfo):
+    """ComparisonInfo"""
+    module_type: str = "comparison"
+
+@dataclass
+class MeasurementInfo(EvaluationModuleInfo):
+    """MeasurementInfo"""
+    module_type: str = "measurement"

--- a/src/evaluate/info.py
+++ b/src/evaluate/info.py
@@ -33,7 +33,7 @@ logger = get_logger(__name__)
 
 @dataclass
 class EvaluationModuleInfo:
-    """Base class to store fnformation about an evaluation used for `MetricInfo`, `ComparisonInfo`, 
+    """Base class to store fnformation about an evaluation used for `MetricInfo`, `ComparisonInfo`,
     and `MeasurementInfo`.
 
     `EvaluationModuleInfo` documents an evaluation, including its name, version, and features.

--- a/src/evaluate/info.py
+++ b/src/evaluate/info.py
@@ -55,7 +55,7 @@ class EvaluationModuleInfo:
     module_type: str = "metric"
 
     # Set later by the builder
-    metric_name: Optional[str] = None
+    module_name: Optional[str] = None
     config_name: Optional[str] = None
     experiment_id: Optional[str] = None
 

--- a/src/evaluate/info.py
+++ b/src/evaluate/info.py
@@ -33,9 +33,10 @@ logger = get_logger(__name__)
 
 @dataclass
 class EvaluationModuleInfo:
-    """Information about a metric.
+    """Base class to store fnformation about an evaluation used for `MetricInfo`, `ComparisonInfo`, 
+    and `MeasurementInfo`.
 
-    `EvaluationModuleInfo` documents a metric, including its name, version, and features.
+    `EvaluationModuleInfo` documents an evaluation, including its name, version, and features.
     See the constructor arguments and properties for a full list.
 
     Note: Not all fields are known on construction and may be updated later.
@@ -102,20 +103,38 @@ class EvaluationModuleInfo:
 
 @dataclass
 class MetricInfo(EvaluationModuleInfo):
-    """MetricInfo"""
+    """Information about a metric.
+
+    `EvaluationModuleInfo` documents a metric, including its name, version, and features.
+    See the constructor arguments and properties for a full list.
+
+    Note: Not all fields are known on construction and may be updated later.
+    """
 
     module_type: str = "metric"
 
 
 @dataclass
 class ComparisonInfo(EvaluationModuleInfo):
-    """ComparisonInfo"""
+    """Information about a comparison.
+
+    `EvaluationModuleInfo` documents a comparison, including its name, version, and features.
+    See the constructor arguments and properties for a full list.
+
+    Note: Not all fields are known on construction and may be updated later.
+    """
 
     module_type: str = "comparison"
 
 
 @dataclass
 class MeasurementInfo(EvaluationModuleInfo):
-    """MeasurementInfo"""
+    """Information about a measurement.
+
+    `EvaluationModuleInfo` documents a measurement, including its name, version, and features.
+    See the constructor arguments and properties for a full list.
+
+    Note: Not all fields are known on construction and may be updated later.
+    """
 
     module_type: str = "measurement"

--- a/src/evaluate/info.py
+++ b/src/evaluate/info.py
@@ -52,7 +52,7 @@ class EvaluationModuleInfo:
     reference_urls: List[str] = field(default_factory=list)
     streamable: bool = False
     format: Optional[str] = None
-    module_type: str = "metric" # deprecate this in the future
+    module_type: str = "metric"  # deprecate this in the future
 
     # Set later by the builder
     module_name: Optional[str] = None
@@ -103,14 +103,19 @@ class EvaluationModuleInfo:
 @dataclass
 class MetricInfo(EvaluationModuleInfo):
     """MetricInfo"""
+
     module_type: str = "metric"
+
 
 @dataclass
 class ComparisonInfo(EvaluationModuleInfo):
     """ComparisonInfo"""
+
     module_type: str = "comparison"
+
 
 @dataclass
 class MeasurementInfo(EvaluationModuleInfo):
     """MeasurementInfo"""
+
     module_type: str = "measurement"

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -735,7 +735,7 @@ class Comparison(EvaluationModule):
     """A Comparison is the base class and common API for all comparisons.
 
     Args:
-        config_name (``str``): This is used to define a hash specific to a  comparison computation script and prevents the comparison's data
+        config_name (``str``): This is used to define a hash specific to a comparison computation script and prevents the comparison's data
             to be overridden when the  comparison loading script is modified.
         keep_in_memory (:obj:`bool`): keep all predictions and references in memory. Not possible in distributed settings.
         cache_dir (``str``): Path to a directory in which temporary prediction/references data will be stored.

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -707,11 +707,14 @@ class EvaluationModule(EvaluationModuleInfoMixin):
             if pa.types.is_string(schema.pa_type) and not isinstance(obj, str):
                 raise TypeError(f"Expected type str but got {type(obj)}.")
 
+
 class Metric(EvaluationModule):
     """Metric"""
 
+
 class Comparison(EvaluationModule):
     """Comparison"""
+
 
 class Measurement(EvaluationModule):
     """Measurement"""

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -709,12 +709,61 @@ class EvaluationModule(EvaluationModuleInfoMixin):
 
 
 class Metric(EvaluationModule):
-    """Metric"""
+    """A Metric is the base class and common API for all metrics.
 
+    Args:
+        config_name (``str``): This is used to define a hash specific to a metric computation script and prevents the metric's data
+            to be overridden when the metric loading script is modified.
+        keep_in_memory (:obj:`bool`): keep all predictions and references in memory. Not possible in distributed settings.
+        cache_dir (``str``): Path to a directory in which temporary prediction/references data will be stored.
+            The data directory should be located on a shared file-system in distributed setups.
+        num_process (``int``): specify the total number of nodes in a distributed settings.
+            This is useful to compute metrics in distributed setups (in particular non-additive metrics like F1).
+        process_id (``int``): specify the id of the current process in a distributed setup (between 0 and num_process-1)
+            This is useful to compute metrics in distributed setups (in particular non-additive metrics like F1).
+        seed (:obj:`int`, optional): If specified, this will temporarily set numpy's random seed when :func:`evaluate.Metric.compute` is run.
+        experiment_id (``str``): A specific experiment id. This is used if several distributed evaluations share the same file system.
+            This is useful to compute metrics in distributed setups (in particular non-additive metrics like F1).
+        max_concurrent_cache_files (``int``): Max number of concurrent metric cache files (default 10000).
+        timeout (``Union[int, float]``): Timeout in second for distributed setting synchronization.
+    """
 
 class Comparison(EvaluationModule):
-    """Comparison"""
+    """A Comparison is the base class and common API for all comparisons.
 
+    Args:
+        config_name (``str``): This is used to define a hash specific to a  comparison computation script and prevents the comparison's data
+            to be overridden when the  comparison loading script is modified.
+        keep_in_memory (:obj:`bool`): keep all predictions and references in memory. Not possible in distributed settings.
+        cache_dir (``str``): Path to a directory in which temporary prediction/references data will be stored.
+            The data directory should be located on a shared file-system in distributed setups.
+        num_process (``int``): specify the total number of nodes in a distributed settings.
+            This is useful to compute  comparisons in distributed setups (in particular non-additive comparisons).
+        process_id (``int``): specify the id of the current process in a distributed setup (between 0 and num_process-1)
+            This is useful to compute  comparisons in distributed setups (in particular non-additive comparisons).
+        seed (:obj:`int`, optional): If specified, this will temporarily set numpy's random seed when :func:`evaluate.Comparison.compute` is run.
+        experiment_id (``str``): A specific experiment id. This is used if several distributed evaluations share the same file system.
+            This is useful to compute  comparisons in distributed setups (in particular non-additive comparisons).
+        max_concurrent_cache_files (``int``): Max number of concurrent comparison cache files (default 10000).
+        timeout (``Union[int, float]``): Timeout in second for distributed setting synchronization.
+    """
 
 class Measurement(EvaluationModule):
-    """Measurement"""
+    """A Measurement is the base class and common API for all measurements.
+
+    Args:
+        config_name (``str``): This is used to define a hash specific to a measurement computation script and prevents the measurement's data
+            to be overridden when the measurement loading script is modified.
+        keep_in_memory (:obj:`bool`): keep all predictions and references in memory. Not possible in distributed settings.
+        cache_dir (``str``): Path to a directory in which temporary prediction/references data will be stored.
+            The data directory should be located on a shared file-system in distributed setups.
+        num_process (``int``): specify the total number of nodes in a distributed settings.
+            This is useful to compute measurements in distributed setups (in particular non-additive measurements).
+        process_id (``int``): specify the id of the current process in a distributed setup (between 0 and num_process-1)
+            This is useful to compute measurements in distributed setups (in particular non-additive measurements).
+        seed (:obj:`int`, optional): If specified, this will temporarily set numpy's random seed when :func:`evaluate.Measurement.compute` is run.
+        experiment_id (``str``): A specific experiment id. This is used if several distributed evaluations share the same file system.
+            This is useful to compute measurements in distributed setups (in particular non-additive measurements).
+        max_concurrent_cache_files (``int``): Max number of concurrent measurement cache files (default 10000).
+        timeout (``Union[int, float]``): Timeout in second for distributed setting synchronization.
+    """

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -706,3 +706,12 @@ class EvaluationModule(EvaluationModuleInfoMixin):
         elif isinstance(schema, Value):
             if pa.types.is_string(schema.pa_type) and not isinstance(obj, str):
                 raise TypeError(f"Expected type str but got {type(obj)}.")
+
+class Metric(EvaluationModule):
+    """Metric"""
+
+class Comparison(EvaluationModule):
+    """Comparison"""
+
+class Measurement(EvaluationModule):
+    """Measurement"""

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -728,6 +728,7 @@ class Metric(EvaluationModule):
         timeout (``Union[int, float]``): Timeout in second for distributed setting synchronization.
     """
 
+
 class Comparison(EvaluationModule):
     """A Comparison is the base class and common API for all comparisons.
 
@@ -747,6 +748,7 @@ class Comparison(EvaluationModule):
         max_concurrent_cache_files (``int``): Max number of concurrent comparison cache files (default 10000).
         timeout (``Union[int, float]``): Timeout in second for distributed setting synchronization.
     """
+
 
 class Measurement(EvaluationModule):
     """A Measurement is the base class and common API for all measurements.

--- a/templates/{{ cookiecutter.module_slug }}/{{ cookiecutter.module_slug }}.py
+++ b/templates/{{ cookiecutter.module_slug }}/{{ cookiecutter.module_slug }}.py
@@ -58,14 +58,14 @@ BAD_WORDS_URL = "http://url/to/external/resource/bad_words.txt"
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
-class {{ cookiecutter.module_class_name }}(evaluate.EvaluationModule):
+class {{ cookiecutter.module_class_name }}(evaluate.{{ cookiecutter.module_type | capitalize}}):
     """TODO: Short description of my evaluation module."""
 
     def _info(self):
         # TODO: Specifies the evaluate.EvaluationModuleInfo object
-        return evaluate.EvaluationModuleInfo(
+        return evaluate.{{ cookiecutter.module_type | capitalize}}Info(
             # This is the description that will appear on the modules page.
-            module_type="{{ cookiecutter.module_type }}",
+            module_type="{{ cookiecutter.module_type}}",
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,


### PR DESCRIPTION
This PR addresses comments in #150 regarding the naming of the `EvaluationModule`. To make things clearer the base class `EvaluationModule` has now three children: `Metric`, `Comparison`, and `Measurement`. Same for the `EvaluationModuleInfo`. 

You can ignore the `update modules` commit which updates all classes for the implemented metrics. There are a few things left to do:

- [x] update the docs
- [x] update the template to create new modules
- [x] add proper docstrings and update existing

What do you think?