### PR TITLE
Add QuestionAnsweringEvaluator

### DIFF
--- a/docs/source/package_reference/evaluator_classes.mdx
+++ b/docs/source/package_reference/evaluator_classes.mdx
@@ -16,6 +16,6 @@ The base class for all evaluator classes:
 
 [[autodoc]] evaluate.ImageClassificationEvaluator
 
-[[autodoc]] evaluate.QuestionAnsweringPipeline
+[[autodoc]] evaluate.QuestionAnsweringEvaluator
 
 [[autodoc]] evaluate.TextClassificationEvaluator

--- a/docs/source/package_reference/evaluator_classes.mdx
+++ b/docs/source/package_reference/evaluator_classes.mdx
@@ -14,8 +14,14 @@ The base class for all evaluator classes:
 
 ## The task specific evaluators
 
+### ImageClassificationEvaluator
+
 [[autodoc]] evaluate.ImageClassificationEvaluator
 
+### QuestionAnsweringEvaluator
+
 [[autodoc]] evaluate.QuestionAnsweringEvaluator
+
+### TextClassificationEvaluator
 
 [[autodoc]] evaluate.TextClassificationEvaluator

--- a/docs/source/package_reference/evaluator_classes.mdx
+++ b/docs/source/package_reference/evaluator_classes.mdx
@@ -21,6 +21,7 @@ The base class for all evaluator classes:
 ### QuestionAnsweringEvaluator
 
 [[autodoc]] evaluate.QuestionAnsweringEvaluator
+    - compute
 
 ### TextClassificationEvaluator
 

--- a/docs/source/package_reference/evaluator_classes.mdx
+++ b/docs/source/package_reference/evaluator_classes.mdx
@@ -12,8 +12,10 @@ The base class for all evaluator classes:
 
 [[autodoc]] evaluate.Evaluator
 
-The class for text classification evaluation:
-
-[[autodoc]] evaluate.TextClassificationEvaluator
+## The task specific evaluators
 
 [[autodoc]] evaluate.ImageClassificationEvaluator
+
+[[autodoc]] evaluate.QuestionAnsweringPipeline
+
+[[autodoc]] evaluate.TextClassificationEvaluator

--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -26,7 +26,13 @@ SCRIPTS_VERSION = "main" if version.parse(__version__).is_devrelease else __vers
 
 del version
 
-from .evaluator import Evaluator, ImageClassificationEvaluator, TextClassificationEvaluator, evaluator
+from .evaluator import (
+    Evaluator,
+    ImageClassificationEvaluator,
+    QuestionAnsweringEvaluator,
+    TextClassificationEvaluator,
+    evaluator,
+)
 from .hub import push_to_hub
 from .info import ComparisonInfo, EvaluationModuleInfo, MeasurementInfo, MetricInfo
 from .inspect import inspect_evaluation_module, list_evaluation_modules

--- a/src/evaluate/evaluator/__init__.py
+++ b/src/evaluate/evaluator/__init__.py
@@ -26,6 +26,7 @@ from typing import Dict, List
 
 from .base import Evaluator
 from .image_classification import ImageClassificationEvaluator
+from .question_answering import QuestionAnsweringEvaluator
 from .text_classification import TextClassificationEvaluator
 
 
@@ -37,6 +38,10 @@ SUPPORTED_EVALUATOR_TASKS = {
     "image-classification": {
         "implementation": ImageClassificationEvaluator,
         "default_metric_name": "accuracy",
+    },
+    "question-answering": {
+        "implementation": QuestionAnsweringEvaluator,
+        "default_metric_name": "squad",
     },
 }
 
@@ -56,8 +61,9 @@ def check_task(task: str) -> Dict:
     Args:
         task (`str`):
             The task defining which evaluator will be returned. Currently accepted tasks are:
-            - `"text-classification"` (alias `"sentiment-analysis"` available)
             - `"image-classification"`
