### PR TITLE
Evaluator device placement

### DIFF
--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -131,24 +131,23 @@ class Evaluator(ABC):
         # try infer with torch first
         try:
             import torch
-            
+
             if torch.cuda.is_available():
-                device = 0 # first GPU
+                device = 0  # first GPU
             else:
-                device = -1 # CPU
+                device = -1  # CPU
         except ImportError:
             # if not available try TF
             try:
                 import tensorflow as tf
-                
-                if len(tf.config.list_physical_devices('GPU')) > 0:
-                    device = 0 # first GPU
+
+                if len(tf.config.list_physical_devices("GPU")) > 0:
+                    device = 0  # first GPU
                 else:
-                    device = -1 # CPU
+                    device = -1  # CPU
             except ImportError:
                 device = -1
         return device
-
 
     @abstractmethod
     def predictions_processor(self, *args, **kwargs):
@@ -181,7 +180,10 @@ class Evaluator(ABC):
         # Prepare inputs
         metric_inputs, pipe_inputs = self.prepare_data(data=data, input_column=input_column, label_column=label_column)
         pipe = self.prepare_pipeline(
-            model_or_pipeline=model_or_pipeline, tokenizer=tokenizer, feature_extractor=feature_extractor, device=device
+            model_or_pipeline=model_or_pipeline,
+            tokenizer=tokenizer,
+            feature_extractor=feature_extractor,
+            device=device,
         )
         metric = self.prepare_metric(metric)
 
