### PR TITLE
Unpin rouge_score

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ TESTS_REQUIRE = [
     "torch",
     # metrics dependencies
     "bert_score>=0.3.6",
-    "rouge_score<0.0.7",
+    "rouge_score",
     "sacrebleu",
     "sacremoses",
     "scipy",


### PR DESCRIPTION
Once the issue has been fixed in their side with version 0.1.2, we can unpin it:
- https://github.com/google-research/google-research/issues/1212
> OK I've verified that 0.1.2 works in colab. Today I learned that colab uses python 3.7.

Follow-up of:
- #197