+            - `"question-answering"`
+            - `"text-classification"` (alias `"sentiment-analysis"` available)
     Returns:
         task_defaults: `dict`, contains the implementasion class of a give Evaluator and the default metric name.
     """
@@ -78,8 +84,9 @@ def evaluator(task: str = None) -> Evaluator:
     Args:
         task (`str`):
             The task defining which evaluator will be returned. Currently accepted tasks are:
-            - `"text-classification"` (alias `"sentiment-analysis"` available): will return a [`TextClassificationEvaluator`].
             - `"image-classification"`: will return a [`ImageClassificationEvaluator`].
+            - `"question-answering"`: will return a [`QuestionAnsweringEvaluator`].
+            - `"text-classification"` (alias `"sentiment-analysis"` available): will return a [`TextClassificationEvaluator`].
     Returns:
         [`Evaluator`]: An evaluator suitable for the task.
     Examples:

--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -270,7 +270,7 @@ class Evaluator(ABC):
     def compute_metric(
         self,
         metric: EvaluationModule,
-        metric_inputs,
+        metric_inputs: Dict,
         strategy: Literal["simple", "bootstrap"] = "simple",
         confidence_level: float = 0.95,
         n_resamples: int = 9999,

--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -208,8 +208,7 @@ class Evaluator(ABC):
         Args:
             model_or_pipeline (`str` or `Pipeline` or `Callable` or `PreTrainedModel` or `TFPreTrainedModel`,
             defaults to `None`):
-                If the argument in not specified, we initialize the default pipeline for the task (in this case
-                `text-classification` or its alias - `sentiment-analysis`). If the argument is of the type `str` or
+                If the argument in not specified, we initialize the default pipeline for the task. If the argument is of the type `str` or
                 is a model instance, we use it to initialize a new `Pipeline` with the given model. Otherwise we assume the
                 argument specifies a pre-initialized pipeline.
             preprocessor (`PreTrainedTokenizerBase` or `FeatureExtractionMixin`, *optional*, defaults to `None`):

--- a/src/evaluate/evaluator/image_classification.py
+++ b/src/evaluate/evaluator/image_classification.py
@@ -82,9 +82,9 @@ class ImageClassificationEvaluator(Evaluator):
         ```python
         >>> from evaluate import evaluator
         >>> from datasets import Dataset, load_dataset
-        >>> e = evaluator("image-classification")
+        >>> task_evaluator = evaluator("image-classification")
         >>> data = load_dataset("beans", split="test[:2]")
-        >>> results = e.compute(
+        >>> results = task_evaluator.compute(
         >>>     model_or_pipeline="nateraw/vit-base-beans",
         >>>     data=data,
         >>>     metric="accuracy",

--- a/src/evaluate/evaluator/image_classification.py
+++ b/src/evaluate/evaluator/image_classification.py
@@ -88,8 +88,6 @@ class ImageClassificationEvaluator(Evaluator):
         >>>     model_or_pipeline="nateraw/vit-base-beans",
         >>>     data=data,
         >>>     metric="accuracy",
-        >>>     input_column="image",
-        >>>     label_column="labels",
         >>>     label_mapping={'angular_leaf_spot': 0, 'bean_rust': 1, 'healthy': 2},
         >>>     strategy="bootstrap",
         >>>     n_resamples=10,

--- a/src/evaluate/evaluator/image_classification.py
+++ b/src/evaluate/evaluator/image_classification.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The HuggingFace Datasets Authors and the TensorFlow Datasets Authors.
+# Copyright 2022 The HuggingFace Evaluate Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ class ImageClassificationEvaluator(Evaluator):
         >>> from evaluate import evaluator
         >>> from datasets import Dataset, load_dataset
         >>> e = evaluator("image-classification")
-        >>> data =  Dataset.from_dict(load_dataset("beans")["test"][:2])
+        >>> data = load_dataset("beans", split="test[:2]")
         >>> results = e.compute(
         >>>     model_or_pipeline="nateraw/vit-base-beans",
         >>>     data=data,

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -85,7 +85,7 @@ class QuestionAnsweringEvaluator(Evaluator):
         In this case, the answer text list should be `[]`.
         """
         original_num_rows = data.num_rows
-        nonempty_num_rows = data.filter(lambda x : len(x[label_column]["text"]) > 0).num_rows
+        nonempty_num_rows = data.filter(lambda x: len(x[label_column]["text"]) > 0).num_rows
         if original_num_rows > nonempty_num_rows:
             return True
         else:
@@ -188,7 +188,7 @@ class QuestionAnsweringEvaluator(Evaluator):
         for i in range(len(_predictions)):
             pred = {"prediction_text": _predictions[i]["answer"], "id": data[i][id_column]}
             if squad_v2_schema:
-                pred["no_answer_probability"] = 0.
+                pred["no_answer_probability"] = 0.0
             predictions.append(pred)
 
         references = [{"id": element[id_column], "answers": element[label_column]} for element in data]

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -80,6 +80,7 @@ class QuestionAnsweringEvaluator(Evaluator):
         return data
 
     def is_squad_v2_schema(self, data: Dataset, label_column: str = "answers"):
