### PR TITLE
Fix bertscore idf

### DIFF
--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -105,12 +105,20 @@ class BERTScore(evaluate.Metric):
             citation=_CITATION,
             homepage="https://github.com/Tiiiger/bert_score",
             inputs_description=_KWARGS_DESCRIPTION,
-            features=datasets.Features(
-                {
-                    "predictions": datasets.Value("string", id="sequence"),
-                    "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
-                }
-            ),
+            features=[
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Sequence(datasets.Value("string", id="sequence"), id="references"),
+                    }
+                ),
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string", id="sequence"),
+                        "references": datasets.Value("string", id="sequence"),
+                    }
+                ),
+            ],
             codebase_urls=["https://github.com/Tiiiger/bert_score"],
             reference_urls=[
                 "https://github.com/Tiiiger/bert_score",
@@ -135,6 +143,9 @@ class BERTScore(evaluate.Metric):
         baseline_path=None,
         use_fast_tokenizer=False,
     ):
+
+        if isinstance(references[0], str):
+            references = [[ref] for ref in references]
         get_hash = bert_score.utils.get_hash
         scorer = bert_score.BERTScorer
 
@@ -190,19 +201,3 @@ class BERTScore(evaluate.Metric):
             "hashcode": hashcode,
         }
         return output_dict
-
-    def add_batch(self, predictions=None, references=None, **kwargs):
-        """Add a batch of predictions and references for the metric's stack."""
-        # References can be strings or lists of strings
-        # Let's change strings to lists of strings with one element
-        if references is not None:
-            references = [[ref] if isinstance(ref, str) else ref for ref in references]
-        super().add_batch(predictions=predictions, references=references, **kwargs)
-
-    def add(self, prediction=None, reference=None, **kwargs):
-        """Add one prediction and reference for the metric's stack."""
-        # References can be strings or lists of strings
-        # Let's change strings to lists of strings with one element
-        if isinstance(reference, str):
-            reference = [reference]
-        super().add(prediction=prediction, reference=reference, **kwargs)

--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -146,6 +146,12 @@ class BERTScore(evaluate.Metric):
 
         if isinstance(references[0], str):
             references = [[ref] for ref in references]
+
+        if idf:
+            idf_sents = [r for ref in references for r in ref]
+        else:
+            idf_sents = None
+
         get_hash = bert_score.utils.get_hash
         scorer = bert_score.BERTScorer
 
@@ -182,6 +188,7 @@ class BERTScore(evaluate.Metric):
                     nthreads=nthreads,
                     all_layers=all_layers,
                     idf=idf,
+                    idf_sents=idf_sents,
                     device=device,
                     lang=lang,
                     rescale_with_baseline=rescale_with_baseline,


### PR DESCRIPTION
This addresses #151: If no sentences for IDF are provided and the IDF dict is not computed and an error is raised during the scoring. 

Also fixed the feature logic with the new logic allowing to specifying multiple feature types.