### PR TITLE
Change test command in installation.mdx to use exact_match

### DIFF
--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -42,13 +42,13 @@ pip install evaluate
 Run the following command to check if 🤗 Evaluate has been properly installed:
 
 ```bash
-python -c "import evaluate; print(evaluate.load('accuracy').compute(references=[1], predictions=[1]))"
+python -c "import evaluate; print(evaluate.load('exact_match').compute(references=['hello'], predictions=['hello']))"
 ```
 
 This should return:
 
 ```bash
-{'accuracy': 1.0}
+{'exact_match': 1.0}
 ```
 
 ## source

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -64,5 +64,5 @@ pip install -e .
 Again, you can check if 🤗 Evaluate has been properly installed with:
 
 ```bash
-python -c "import evaluate; print(evaluate.load('accuracy').compute(references=[1], predictions=[1]))"
+python -c "import evaluate; print(evaluate.load('exact_match').compute(references=['hello'], predictions=['hello']))"
 ```


### PR DESCRIPTION
The current command used to test the installation of `evaluate` uses the `accuracy` metric, which requires the installation of sklearn. This PR changes it to use the `exact_match` metric instead, which does not require any other dependencies.