### PR TITLE
set datasets to >=2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ from setuptools import find_packages, setup
 
 REQUIRED_PKGS = [
     # We need datasets as a backend
-    "datasets",
+    "datasets>=2.0.0",
     # We use numpy>=1.17 to have np.random.Generator (Dataset shuffling)
     "numpy>=1.17",
     # For smart caching dataset processing
@@ -87,7 +87,6 @@ REQUIRED_PKGS = [
     # Utilities from PyPA to e.g., compare versions
     "packaging",
     "responses<0.19",
-
 ]
 
 TEMPLATE_REQUIRE = [


### PR DESCRIPTION
We already fixed the datasets version in all spaces but for some reason not in `evaluate`. This fixes this.

cc @sgugger 

Closes #209 