@@ -243,7 +245,7 @@ class Evaluator(ABC):
         model_or_pipeline: Union[str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"],  # noqa: F821
         tokenizer: Union["PreTrainedTokenizerBase", "FeatureExtractionMixin"] = None,  # noqa: F821
         feature_extractor: Union["PreTrainedTokenizerBase", "FeatureExtractionMixin"] = None,  # noqa: F821
-        device: int = None
+        device: int = None,
     ):
         """
         Prepare pipeline.

--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -273,11 +273,15 @@ class Evaluator(ABC):
             or isinstance(model_or_pipeline, transformers.TFPreTrainedModel)
         ):
             pipe = pipeline(
-                self.task, model=model_or_pipeline, tokenizer=tokenizer, feature_extractor=feature_extractor
+                self.task,
+                model=model_or_pipeline,
+                tokenizer=tokenizer,
+                feature_extractor=feature_extractor,
+                device=device,
             )
         else:
             if model_or_pipeline is None:
-                pipe = pipeline(self.task)
+                pipe = pipeline(self.task, device=device)
             else:
                 pipe = model_or_pipeline
             if tokenizer is not None and feature_extractor is not None:

--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -128,6 +128,7 @@ class Evaluator(ABC):
 
     @staticmethod
     def _infer_device():
+        """Helper function to check if GPU or CPU is available for inference."""
         # try infer with torch first
         try:
             import torch
@@ -147,6 +148,12 @@ class Evaluator(ABC):
                     device = -1  # CPU
             except ImportError:
                 device = -1
+
+        if device == -1:
+            logger.info("No GPU found. The default device for pipeline inference is set to CPU.")
+        else:
+            logger.info("GPU found. The default device for pipeline inference is set to GPU (0).")
+
         return device
 
     @abstractmethod

--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -127,7 +127,7 @@ class Evaluator(ABC):
         }
 
     @staticmethod
-    def _infer_device():
+    def _infer_device() -> int:
         """Helper function to check if GPU or CPU is available for inference."""
         # try infer with torch first
         try:
@@ -152,7 +152,7 @@ class Evaluator(ABC):
         if device == -1:
             logger.info("No GPU found. The default device for pipeline inference is set to CPU.")
         else:
-            logger.info("GPU found. The default device for pipeline inference is set to GPU (0).")
+            logger.info("GPU found. The default device for pipeline inference is set to GPU (CUDA:0).")
 
         return device
 

--- a/src/evaluate/evaluator/image_classification.py
+++ b/src/evaluate/evaluator/image_classification.py
@@ -63,10 +63,10 @@ class ImageClassificationEvaluator(Evaluator):
                 The `confidence_level` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
             n_resamples (`int`, defaults to `9999`):
                 The `n_resamples` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
-            device (`int`, defaults to None):
-                 Device ordinal for CPU/GPU supports of pipeline. Setting this to -1 will leverage CPU, a positive
-                 will run the model on the associated CUDA device id. If none is provided it will be inferred and
-                 GPU:0 used if available, CPU otherwise.
+            device (`int`, defaults to `None`):
+                 Device ordinal for CPU/GPU support of the pipeline. Setting this to -1 will leverage CPU, a positive
+                 integer will run the model on the associated CUDA device ID. If`None` is provided it will be inferred and
+                 CUDA:0 used if available, CPU otherwise.
             random_state (`int`, *optional*, defaults to `None`):
                 The `random_state` value passed to `bootstrap` if `"bootstrap"` strategy is chosen. Useful for
                 debugging.

--- a/src/evaluate/evaluator/image_classification.py
+++ b/src/evaluate/evaluator/image_classification.py
@@ -63,6 +63,10 @@ class ImageClassificationEvaluator(Evaluator):
                 The `confidence_level` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
             n_resamples (`int`, defaults to `9999`):
                 The `n_resamples` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
+            device (`int`, defaults to None):
+                 Device ordinal for CPU/GPU supports of pipeline. Setting this to -1 will leverage CPU, a positive
+                 will run the model on the associated CUDA device id. If none is provided it will be inferred and
+                 GPU:0 used if available, CPU otherwise.
             random_state (`int`, *optional*, defaults to `None`):
                 The `random_state` value passed to `bootstrap` if `"bootstrap"` strategy is chosen. Useful for
                 debugging.

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -123,6 +123,7 @@ class QuestionAnsweringEvaluator(Evaluator):
         strategy: Literal["simple", "bootstrap"] = "simple",
         confidence_level: float = 0.95,
         n_resamples: int = 9999,
+        device: int = None,
         random_state: Optional[int] = None,
         question_column: str = "question",
         context_column: str = "context",
@@ -227,7 +228,7 @@ class QuestionAnsweringEvaluator(Evaluator):
                 f"`squad_v2_format` parameter not provided to QuestionAnsweringEvaluator.compute(). Auto-infered `squad_v2_format` to {squad_v2_format}."
             )
 
-        pipe = self.prepare_pipeline(model_or_pipeline=model_or_pipeline, tokenizer=tokenizer)
+        pipe = self.prepare_pipeline(model_or_pipeline=model_or_pipeline, tokenizer=tokenizer, device=device)
 
         metric = self.prepare_metric(metric)
 

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -159,10 +159,10 @@ class QuestionAnsweringEvaluator(Evaluator):
                 The `confidence_level` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
             n_resamples (`int`, defaults to `9999`):
                 The `n_resamples` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
-            device (`int`, defaults to None):
-                 Device ordinal for CPU/GPU supports of pipeline. Setting this to -1 will leverage CPU, a positive
-                 will run the model on the associated CUDA device id. If none is provided it will be inferred and
-                 GPU:0 used if available, CPU otherwise.
+            device (`int`, defaults to `None`):
+                 Device ordinal for CPU/GPU support of the pipeline. Setting this to -1 will leverage CPU, a positive
+                 will run the model on the associated CUDA device ID. If`None` is provided it will be inferred and
+                 CUDA:0 used if available, CPU otherwise.
             random_state (`int`, *optional*, defaults to `None`):
                 The `random_state` value passed to `bootstrap` if `"bootstrap"` strategy is chosen. Useful for
                 debugging.

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -159,6 +159,10 @@ class QuestionAnsweringEvaluator(Evaluator):
                 The `confidence_level` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
             n_resamples (`int`, defaults to `9999`):
                 The `n_resamples` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
+            device (`int`, defaults to None):
+                 Device ordinal for CPU/GPU supports of pipeline. Setting this to -1 will leverage CPU, a positive
+                 will run the model on the associated CUDA device id. If none is provided it will be inferred and
+                 GPU:0 used if available, CPU otherwise.
             random_state (`int`, *optional*, defaults to `None`):
                 The `random_state` value passed to `bootstrap` if `"bootstrap"` strategy is chosen. Useful for
                 debugging.

--- a/src/evaluate/evaluator/text_classification.py
+++ b/src/evaluate/evaluator/text_classification.py
@@ -67,10 +67,10 @@ class TextClassificationEvaluator(Evaluator):
                 The `confidence_level` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
             n_resamples (`int`, defaults to `9999`):
                 The `n_resamples` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
-            device (`int`, defaults to None):
-                 Device ordinal for CPU/GPU supports of pipeline. Setting this to -1 will leverage CPU, a positive
-                 will run the model on the associated CUDA device id. If none is provided it will be inferred and
-                 GPU:0 used if available, CPU otherwise.
+            device (`int`, defaults to `None`):
+                 Device ordinal for CPU/GPU support of the pipeline. Setting this to -1 will leverage CPU, a positive
+                 integer will run the model on the associated CUDA device ID. If`None` is provided it will be inferred and
+                 CUDA:0 used if available, CPU otherwise.
             random_state (`int`, *optional*, defaults to `None`):
                 The `random_state` value passed to `bootstrap` if `"bootstrap"` strategy is chosen. Useful for
                 debugging.

--- a/src/evaluate/evaluator/text_classification.py
+++ b/src/evaluate/evaluator/text_classification.py
@@ -67,6 +67,10 @@ class TextClassificationEvaluator(Evaluator):
                 The `confidence_level` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
             n_resamples (`int`, defaults to `9999`):
                 The `n_resamples` value passed to `bootstrap` if `"bootstrap"` strategy is chosen.
+            device (`int`, defaults to None):
+                 Device ordinal for CPU/GPU supports of pipeline. Setting this to -1 will leverage CPU, a positive
+                 will run the model on the associated CUDA device id. If none is provided it will be inferred and
+                 GPU:0 used if available, CPU otherwise.
             random_state (`int`, *optional*, defaults to `None`):
                 The `random_state` value passed to `bootstrap` if `"bootstrap"` strategy is chosen. Useful for
                 debugging.


### PR DESCRIPTION
This PR ads device placement for the pipeline in the evaluator. There are two mechanisms:

1. The user can pass a device to `Evaluator.compute`.
2. If no device is passed we attempt to infer if a GPU is available and device 0 is used.

Alternatively, a user can always use a custom configuration and initialize the pipeline before passing it to the `evaluator`. If the an initialized pipeline is passed the device has no effect.