### PR TITLE
fixed duplicate calculation of spearmanr function in metrics wrapper.

### DIFF
--- a/metrics/spearmanr/spearmanr.py
+++ b/metrics/spearmanr/spearmanr.py
@@ -113,12 +113,8 @@ class Spearmanr(evaluate.Metric):
         )
 
     def _compute(self, predictions, references, return_pvalue=False):
+        results = spearmanr(references, predictions)
         if return_pvalue:
-            return {
-                "spearmanr": spearmanr(references, predictions)[0],
-                "spearmanr_pvalue": spearmanr(references, predictions)[1],
-            }
+            return {"spearmanr": results[0], "spearmanr_pvalue": results[1]}
         else:
-            return {
-                "spearmanr": spearmanr(references, predictions)[0],
-            }
+            return {"spearmanr": results[0]}


### PR DESCRIPTION
In spearmanr metric _evaluate function, wrapped scipy.stats function is called twice, once for score and once for p-value, resulting in redundant duplicate calculation. Adjusted here to only run calculation once. Already opened PR in huggingface/datasets (https://github.com/huggingface/datasets/pull/4627) and am matching here.