### PR TITLE
refactor evaluator base and task classes

### DIFF
--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -88,6 +88,7 @@ class Evaluator(ABC):
         def build_args_metric(metric, key, **kwargs):
             def args_metric(*args):
                 return metric.compute(**{k: v for k, v in zip(kwargs.keys(), args)})[key]
+
             return args_metric
 
         bootstrap_dict = {}
@@ -131,7 +132,7 @@ class Evaluator(ABC):
         with the task specified by the `Evaluator`.
         """
         raise NotImplementedError()
-    
+
     def prepare_data(self, data: Union[str, Dataset], input_column: str, label_column: str):
         """
         Prepare data.

--- a/src/evaluate/evaluator/image_classification.py
+++ b/src/evaluate/evaluator/image_classification.py
@@ -127,8 +127,8 @@ class ImageClassificationEvaluator(Evaluator):
         >>> )
         ```"""
 
-        result= {}
-        
+        result = {}
+
         data = self.prepare_data(data=data, input_column=input_column, label_column=label_column)
         metric_inputs = {"references": data[label_column]}
 
@@ -139,15 +139,16 @@ class ImageClassificationEvaluator(Evaluator):
         # Compute predictions
         predictions = self.call_pipeline(pipe, data[input_column])
         metric_inputs["predictions"] = self.predictions_processor(predictions, label_mapping)
-        
+
         # Compute metrics from references and predictions
-        result.update(self.compute_metric(
-            metric=metric,
-            metric_inputs=metric_inputs,
-            strategy=strategy,
-            confidence_level=confidence_level,
-            n_resamples=n_resamples,
-            random_state=random_state,
+        result.update(
+            self.compute_metric(
+                metric=metric,
+                metric_inputs=metric_inputs,
+                strategy=strategy,
+                confidence_level=confidence_level,
+                n_resamples=n_resamples,
+                random_state=random_state,
             )
         )
 

--- a/src/evaluate/evaluator/image_classification.py
+++ b/src/evaluate/evaluator/image_classification.py
@@ -47,6 +47,10 @@ class ImageClassificationEvaluator(Evaluator):
     def __init__(self, task="image-classification", default_metric_name=None):
         super().__init__(task, default_metric_name=default_metric_name)
 
+    def predictions_processor(self, predictions, label_mapping):
+        pred_label = [max(pred, key=lambda x: x["score"])["label"] for pred in predictions]
+        return [label_mapping[pred] if label_mapping is not None else pred for pred in pred_label]
+
     def compute(
         self,
         model_or_pipeline: Union[str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"] = None,
@@ -122,26 +126,29 @@ class ImageClassificationEvaluator(Evaluator):
         >>>     random_state=0
         >>> )
         ```"""
+
+        result= {}
+        
         data = self.prepare_data(data=data, input_column=input_column, label_column=label_column)
+        metric_inputs = {"references": data[label_column]}
 
         pipe = self.prepare_pipeline(model_or_pipeline=model_or_pipeline, preprocessor=feature_extractor)
 
         metric = self.prepare_metric(metric)
 
         # Compute predictions
-        predictions = pipe(data[input_column])
-        pred_label = [max(pred, key=lambda x: x["score"])["label"] for pred in predictions]
-        predictions = [label_mapping[pred] if label_mapping is not None else pred for pred in pred_label]
-
+        predictions = self.call_pipeline(pipe, data[input_column])
+        metric_inputs["predictions"] = self.predictions_processor(predictions, label_mapping)
+        
         # Compute metrics from references and predictions
-        result = self.core_compute(
-            references=data[label_column],
-            predictions=predictions,
+        result.update(self.compute_metric(
             metric=metric,
+            metric_inputs=metric_inputs,
             strategy=strategy,
             confidence_level=confidence_level,
             n_resamples=n_resamples,
             random_state=random_state,
+            )
         )
 
         return result

--- a/src/evaluate/evaluator/image_classification.py
+++ b/src/evaluate/evaluator/image_classification.py
@@ -12,28 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numbers import Number
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple
 
-# Lint as: python3
-from datasets import Dataset
-
-
-try:
-    from transformers import FeatureExtractionMixin, Pipeline, PreTrainedModel, TFPreTrainedModel
-
-    TRANSFORMERS_AVAILABLE = True
-except ImportError:
-    TRANSFORMERS_AVAILABLE = False
-
-from typing_extensions import Literal
-
-from ..module import EvaluationModule
-from ..utils.logging import get_logger
 from .base import Evaluator
-
-
-logger = get_logger(__name__)
 
 
 class ImageClassificationEvaluator(Evaluator):
@@ -49,22 +30,11 @@ class ImageClassificationEvaluator(Evaluator):
 
     def predictions_processor(self, predictions, label_mapping):
         pred_label = [max(pred, key=lambda x: x["score"])["label"] for pred in predictions]
-        return [label_mapping[pred] if label_mapping is not None else pred for pred in pred_label]
+        pred_label = [label_mapping[pred] if label_mapping is not None else pred for pred in pred_label]
 
-    def compute(
-        self,
-        model_or_pipeline: Union[str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"] = None,
-        data: Union[str, Dataset] = None,
-        metric: Union[str, EvaluationModule] = None,
-        feature_extractor: Optional[Union[str, "FeatureExtractionMixin"]] = None,
-        strategy: Literal["simple", "bootstrap"] = "simple",
-        confidence_level: float = 0.95,
-        n_resamples: int = 9999,
-        random_state: Optional[int] = None,
-        input_column: str = "image",
-        label_column: str = "labels",
-        label_mapping: Optional[Dict[str, Number]] = None,
-    ) -> Tuple[Dict[str, float], Any]:
+        return {"predictions": pred_label}
+
+    def compute(self, *args, **kwargs) -> Tuple[Dict[str, float], Any]:
         """
         Compute the metric for a given pipeline and dataset combination.
         Args:
@@ -127,29 +97,6 @@ class ImageClassificationEvaluator(Evaluator):
         >>> )
         ```"""
 
-        result = {}
-
-        data = self.prepare_data(data=data, input_column=input_column, label_column=label_column)
-        metric_inputs = {"references": data[label_column]}
-
-        pipe = self.prepare_pipeline(model_or_pipeline=model_or_pipeline, preprocessor=feature_extractor)
-
-        metric = self.prepare_metric(metric)
-
-        # Compute predictions
-        predictions = self.call_pipeline(pipe, data[input_column])
-        metric_inputs["predictions"] = self.predictions_processor(predictions, label_mapping)
-
-        # Compute metrics from references and predictions
-        result.update(
-            self.compute_metric(
-                metric=metric,
-                metric_inputs=metric_inputs,
-                strategy=strategy,
-                confidence_level=confidence_level,
-                n_resamples=n_resamples,
-                random_state=random_state,
-            )
-        )
+        result = super().compute(*args, **kwargs)
 
         return result

--- a/src/evaluate/evaluator/text_classification.py
+++ b/src/evaluate/evaluator/text_classification.py
@@ -48,7 +48,7 @@ class TextClassificationEvaluator(Evaluator):
     def __init__(self, task="text-classification", default_metric_name=None):
         super().__init__(task, default_metric_name=default_metric_name)
 
-    def predictions_processor(self,predictions, label_mapping):
+    def predictions_processor(self, predictions, label_mapping):
         predictions = [
             label_mapping[element["label"]] if label_mapping is not None else element["label"]
             for element in predictions
@@ -144,13 +144,14 @@ class TextClassificationEvaluator(Evaluator):
         metric_inputs["predictions"] = self.predictions_processor(predictions, label_mapping)
 
         # Compute metrics from references and predictions
-        result.update(self.compute_metric(
-            metric=metric,
-            metric_inputs=metric_inputs,
-            strategy=strategy,
-            confidence_level=confidence_level,
-            n_resamples=n_resamples,
-            random_state=random_state,
+        result.update(
+            self.compute_metric(
+                metric=metric,
+                metric_inputs=metric_inputs,
+                strategy=strategy,
+                confidence_level=confidence_level,
+                n_resamples=n_resamples,
+                random_state=random_state,
             )
         )
 

--- a/src/evaluate/evaluator/text_classification.py
+++ b/src/evaluate/evaluator/text_classification.py
@@ -12,28 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numbers import Number
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple
 
-# Lint as: python3
-from datasets import Dataset
-
-
-try:
-    from transformers import Pipeline, PreTrainedModel, PreTrainedTokenizer, TFPreTrainedModel
-
-    TRANSFORMERS_AVAILABLE = True
-except ImportError:
-    TRANSFORMERS_AVAILABLE = False
-
-from typing_extensions import Literal
-
-from ..module import EvaluationModule
-from ..utils.logging import get_logger
 from .base import Evaluator
-
-
-logger = get_logger(__name__)
 
 
 class TextClassificationEvaluator(Evaluator):
@@ -45,6 +26,8 @@ class TextClassificationEvaluator(Evaluator):
     feature as input and a categorical label as output.
     """
 
+    PIPELINE_KWARGS = {"truncation": True}
+
     def __init__(self, task="text-classification", default_metric_name=None):
         super().__init__(task, default_metric_name=default_metric_name)
 
@@ -53,22 +36,9 @@ class TextClassificationEvaluator(Evaluator):
             label_mapping[element["label"]] if label_mapping is not None else element["label"]
             for element in predictions
         ]
-        return predictions
+        return {"predictions": predictions}
 
-    def compute(
-        self,
-        model_or_pipeline: Union[str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"] = None,
-        data: Union[str, Dataset] = None,
-        metric: Union[str, EvaluationModule] = None,
-        tokenizer: Optional[Union[str, "PreTrainedTokenizer"]] = None,
-        strategy: Literal["simple", "bootstrap"] = "simple",
-        confidence_level: float = 0.95,
-        n_resamples: int = 9999,
-        random_state: Optional[int] = None,
-        input_column: str = "text",
-        label_column: str = "label",
-        label_mapping: Optional[Dict[str, Number]] = None,
-    ) -> Tuple[Dict[str, float], Any]:
+    def compute(self, *args, **kwargs) -> Tuple[Dict[str, float], Any]:
         """
         Compute the metric for a given pipeline and dataset combination.
         Args:
@@ -131,28 +101,6 @@ class TextClassificationEvaluator(Evaluator):
         >>> )
         ```"""
 
-        result = {}
-
-        data = self.prepare_data(data=data, input_column=input_column, label_column=label_column)
-        metric_inputs = {"references": data[label_column]}
-
-        pipe = self.prepare_pipeline(model_or_pipeline=model_or_pipeline, preprocessor=tokenizer)
-        metric = self.prepare_metric(metric)
-
-        # Compute predictions
-        predictions = self.call_pipeline(pipe, data[input_column], truncation=True)
-        metric_inputs["predictions"] = self.predictions_processor(predictions, label_mapping)
-
-        # Compute metrics from references and predictions
-        result.update(
-            self.compute_metric(
-                metric=metric,
-                metric_inputs=metric_inputs,
-                strategy=strategy,
-                confidence_level=confidence_level,
-                n_resamples=n_resamples,
-                random_state=random_state,
-            )
-        )
+        result = super().compute(*args, **kwargs)
 
         return result


### PR DESCRIPTION
Refactored the `evaluator` base and task classes based on discussions in #178 to make them a bit more abstract for new tasks and draw a clearer separation between base and task classes. 

Adding the performance should now be easy: measure inside `call_pipeline` and return an dict with which you can update the `result` dict inside the `compute` methods.

Also if a user wants to pass a custom prediction postprocessing (as suggested by @craffel) before passing to the metric we can just overwrite the `predictions_processing` method or wrap the custom function around it.

Let me know what you think @ola13 and @fxmarty.