### PR TITLE
Evaluator column loading

### DIFF
--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -39,10 +39,10 @@ from time import perf_counter
 
 from typing_extensions import Literal
 
-from .utils import DatasetColumn
 from ..loading import load
 from ..module import EvaluationModule
 from ..utils.logging import get_logger
+from .utils import DatasetColumn
 
 
 logger = get_logger(__name__)

--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -39,6 +39,7 @@ from time import perf_counter
 
 from typing_extensions import Literal
 
+from .utils import DatasetColumn
 from ..loading import load
 from ..module import EvaluationModule
 from ..utils.logging import get_logger
@@ -245,7 +246,7 @@ class Evaluator(ABC):
                 f"Invalid `label_column` {label_column} specified. The dataset contains the following columns: {data.column_names}."
             )
 
-        return {"references": data[label_column]}, data[input_column]
+        return {"references": data[label_column]}, DatasetColumn(data, input_column)
 
     def prepare_pipeline(
         self,

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -30,6 +30,7 @@ from typing_extensions import Literal
 from ..module import EvaluationModule
 from ..utils.logging import get_logger
 from .base import Evaluator
+from .utils import DatasetColumn
 
 
 logger = get_logger(__name__)
@@ -89,7 +90,10 @@ class QuestionAnsweringEvaluator(Evaluator):
             {"id": element[id_column], "answers": element[label_column]} for element in data
         ]
 
-        return metric_inputs, {"question": data[question_column], "context": data[context_column]}
+        return metric_inputs, {
+            "question": DatasetColumn(data, question_column),
+            "context": DatasetColumn(data, context_column),
+        }
 
     def is_squad_v2_format(self, data: Dataset, label_column: str = "answers"):
         """

--- a/src/evaluate/evaluator/token_classification.py
+++ b/src/evaluate/evaluator/token_classification.py
@@ -17,6 +17,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from datasets import ClassLabel, Dataset, Sequence
 from typing_extensions import Literal
 
+from evaluate.evaluator.utils import DatasetColumn
+
 from .base import Evaluator
 
 
@@ -119,7 +121,8 @@ class TokenClassificationEvaluator(Evaluator):
             references = data[label_column]
 
         metric_inputs = {"references": references}
-        pipeline_inputs = [join_by.join(element) for element in data[input_column]]
+        data = data.map(lambda x: {input_column: join_by.join(x[input_column])})
+        pipeline_inputs = DatasetColumn(data, input_column)
 
         return metric_inputs, pipeline_inputs
 

--- a/src/evaluate/evaluator/utils.py
+++ b/src/evaluate/evaluator/utils.py
@@ -1,0 +1,14 @@
+from datasets import Dataset
+
+
+class DatasetColumn(list):
+    """Helper class to avoid loading a dataset column into memory when accessing it."""
+    def __init__(self, dataset: Dataset, key: str):
+        self.dataset = dataset
+        self.key = key
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getitem__(self, i):
+        return self.dataset[i][self.key]

--- a/src/evaluate/evaluator/utils.py
+++ b/src/evaluate/evaluator/utils.py
@@ -3,6 +3,7 @@ from datasets import Dataset
 
 class DatasetColumn(list):
     """Helper class to avoid loading a dataset column into memory when accessing it."""
+
     def __init__(self, dataset: Dataset, key: str):
         self.dataset = dataset
         self.key = key

--- a/src/evaluate/evaluator/utils.py
+++ b/src/evaluate/evaluator/utils.py
@@ -12,3 +12,6 @@ class DatasetColumn(list):
 
     def __getitem__(self, i):
         return self.dataset[i][self.key]
+
+    def __iter__(self):
+        return (self.dataset[i][self.key] for i in range(len(self)))


### PR DESCRIPTION
Instead of loading the pipeline inputs into memory this PR just wraps the original dataset in a `DatasetColumn` class. This allows to evaluate on huge datasets (e.g. ImageNet) without OOM errors. 

cc @fxmarty 