### PR TITLE
forbid hyphens in template for module names

### DIFF
--- a/src/evaluate/commands/evaluate_cli.py
+++ b/src/evaluate/commands/evaluate_cli.py
@@ -68,6 +68,9 @@ def main():
     if args["module_type"] not in ["metric", "comparison", "measurement"]:
         raise ValueError("The module_type needs to be one of metric, comparison, or measurement")
 
+    if "-" in args["module_name"]:
+        raise ValueError("Hyphens ('-') are not allowed in module names.")
+
     output_dir = Path(args["output_dir"])
     organization = args["organization"]
     module_slug = args["module_name"].lower().replace(" ", "_")


### PR DESCRIPTION
This PR adds a test for hyphens in module names when creating a new space with the template. If it contains hyphen an `ValueError` is thrown.

Fixes #171 