+        print(data)
         """
         Check if the provided dataset follows the squad v2 data schema, namely possible samples where the answer is not in the context.
         In this case, the answer text list should be `[]`.

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -153,6 +153,7 @@ class QuestionAnsweringEvaluator(Evaluator):
             A `Dict`. The keys represent metric keys calculated for the `metric` spefied in function arguments. For the
             `"simple"` strategy, the value is the metric score. For the `"bootstrap"` strategy, the value is a `Dict`
             containing the score, the confidence interval and the standard error calculated for each metric key.
+
         Examples:
         ```python
         >>> from evaluate import evaluator
@@ -160,17 +161,33 @@ class QuestionAnsweringEvaluator(Evaluator):
         >>> e = evaluator("question-answering")
         >>> data = load_dataset("squad", split="validation[:2]")
         >>> results = e.compute(
-        >>>     model_or_pipeline="mrm8488/bert-tiny-finetuned-squadv2",
+        >>>     model_or_pipeline="sshleifer/tiny-distilbert-base-cased-distilled-squad",
         >>>     data=data,
         >>>     metric="squad",
-        >>>     question_column="question",
-        >>>     context_column="context",
-        >>>     label_column="answers",
-        >>>     strategy="bootstrap",
-        >>>     n_resamples=10,
-        >>>     random_state=0
         >>> )
-        ```"""
+        ```
+
+        <Tip>
+
+        Datasets where the answer may be missing in the context are supported, for example SQuAD v2 dataset. If using transformers pipeline,
+        make sure to pass `handle_impossible_answer=True` as an argument to the pipeline.
+
+        </Tip>
+
+        ```python
+        >>> from evaluate import evaluator
+        >>> from datasets import Dataset, load_dataset
+        >>> from transformers import pipeline
+        >>> e = evaluator("question-answering")
+        >>> data = load_dataset("squad_v2", split="validation[:2]")
+        >>> pipe = pipeline(task="question-answering", model="sshleifer/mrm8488/bert-tiny-finetuned-squadv2", handle_impossible_answer=True)
+        >>> results = e.compute(
+        >>>     model_or_pipeline=pipe,
+        >>>     data=data,
+        >>>     metric="squad_v2",
+        >>> )
+        ```
+        """
         data = self.prepare_data(
             data=data,
             question_column=question_column,

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -196,14 +196,14 @@ class QuestionAnsweringEvaluator(Evaluator):
         >>> from evaluate import evaluator
         >>> from datasets import Dataset, load_dataset
         >>> from transformers import pipeline
-        >>> e = evaluator("question-answering")
+        >>> task_evaluator = evaluator("question-answering")
         >>> data = load_dataset("squad_v2", split="validation[:2]")
         >>> pipe = pipeline(
         >>>     task="question-answering",
         >>>     model="sshleifer/mrm8488/bert-tiny-finetuned-squadv2",
         >>>     handle_impossible_answer=True
         >>> )
-        >>> results = e.compute(
+        >>> results = task_evaluator.compute(
         >>>     model_or_pipeline=pipe,
         >>>     data=data,
         >>>     metric="squad_v2",

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -80,13 +80,14 @@ class QuestionAnsweringEvaluator(Evaluator):
         return data
 
     def is_squad_v2_schema(self, data: Dataset, label_column: str = "answers"):
-        print(data)
         """
         Check if the provided dataset follows the squad v2 data schema, namely possible samples where the answer is not in the context.
         In this case, the answer text list should be `[]`.
         """
         original_num_rows = data.num_rows
-        nonempty_num_rows = data.filter(lambda x: len(x[label_column]["text"]) > 0).num_rows
+        nonempty_num_rows = data.filter(
+            lambda x: len(x[label_column]["text"]) > 0, load_from_cache_file=False
+        ).num_rows
         if original_num_rows > nonempty_num_rows:
             return True
         else:

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The HuggingFace Datasets Authors and the TensorFlow Datasets Authors.
+# Copyright 2022 The HuggingFace Evaluate Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -144,14 +144,14 @@ class QuestionAnsweringEvaluator(Evaluator):
         >>> from evaluate import evaluator
         >>> from datasets import Dataset, load_dataset
         >>> e = evaluator("question-answering")
-        >>> data =  Dataset.from_dict(load_dataset("squad")["validation"][:2])
+        >>> data = load_dataset("squad", split="validation[:2]")
         >>> results = e.compute(
         >>>     model_or_pipeline="mrm8488/bert-tiny-finetuned-squadv2",
         >>>     data=data,
         >>>     metric="squad",
         >>>     question_column="question",
         >>>     context_column="context",
-        >>>     label_column="questions",
+        >>>     label_column="answers",
         >>>     strategy="bootstrap",
         >>>     n_resamples=10,
         >>>     random_state=0

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numbers import Number
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 # Lint as: python3
-from datasets import Dataset
+from datasets import Dataset, load_dataset
 
 
 try:

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -108,7 +108,7 @@ class QuestionAnsweringEvaluator(Evaluator):
         for i in range(len(predictions)):
             pred = {"prediction_text": predictions[i]["answer"], "id": ids[i]}
             if squad_v2_schema:
-                pred["no_answer_probability"] = 0.0
+                pred["no_answer_probability"] = predictions[i]["score"]
             result.append(pred)
         return {"predictions": result}
 

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -145,7 +145,7 @@ class QuestionAnsweringEvaluator(Evaluator):
         >>> from evaluate import evaluator
         >>> from datasets import Dataset, load_dataset
         >>> e = evaluator("question-answering")
-        >>> data =  Dataset.from_dict(load_dataset("imdb")["test"][:2])
+        >>> data =  Dataset.from_dict(load_dataset("squad")["validation"][:2])
         >>> results = e.compute(
         >>>     model_or_pipeline="mrm8488/bert-tiny-finetuned-squadv2",
         >>>     data=data,

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -37,10 +37,15 @@ logger = get_logger(__name__)
 
 class QuestionAnsweringEvaluator(Evaluator):
     """
-    Question answering evaluator.
+    Question answering evaluator. This evaluator handles
+    [**extractive** question answering](https://huggingface.co/docs/transformers/task_summary#extractive-question-answering),
+    where the answer to the question is extracted from a context.
+
     This question answering evaluator can currently be loaded from [`evaluator`] using the default task name
     `question-answering`.
-    Methods in this class assume a data format compatible with the [`QuestionAnsweringPipeline`].
+
+    Methods in this class assume a data format compatible with the
+    [`QuestionAnsweringPipeline`](https://huggingface.co/docs/transformers/en/main_classes/pipelines#transformers.QuestionAnsweringPipeline).
     """
 
     def __init__(self, task="question-answering", default_metric_name=None):
@@ -169,9 +174,9 @@ class QuestionAnsweringEvaluator(Evaluator):
 
         <Tip>
 
-        Datasets where the answer may be missing in the context are supported, for example SQuAD v2 dataset. If using transformers pipeline,
-        make sure to pass `handle_impossible_answer=True` as an argument to the pipeline.
-
+        Datasets where the answer may be missing in the context are supported, for example SQuAD v2 dataset. If using transformers pipeline
+        with models trained on this type of data, make sure to pass `handle_impossible_answer=True` as an argument to the pipeline.
+        
         </Tip>
 
         ```python
@@ -180,7 +185,11 @@ class QuestionAnsweringEvaluator(Evaluator):
         >>> from transformers import pipeline
         >>> e = evaluator("question-answering")
         >>> data = load_dataset("squad_v2", split="validation[:2]")
