### PR TITLE
Pin rouge_score

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ TESTS_REQUIRE = [
     "torch",
     # metrics dependencies
     "bert_score>=0.3.6",
-    "rouge_score",
+    "rouge_score<0.0.7",
     "sacrebleu",
     "sacremoses",
     "scipy",


### PR DESCRIPTION
Temporarily pin `rouge_score` (to avoid latest version 0.7.0) until the issue is fixed on their side:
- https://github.com/google-research/google-research/issues/1212

See:
- https://github.com/huggingface/datasets/issues/4734
