### PR TITLE
Rename perf metric evaluator

### DIFF
--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -111,12 +111,18 @@ class Evaluator(ABC):
     def _compute_time_perf(start_time: float, end_time: float, num_samples: int) -> Dict[str, Any]:
         """
         A utility function computing time performance metrics:
-            - `latency` - pipeline inference runtime for the evaluation data in seconds,
-            - `throughput` - pipeline throughput in the number of samples per second.
+            - `latency_in_seconds` - pipeline inference runtime for the evaluation data in seconds,
+            - `samples_per_second` - pipeline throughput in the number of samples per second.
         """
         latency = end_time - start_time
         throughput = num_samples / latency
-        return {"latency": latency, "throughput": throughput}
+        latency_sample = 1.0 / throughput
+
+        return {
+            "total_time_in_seconds": latency,
+            "samples_per_second": throughput,
+            "latency_in_seconds": latency_sample,
+        }
 
     @abstractmethod
     def predictions_processor(self, *args, **kwargs):

--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -114,7 +114,7 @@ class Evaluator(ABC):
             - `total_time_in_seconds` - pipeline inference runtime for the evaluation data in seconds,
             - `samples_per_second` - pipeline throughput in the number of samples per second.
             - `latency_in_seconds` - pipeline inference runtime for the evaluation data in seconds per sample,
-            
+
         """
         latency = end_time - start_time
         throughput = num_samples / latency

--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -111,8 +111,10 @@ class Evaluator(ABC):
     def _compute_time_perf(start_time: float, end_time: float, num_samples: int) -> Dict[str, Any]:
         """
         A utility function computing time performance metrics:
-            - `latency_in_seconds` - pipeline inference runtime for the evaluation data in seconds,
+            - `total_time_in_seconds` - pipeline inference runtime for the evaluation data in seconds,
             - `samples_per_second` - pipeline throughput in the number of samples per second.
+            - `latency_in_seconds` - pipeline inference runtime for the evaluation data in seconds per sample,
+            
         """
         latency = end_time - start_time
         throughput = num_samples / latency

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -200,8 +200,10 @@ class TestTextClassificationEvaluator(TestCase):
             random_state=0,
         )
         self.assertEqual(results["accuracy"], 1.0)
-        self.assertAlmostEqual(results["latency"], 0.1, 1)
-        self.assertAlmostEqual(results["throughput"], len(self.data) / results["latency"], 5)
+        self.assertAlmostEqual(results["total_time_in_seconds"], 0.1, 1)
+        self.assertAlmostEqual(results["samples_per_second"], len(self.data) / results["total_time_in_seconds"], 5)
+        self.assertAlmostEqual(results["latency_in_seconds"], results["total_time_in_seconds"] / len(self.data), 5)
+
 
     def test_bootstrap_and_perf(self):
         data = Dataset.from_dict({"label": [1, 0, 0], "text": ["great movie", "great movie", "horrible movie"]})
@@ -222,8 +224,10 @@ class TestTextClassificationEvaluator(TestCase):
         self.assertAlmostEqual(results["accuracy"]["confidence_interval"][0], 0.333333, 5)
         self.assertAlmostEqual(results["accuracy"]["confidence_interval"][1], 0.666666, 5)
         self.assertAlmostEqual(results["accuracy"]["standard_error"], 0.22498285, 5)
-        self.assertAlmostEqual(results["latency"], 0.1, 1)
-        self.assertAlmostEqual(results["throughput"], len(data) / results["latency"], 5)
+        self.assertAlmostEqual(results["total_time_in_seconds"], 0.1, 1)
+        self.assertAlmostEqual(results["samples_per_second"], len(data) / results["total_time_in_seconds"], 5)
+        self.assertAlmostEqual(results["latency_in_seconds"], results["total_time_in_seconds"] / len(data), 5)
+
 
 
 class TestImageClassificationEvaluator(TestCase):

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -204,7 +204,6 @@ class TestTextClassificationEvaluator(TestCase):
         self.assertAlmostEqual(results["samples_per_second"], len(self.data) / results["total_time_in_seconds"], 5)
         self.assertAlmostEqual(results["latency_in_seconds"], results["total_time_in_seconds"] / len(self.data), 5)
 
-
     def test_bootstrap_and_perf(self):
         data = Dataset.from_dict({"label": [1, 0, 0], "text": ["great movie", "great movie", "horrible movie"]})
 
@@ -227,7 +226,6 @@ class TestTextClassificationEvaluator(TestCase):
         self.assertAlmostEqual(results["total_time_in_seconds"], 0.1, 1)
         self.assertAlmostEqual(results["samples_per_second"], len(data) / results["total_time_in_seconds"], 5)
         self.assertAlmostEqual(results["latency_in_seconds"], results["total_time_in_seconds"] / len(data), 5)
-
 
 
 class TestImageClassificationEvaluator(TestCase):


### PR DESCRIPTION
After playing a bit with the new evaluators I found that names of the performance metrics are self-explanatory and since the user won't see the docstring with the function that computes them easily decided to rename them with more expressive names. What do you think @ola13?