-        >>> pipe = pipeline(task="question-answering", model="sshleifer/mrm8488/bert-tiny-finetuned-squadv2", handle_impossible_answer=True)
+        >>> pipe = pipeline(
+        >>>     task="question-answering",
+        >>>     model="sshleifer/mrm8488/bert-tiny-finetuned-squadv2",
+        >>>     handle_impossible_answer=True
+        >>> )
         >>> results = e.compute(
         >>>     model_or_pipeline=pipe,
         >>>     data=data,

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -222,6 +222,10 @@ class QuestionAnsweringEvaluator(Evaluator):
 
         squad_v2_schema = self.is_squad_v2_schema(data=data, label_column=label_column)
 
+        pipe = self.prepare_pipeline(model_or_pipeline=model_or_pipeline, tokenizer=tokenizer)
+
+        metric = self.prepare_metric(metric)
+
         if squad_v2_schema and metric.name == "squad":
             logger.warn(
                 "The dataset has SQuAD v2 format but you are using the SQuAD metric. Consider passing the 'squad_v2' metric."
@@ -230,10 +234,6 @@ class QuestionAnsweringEvaluator(Evaluator):
             logger.warn(
                 "The dataset has SQuAD v1 format but you are using the SQuAD v2 metric. Consider passing the 'squad' metric."
             )
-
-        pipe = self.prepare_pipeline(model_or_pipeline=model_or_pipeline, tokenizer=tokenizer)
-
-        metric = self.prepare_metric(metric)
 
         predictions = self.call_pipeline(pipe, **pipe_inputs)
         predictions = self.predictions_processor(predictions, squad_v2_schema=squad_v2_schema, ids=data[id_column])

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -133,7 +133,7 @@ class QuestionAnsweringEvaluator(Evaluator):
             id_column (`str`, defaults to `"id"`):
                 the name of the column cointaing the identification field of the question and answer pair in the
                 dataset specified by `data`.
-            label_column (`str`, defaults to `"label"`):
+            label_column (`str`, defaults to `"answers"`):
                 the name of the column containing the answers in the dataset specified by `data`.
         Return:
             A `Dict`. The keys represent metric keys calculated for the `metric` spefied in function arguments. For the

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -1,0 +1,192 @@
+# Copyright 2022 The HuggingFace Datasets Authors and the TensorFlow Datasets Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from numbers import Number
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+# Lint as: python3
+from datasets import Dataset
+
+
+try:
+    from transformers import Pipeline, PreTrainedModel, PreTrainedTokenizer, TFPreTrainedModel
+
+    TRANSFORMERS_AVAILABLE = True
+except ImportError:
+    TRANSFORMERS_AVAILABLE = False
+
+from typing_extensions import Literal
+
+from ..module import EvaluationModule
+from ..utils.logging import get_logger
+from .base import Evaluator
+
+
+logger = get_logger(__name__)
+
+
+class QuestionAnsweringEvaluator(Evaluator):
+    """
+    Question answering evaluator.
+    This question answering evaluator can currently be loaded from [`evaluator`] using the default task name
+    `question-answering`.
+    Methods in this class assume a data format compatible with the [`QuestionAnsweringPipeline`].
+    """
+
+    def __init__(self, task="question-answering", default_metric_name=None):
+        super().__init__(task, default_metric_name=default_metric_name)
+
+    def prepare_data(
+        self,
+        data: Union[str, Dataset],
+        question_column: str,
+        context_column: str,
+        id_column: str,
+        label_column: str,
+    ):
+        """Prepare data."""
+        if data is None:
+            raise ValueError(
+                "Please specify a valid `data` object - either a `str` with a name or a `Dataset` object."
+            )
+        data = load_dataset(data) if isinstance(data, str) else data
+        if question_column not in data.column_names:
+            raise ValueError(
+                f"Invalid `question_column` {question_column} specified. The dataset contains the following columns: {data.column_names}."
+            )
+        if context_column not in data.column_names:
+            raise ValueError(
+                f"Invalid `context_column` {context_column} specified. The dataset contains the following columns: {data.column_names}."
+            )
+        if id_column not in data.column_names:
+            raise ValueError(
+                f"Invalid `id_column` {id_column} specified. The dataset contains the following columns: {data.column_names}."
+            )
+        if label_column not in data.column_names:
+            raise ValueError(
+                f"Invalid `label_column` {label_column} specified. The dataset contains the following columns: {data.column_names}."
+            )
+
+        return data
+
+    def compute(
+        self,
+        model_or_pipeline: Union[str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"] = None,
+        data: Union[str, Dataset] = None,
+        metric: Union[str, EvaluationModule] = None,
+        tokenizer: Optional[Union[str, "PreTrainedTokenizer"]] = None,
+        strategy: Literal["simple", "bootstrap"] = "simple",
+        confidence_level: float = 0.95,
+        n_resamples: int = 9999,
+        random_state: Optional[int] = None,
+        question_column: str = "question",
+        context_column: str = "context",
+        id_column: str = "id",
+        label_column: str = "answers",
+    ) -> Tuple[Dict[str, float], Any]:
+        """
+        Compute the metric for a given pipeline and dataset combination.
+        Args:
+            model_or_pipeline (`str` or `Pipeline` or `Callable` or `PreTrainedModel` or `TFPreTrainedModel`,
+            defaults to `None`):
+                If the argument in not specified, we initialize the default pipeline for the task (in this case
+                `question-answering`). If the argument is of the type `str` or
+                is a model instance, we use it to initialize a new `Pipeline` with the given model. Otherwise we assume the
+                argument specifies a pre-initialized pipeline.
+            data (`str` or `Dataset`, defaults to `None):
+                Specifies the dataset we will run evaluation on. If it is of type `str`, we treat it as the dataset
+                name, and load it. Otherwise we assume it represents a pre-loaded dataset.
+            metric (`str` or `EvaluationModule`, defaults to `None`):"
+                Specifies the metric we use in evaluator. If it is of type `str`, we treat it as the metric name, and
+                load it. Otherwise we assume it represents a pre-loaded metric.
+            tokenizer: (`str` or `PreTrainedTokenizer`, *optional*, defaults to `None`):
+                Argument can be used to overwrite a default tokenizer if `model_or_pipeline` represents a model for
+                which we build a pipeline. If `model_or_pipeline` is `None` or a pre-initialized pipeline, we ignore
+                this argument.
+            strategy: (`Literal["simple", "bootstrap"]`, defaults to "simple"):
+                specifies the evaluation strategy. Possible values are:
+                - `"simple"` - we evaluate the metric and return the scores.
+                - `"bootstrap"` - on top of computing the metric scores, we calculate the confidence interval for each
+                of the returned metric keys, using `scipy`'s `bootstrap` method
+                https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.html.
+            confidence_level (`float`, defaults to `0.95`):
+                The `confidence_level` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
+            n_resamples (`int`, defaults to `9999`):
+                The `n_resamples` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
+            random_state (`int`, *optional*, defaults to `None`):
+                The `random_state` value passed to `bootstrap` if `"bootstrap"` strategy is chosen. Useful for
+                debugging.
+            question_column (`str`, defaults to `"question"`):
+                the name of the column containing the question in the dataset specified by `data`.
+            context_column (`str`, defaults to `"context"`):
+                the name of the column containing the context in the dataset specified by `data`.
+            id_column (`str`, defaults to `"id"`):
+                the name of the column cointaing the identification field of the question and answer pair in the
+                dataset specified by `data`.
+            label_column (`str`, defaults to `"label"`):
+                the name of the column containing the answers in the dataset specified by `data`.
+        Return:
+            A `Dict`. The keys represent metric keys calculated for the `metric` spefied in function arguments. For the
+            `"simple"` strategy, the value is the metric score. For the `"bootstrap"` strategy, the value is a `Dict`
+            containing the score, the confidence interval and the standard error calculated for each metric key.
+        Examples:
+        ```python
+        >>> from evaluate import evaluator
+        >>> from datasets import Dataset, load_dataset
+        >>> e = evaluator("question-answering")
+        >>> data =  Dataset.from_dict(load_dataset("imdb")["test"][:2])
+        >>> results = e.compute(
+        >>>     model_or_pipeline="mrm8488/bert-tiny-finetuned-squadv2",
+        >>>     data=data,
+        >>>     metric="squad",
+        >>>     question_column="question",
+        >>>     context_column="context",
+        >>>     label_column="questions",
+        >>>     strategy="bootstrap",
+        >>>     n_resamples=10,
+        >>>     random_state=0
+        >>> )
+        ```"""
+        data = self.prepare_data(
+            data=data,
+            question_column=question_column,
+            context_column=context_column,
+            id_column=id_column,
+            label_column=label_column,
+        )
+
+        pipe = self.prepare_pipeline(model_or_pipeline=model_or_pipeline, preprocessor=tokenizer)
+
+        metric = self.prepare_metric(metric)
+
+        # Compute predictions
+        predictions = pipe(question=data[question_column], context=data[context_column], padding="max_length")
+        predictions = [
+            {"prediction_text": predictions[i]["answer"], "id": data[i][id_column]} for i in range(len(predictions))
+        ]
+
+        references = [{"id": element[id_column], "answers": element[label_column]} for element in data]
+
+        # Compute metrics from references and predictions
+        result = self.core_compute(
+            references=references,
+            predictions=predictions,
+            metric=metric,
+            strategy=strategy,
+            confidence_level=confidence_level,
+            n_resamples=n_resamples,
+            random_state=random_state,
+        )
+
+        return result

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -222,6 +222,15 @@ class QuestionAnsweringEvaluator(Evaluator):
 
         squad_v2_schema = self.is_squad_v2_schema(data=data, label_column=label_column)
 
+        if squad_v2_schema and metric.name == "squad":
+            logger.warn(
+                "The dataset has SQuAD v2 format but you are using the SQuAD metric. Consider passing the 'squad_v2' metric."
+            )
+        if not squad_v2_schema and metric.name == "squad_v2":
+            logger.warn(
+                "The dataset has SQuAD v1 format but you are using the SQuAD v2 metric. Consider passing the 'squad' metric."
+            )
+
         pipe = self.prepare_pipeline(model_or_pipeline=model_or_pipeline, tokenizer=tokenizer)
 
         metric = self.prepare_metric(metric)

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -141,11 +141,11 @@ class QuestionAnsweringEvaluator(Evaluator):
             metric (`str` or `EvaluationModule`, defaults to `None`):
                 Specifies the metric we use in evaluator. If it is of type `str`, we treat it as the metric name, and
                 load it. Otherwise we assume it represents a pre-loaded metric.
-            tokenizer: (`str` or `PreTrainedTokenizer`, *optional*, defaults to `None`):
+            tokenizer (`str` or `PreTrainedTokenizer`, *optional*, defaults to `None`):
                 Argument can be used to overwrite a default tokenizer if `model_or_pipeline` represents a model for
                 which we build a pipeline. If `model_or_pipeline` is `None` or a pre-initialized pipeline, we ignore
                 this argument.
-            strategy: (`Literal["simple", "bootstrap"]`, defaults to "simple"):
+            strategy (`Literal["simple", "bootstrap"]`, defaults to "simple"):
                 specifies the evaluation strategy. Possible values are:
                 - `"simple"` - we evaluate the metric and return the scores.
                 - `"bootstrap"` - on top of computing the metric scores, we calculate the confidence interval for each
@@ -175,7 +175,7 @@ class QuestionAnsweringEvaluator(Evaluator):
         Examples:
         ```python
         >>> from evaluate import evaluator
-        >>> from datasets import Dataset, load_dataset
+        >>> from datasets import load_dataset
         >>> e = evaluator("question-answering")
         >>> data = load_dataset("squad", split="validation[:2]")
         >>> results = e.compute(
@@ -194,7 +194,7 @@ class QuestionAnsweringEvaluator(Evaluator):
 
         ```python
         >>> from evaluate import evaluator
-        >>> from datasets import Dataset, load_dataset
+        >>> from datasets import load_dataset
         >>> from transformers import pipeline
         >>> task_evaluator = evaluator("question-answering")
         >>> data = load_dataset("squad_v2", split="validation[:2]")

--- a/src/evaluate/evaluator/text_classification.py
+++ b/src/evaluate/evaluator/text_classification.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The HuggingFace Datasets Authors and the TensorFlow Datasets Authors.
+# Copyright 2022 The HuggingFace Evaluate Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ class TextClassificationEvaluator(Evaluator):
         >>> from evaluate import evaluator
         >>> from datasets import Dataset, load_dataset
         >>> e = evaluator("text-classification")
-        >>> data =  Dataset.from_dict(load_dataset("imdb")["test"][:2])
+        >>> data = load_dataset("imdb", split="test[:2]")
         >>> results = e.compute(
         >>>     model_or_pipeline="huggingface/prunebert-base-uncased-6-finepruned-w-distil-mnli",
         >>>     data=data,

--- a/src/evaluate/evaluator/text_classification.py
+++ b/src/evaluate/evaluator/text_classification.py
@@ -92,8 +92,6 @@ class TextClassificationEvaluator(Evaluator):
         >>>     model_or_pipeline="huggingface/prunebert-base-uncased-6-finepruned-w-distil-mnli",
         >>>     data=data,
         >>>     metric="accuracy",
-        >>>     input_column="text",
-        >>>     label_column="label",
         >>>     label_mapping={"LABEL_0": 0.0, "LABEL_1": 1.0},
         >>>     strategy="bootstrap",
         >>>     n_resamples=10,

--- a/src/evaluate/evaluator/text_classification.py
+++ b/src/evaluate/evaluator/text_classification.py
@@ -86,9 +86,9 @@ class TextClassificationEvaluator(Evaluator):
         ```python
         >>> from evaluate import evaluator
         >>> from datasets import Dataset, load_dataset
-        >>> e = evaluator("text-classification")
+        >>> task_evaluator = evaluator("text-classification")
         >>> data = load_dataset("imdb", split="test[:2]")
-        >>> results = e.compute(
+        >>> results = task_evaluator.compute(
         >>>     model_or_pipeline="huggingface/prunebert-base-uncased-6-finepruned-w-distil-mnli",
         >>>     data=data,
         >>>     metric="accuracy",

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -22,11 +22,18 @@ from transformers import (
     AutoConfig,
     AutoFeatureExtractor,
     AutoModelForImageClassification,
+    AutoModelForQuestionAnswering,
     AutoModelForSequenceClassification,
     AutoTokenizer,
 )
 
-from evaluate import ImageClassificationEvaluator, TextClassificationEvaluator, evaluator, load
+from evaluate import (
+    ImageClassificationEvaluator,
+    QuestionAnsweringEvaluator,
+    TextClassificationEvaluator,
+    evaluator,
+    load,
+)
 
 
 class DummyTextClassificationPipeline:
@@ -43,6 +50,14 @@ class DummyImageClassificationPipeline:
 
     def __call__(self, images, **kwargs):
         return [[{"score": 0.9, "label": "yurt"}, {"score": 0.1, "label": "umbrella"}] for i, _ in enumerate(images)]
+
+
+class DummyQuestionAnsweringPipeline:
+    def __init__(self):
+        self.task = "question-answering"
+
+    def __call__(self, question, context, **kwargs):
+        return [{"score": 0.95, "start": 31, "end": 39, "answer": "Felix"} for _ in question]
 
 
 class TestEvaluator(TestCase):
@@ -253,3 +268,76 @@ class TestImageClassificationEvaluator(TestCase):
             label_mapping=self.label_mapping,
         )
         self.assertEqual(scores, {"accuracy": 0})
+
+
+class TestQuestionAnsweringEvaluator(TestCase):
+    def setUp(self):
+        self.data = Dataset.from_dict(
+            {
+                "id": ["56be4db0acb8001400a502ec", "56be4db0acb8001400a502ed"],
+                "context": ["My name is Felix and I love cookies!", "Misa name is Felix and misa love cookies!"],
+                "answers": [{"text": ["Felix"], "answer_start": [11]}, {"text": ["Felix"], "answer_start": [13]}],
+                "question": ["What is my name?", "What is my name?"],
+            }
+        )
+
+        self.default_model = "mrm8488/bert-tiny-finetuned-squadv2"
+        self.pipe = DummyQuestionAnsweringPipeline()
+        self.evaluator = evaluator("question-answering")
+
+    def test_pipe_init(self):
+        scores = self.evaluator.compute(
+            model_or_pipeline=self.pipe,
+            data=self.data,
+        )
+        self.assertDictEqual(scores, {"exact_match": 100.0, "f1": 100.0})
+
+    def test_model_init(self):
+        scores = self.evaluator.compute(
+            model_or_pipeline=self.default_model,
+            data=self.data,
+            metric="squad",
+        )
+        self.assertDictEqual(scores, {"exact_match": 0, "f1": 100 / 3})
+        model = AutoModelForQuestionAnswering.from_pretrained(self.default_model)
+        tokenizer = AutoTokenizer.from_pretrained(self.default_model)
+        scores = self.evaluator.compute(
+            model_or_pipeline=model,
+            data=self.data,
+            metric="squad",
+            tokenizer=tokenizer,
+        )
+        self.assertDictEqual(scores, {"exact_match": 0, "f1": 100 / 3})
+
+    def test_class_init(self):
+        evaluator = QuestionAnsweringEvaluator()
+        self.assertEqual(evaluator.task, "question-answering")
+        self.assertIsNone(evaluator.default_metric_name)
+
+        scores = evaluator.compute(
+            model_or_pipeline=self.pipe,
+            data=self.data,
+            metric="squad",
+        )
+        self.assertDictEqual(scores, {"exact_match": 100.0, "f1": 100.0})
+
+    def test_default_pipe_init(self):
+        scores = self.evaluator.compute(
+            data=self.data,
+        )
+        self.assertDictEqual(scores, {"exact_match": 100.0, "f1": 100.0})
+
+    def test_overwrite_default_metric(self):
+        squad = load("squad")
+        scores = self.evaluator.compute(
+            model_or_pipeline=self.pipe,
+            data=self.data,
+            metric=squad,
+        )
+        self.assertDictEqual(scores, {"exact_match": 100.0, "f1": 100.0})
+        scores = self.evaluator.compute(
+            model_or_pipeline=self.pipe,
+            data=self.data,
+            metric="squad",
+        )
+        self.assertDictEqual(scores, {"exact_match": 100.0, "f1": 100.0})

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -63,7 +63,7 @@ class DummyQuestionAnsweringPipeline:
                 {"score": 0.95, "start": 31, "end": 39, "answer": "Felix"}
                 if i % 2 == 0
                 else {"score": 0.95, "start": 0, "end": 0, "answer": ""}
-                for i in len(question)
+                for i in range(len(question))
             ]
         else:
             return [{"score": 0.95, "start": 31, "end": 39, "answer": "Felix"} for _ in question]
@@ -304,27 +304,19 @@ class TestQuestionAnsweringEvaluator(TestCase):
         self.evaluator = evaluator("question-answering")
 
     def test_pipe_init(self):
+        # squad_v1-like dataset
         scores = self.evaluator.compute(
             model_or_pipeline=self.pipe,
             data=self.data,
         )
         self.assertDictEqual(scores, {"exact_match": 100.0, "f1": 100.0})
 
-        scores = self.evaluator.compute(model_or_pipeline=self.pipe_v2, data=self.data_v2, metric="squad_v2")
-        self.assertDictEqual(scores, {"exact_match": 100.0, "f1": 100.0})
-
     def test_model_init(self):
+        # squad_v1-like dataset
         scores = self.evaluator.compute(
             model_or_pipeline=self.default_model,
             data=self.data,
             metric="squad",
-        )
-        self.assertDictEqual(scores, {"exact_match": 0, "f1": 100 / 3})
-
-        scores = self.evaluator.compute(
-            model_or_pipeline=self.default_model,
-            data=self.data_v2,
-            metric="squad_v2",
         )
         self.assertDictEqual(scores, {"exact_match": 0, "f1": 100 / 3})
 
@@ -334,14 +326,6 @@ class TestQuestionAnsweringEvaluator(TestCase):
             model_or_pipeline=model,
             data=self.data,
             metric="squad",
-            tokenizer=tokenizer,
-        )
-        self.assertDictEqual(scores, {"exact_match": 0, "f1": 100 / 3})
-
-        scores = self.evaluator.compute(
-            model_or_pipeline=model,
-            data=self.data_v2,
-            metric="squad_v2",
             tokenizer=tokenizer,
         )
         self.assertDictEqual(scores, {"exact_match": 0, "f1": 100 / 3})
@@ -369,7 +353,9 @@ class TestQuestionAnsweringEvaluator(TestCase):
             data=self.data_v2,
             metric="squad_v2",
         )
-        self.assertDictEqual(scores, {"exact_match": 100.0, "f1": 100.0})
+        self.assertDictEqual(
+            {key: scores[key] for key in ["HasAns_f1", "NoAns_f1"]}, {"HasAns_f1": 100.0, "NoAns_f1": 100.0}
+        )
 
     def test_default_pipe_init(self):
         # squad_v1-like dataset
@@ -381,8 +367,11 @@ class TestQuestionAnsweringEvaluator(TestCase):
         # squad_v2-like dataset
         scores = self.evaluator.compute(
             data=self.data_v2,
+            metric="squad_v2",
         )
-        self.assertDictEqual(scores, {"exact_match": 100.0, "f1": 100.0})
+        self.assertDictEqual(
+            {key: scores[key] for key in ["HasAns_f1", "NoAns_f1"]}, {"HasAns_f1": 100.0, "NoAns_f1": 0.0}
+        )
 
     def test_overwrite_default_metric(self):
         # squad_v1-like dataset
@@ -398,21 +387,5 @@ class TestQuestionAnsweringEvaluator(TestCase):
             model_or_pipeline=self.pipe,
             data=self.data,
             metric="squad",
-        )
-        self.assertDictEqual(scores, {"exact_match": 100.0, "f1": 100.0})
-
-        # squad_v2-like dataset
-        squad = load("squad_v2")
-        scores = self.evaluator.compute(
-            model_or_pipeline=self.pipe_v2,
-            data=self.data_v2,
-            metric=squad,
-        )
-        self.assertDictEqual(scores, {"exact_match": 100.0, "f1": 100.0})
-
-        scores = self.evaluator.compute(
-            model_or_pipeline=self.pipe_v2,
-            data=self.data_v2,
-            metric="squad_v2",
         )
         self.assertDictEqual(scores, {"exact_match": 100.0, "f1": 100.0})

--- a/tests/test_trainer_evaluator_parity.py
+++ b/tests/test_trainer_evaluator_parity.py
@@ -9,16 +9,7 @@ import numpy as np
 import torch
 import transformers
 from datasets import load_dataset
-from transformers import (
-    AutoFeatureExtractor,
-    AutoModelForImageClassification,
-    AutoModelForQuestionAnswering,
-    AutoModelForSequenceClassification,
-    AutoTokenizer,
-    Trainer,
-    TrainingArguments,
-    pipeline,
-)
+from transformers import AutoFeatureExtractor, AutoModelForImageClassification, Trainer, TrainingArguments, pipeline
 
 from evaluate import evaluator, load
 
@@ -68,9 +59,7 @@ class TestEvaluatorTrainerParity(unittest.TestCase):
 
         eval_dataset = load_dataset("glue", "sst2", split="validation[:80]")
 
-        model = AutoModelForSequenceClassification.from_pretrained(model_name)
-        tokenizer = AutoTokenizer.from_pretrained(model_name)
-        pipe = pipeline(task="text-classification", model=model, tokenizer=tokenizer)
+        pipe = pipeline(task="text-classification", model=model_name, tokenizer=model_name)
 
         e = evaluator(task="text-classification")
         evaluator_results = e.compute(
@@ -128,7 +117,7 @@ class TestEvaluatorTrainerParity(unittest.TestCase):
         ) as f:
             transformers_results = json.load(f)
 
-        pipe = pipeline(task="image-classification", model=model, feature_extractor=feature_extractor)
+        pipe = pipeline(task="image-classification", model=model_name, feature_extractor=model_name)
 
         e = evaluator(task="image-classification")
         evaluator_results = e.compute(
@@ -171,9 +160,7 @@ class TestEvaluatorTrainerParity(unittest.TestCase):
 
         eval_dataset = load_dataset("squad", split="validation[:100]")
 
-        model = AutoModelForQuestionAnswering.from_pretrained(model_name)
-        tokenizer = AutoTokenizer.from_pretrained(model_name)
-        pipe = pipeline(task="question-answering", model=model, tokenizer=tokenizer, max_answer_len=30)
+        pipe = pipeline(task="question-answering", model=model_name, tokenizer=model_name, max_answer_len=30)
 
         e = evaluator(task="question-answering")
         evaluator_results = e.compute(

--- a/tests/test_trainer_evaluator_parity.py
+++ b/tests/test_trainer_evaluator_parity.py
@@ -161,7 +161,9 @@ class TestEvaluatorTrainerParity(unittest.TestCase):
 
         eval_dataset = load_dataset("squad", split="validation[:100]")
 
-        pipe = pipeline(task="question-answering", model=model_name, tokenizer=model_name, max_answer_len=30)
+        pipe = pipeline(
+            task="question-answering", model=model_name, tokenizer=model_name, max_answer_len=30, padding="max_length"
+        )
 
         e = evaluator(task="question-answering")
         evaluator_results = e.compute(
@@ -211,5 +213,6 @@ class TestEvaluatorTrainerParity(unittest.TestCase):
             strategy="simple",
         )
 
+        self.assertEqual(transformers_results["eval_f1"], evaluator_results["f1"])
         self.assertEqual(transformers_results["eval_HasAns_f1"], evaluator_results["HasAns_f1"])
         self.assertEqual(transformers_results["eval_NoAns_f1"], evaluator_results["NoAns_f1"])

--- a/tests/test_trainer_evaluator_parity.py
+++ b/tests/test_trainer_evaluator_parity.py
@@ -173,7 +173,7 @@ class TestEvaluatorTrainerParity(unittest.TestCase):
 
         model = AutoModelForQuestionAnswering.from_pretrained(model_name)
         tokenizer = AutoTokenizer.from_pretrained(model_name)
-        pipe = pipeline(task="question-answering", model=model, tokenizer=tokenizer)
+        pipe = pipeline(task="question-answering", model=model, tokenizer=tokenizer, max_answer_len=30)
 
         e = evaluator(task="question-answering")
         evaluator_results = e.compute(
@@ -183,4 +183,5 @@ class TestEvaluatorTrainerParity(unittest.TestCase):
             strategy="simple",
         )
 
-        self.assertEqual(transformers_results["eval_f1"], evaluator_results["eval_f1"])
+        self.assertEqual(transformers_results["eval_f1"], evaluator_results["f1"])
+        self.assertEqual(transformers_results["eval_exact_match"], evaluator_results["exact_match"])


### PR DESCRIPTION
This PR adds a subclass for `Evaluator` to handle question-answering. I kept `label_column` for the answers, but I wonder if we should not rename it everywhere `reference_column` in all evaluators, not sure.