### PR TITLE
Add a fingerprint for each EvaluationModule

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -710,7 +710,7 @@ def load(
         cache_dir=cache_dir,
         keep_in_memory=keep_in_memory,
         experiment_id=experiment_id,
-        fingerprint=evaluation_module.hash,
+        hash=evaluation_module.hash,
         **init_kwargs,
     )
 

--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -678,7 +678,7 @@ def load(
         path (``str``):
             path to the evaluation processing script with the evaluation builder. Can be either:
                 - a local path to processing script or the directory containing the script (if the script has the same name as the directory),
-                    e.g. ``'./metrics/rouge'`` or ``'./metrics/rogue/rouge.py'``
+                    e.g. ``'./metrics/rouge'`` or ``'./metrics/rouge/rouge.py'``
                 - a evaluation module identifier on the HuggingFace evaluate repo e.g. ``'rouge'`` or ``'bleu'`` that are in either ``'metrics/'``,
                     ``'comparisons/'``, or ``'measurements/'`` depending on the provided ``module_type``.
         config_name (:obj:`str`, optional): selecting a configuration for the metric (e.g. the GLUE metric has a configuration for each subset)
@@ -701,8 +701,8 @@ def load(
     download_mode = DownloadMode(download_mode or DownloadMode.REUSE_DATASET_IF_EXISTS)
     evaluation_module = evaluation_module_factory(
         path, module_type=module_type, revision=revision, download_config=download_config, download_mode=download_mode
-    ).module_path
-    evaluation_cls = import_main_class(evaluation_module)
+    )
+    evaluation_cls = import_main_class(evaluation_module.module_path)
     evaluation_instance = evaluation_cls(
         config_name=config_name,
         process_id=process_id,
@@ -710,6 +710,7 @@ def load(
         cache_dir=cache_dir,
         keep_in_memory=keep_in_memory,
         experiment_id=experiment_id,
+        fingerprint=evaluation_module.hash,
         **init_kwargs,
     )
 

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -234,7 +234,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
         self.filelocks = None
 
         # This fingerprints the evaluation module according to the hashed contents of the module code
-        self._hash = git commit -am "Rename _hash
+        self._hash = hash
 
     def __len__(self):
         """Return the number of examples (predictions or predictions/references pair)

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -158,6 +158,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
         seed (:obj:`int`, optional): If specified, this will temporarily set numpy's random seed when :func:`evaluate.EvaluationModule.compute` is run.
         experiment_id (``str``): A specific experiment id. This is used if several distributed evaluations share the same file system.
             This is useful to compute module in distributed setups (in particular non-additive metrics like F1).
+        fingerprint (``str``): Used to fingerprint the evaluation module according to the hashed file contents.
         max_concurrent_cache_files (``int``): Max number of concurrent module cache files (default 10000).
         timeout (``Union[int, float]``): Timeout in second for distributed setting synchronization.
     """
@@ -171,6 +172,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
         process_id: int = 0,
         seed: Optional[int] = None,
         experiment_id: Optional[str] = None,
+        fingerprint: str = None,
         max_concurrent_cache_files: int = 10000,
         timeout: Union[int, float] = 100,
         **kwargs,
@@ -230,6 +232,9 @@ class EvaluationModule(EvaluationModuleInfoMixin):
         # This is all the cache files on which we have a lock when we are in a distributed setting
         self.file_paths = None
         self.filelocks = None
+
+        # This fingerprints the evaluation module according to the hashed contents of the module code
+        self._fingerprint = fingerprint
 
     def __len__(self):
         """Return the number of examples (predictions or predictions/references pair)

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -158,7 +158,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
         seed (:obj:`int`, optional): If specified, this will temporarily set numpy's random seed when :func:`evaluate.EvaluationModule.compute` is run.
         experiment_id (``str``): A specific experiment id. This is used if several distributed evaluations share the same file system.
             This is useful to compute module in distributed setups (in particular non-additive metrics like F1).
-        fingerprint (``str``): Used to fingerprint the evaluation module according to the hashed file contents.
+        hash (``str``): Used to identify the evaluation module according to the hashed file contents.
         max_concurrent_cache_files (``int``): Max number of concurrent module cache files (default 10000).
         timeout (``Union[int, float]``): Timeout in second for distributed setting synchronization.
     """
@@ -172,7 +172,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
         process_id: int = 0,
         seed: Optional[int] = None,
         experiment_id: Optional[str] = None,
-        fingerprint: str = None,
+        hash: str = None,
         max_concurrent_cache_files: int = 10000,
         timeout: Union[int, float] = 100,
         **kwargs,
@@ -234,7 +234,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
         self.filelocks = None
 
         # This fingerprints the evaluation module according to the hashed contents of the module code
-        self._fingerprint = fingerprint
+        self._hash = git commit -am "Rename _hash
 
     def __len__(self):
         """Return the number of examples (predictions or predictions/references pair)


### PR DESCRIPTION
In order to support #126 we need to fingerprint whichever EvaluationModule (metric, measurement, etc) we're using for later reproducibility. 

This extracts the already-computed hash from each EvaluationModule and makes it easy to access in the `evaluation_cls` via `module._fingerprint`, similar to how in `datasets` you can do `ds._fingerprint`.

Test via 
```
module = evaluate.load("lvwerra/element_count", module_type="measurement")
print(f"Module fingerprint: {module._fingerprint}")
```