### PR TITLE
add keras callback

### DIFF
--- a/src/evaluate/keras.py
+++ b/src/evaluate/keras.py
@@ -1,0 +1,52 @@
+import os
+
+import tensorflow as tf
+import tensorflow.keras as keras
+
+
+class KerasCallback(keras.callbacks.Callback):
+    def __init__(
+        self,
+        model,
+        model_inputs,
+        metric,
+        metric_inputs,
+        model_output_name="predictions",
+        predictions_processor=None,
+        log_dir=None,
+    ):
+        self.model = model
+        self.model_inputs = model_inputs
+        self.model_output_name = model_output_name
+        self.predictions_processor = predictions_processor
+        self.metric = metric
+        self.metric_inputs = metric_inputs
+        self.epoch = 0
+        self.predictions_processor = predictions_processor
+
+        if log_dir is not None:
+            self.summary_writer = tf.summary.create_file_writer(os.path.join(log_dir, model.name))
+        else:
+            self.summary_writer = None
+
+    def on_epoch_end(self, batch, logs=dict()):
+        self.epoch += 1
+        predictions = self.model.predict(self.model_inputs)
+        if self.predictions_processor is not None:
+            predictions = self.predictions_processor(predictions)
+        self.metric_inputs.update({self.model_output_name: predictions})
+
+        result = self.metric.compute(**self.metric_inputs)
+        logs.update(result)
+        if self.summary_writer is not None:
+            self._write_metric(result)
+
+    def _write_metric(self, result):
+        with self.summary_writer.as_default():
+            for name, value in result.items():
+                tf.summary.scalar(
+                    name,
+                    value,
+                    step=self.epoch,
+                )
+            self.summary_writer.flush()


### PR DESCRIPTION
This PR adds a `KerasCallback` class which lets a user wrap an evaluation in a `keras` compatible wrapper. Following the discussions in https://github.com/huggingface/evaluate/issues/10#issuecomment-1116365811.


```py
import evaluate

recall = evaluate.load("recall")

transform = lambda x: np.argmax(x, axis-1) # labels are 1-hot encoded but recall needs integer representation

recall_callback = evaluate.KerasCallback(
    model, # model object
    x_test, # model input
    recall, # metric object
    {"references": transform(y_test), "average":"micro"}, # metric input
    predictions_processor=transform # transform between model ouput/metric inputs
    ) 

model.compile(loss="categorical_crossentropy", optimizer="adam", metrics=["accuracy"])

hist = model.fit(
    x_train,
    y_train,
    batch_size=batch_size,
    epochs=epochs,
    validation_split=0.1,
    callbacks=[recall_callback],
)
```

If there are multiple metrics we can either create several callbacks or combine them all with `combine` into a single metric. There are still a few namings/rough edges to iron out but I would be interested in some early feedback.

cc @lhoestq @sashavor 