### PR TITLE
Fix loading error

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -647,7 +647,7 @@ def evaluation_module_factory(
             try:
                 return CachedEvaluationModuleFactory(path, dynamic_modules_path=dynamic_modules_path).get_module()
             except Exception as e2:  # noqa: if it's not in the cache, then it doesn't exist.
-                if not isinstance(e1, FileNotFoundError):
+                if not isinstance(e1, (ConnectionError, FileNotFoundError)):
                     raise e1 from None
                 raise FileNotFoundError(
                     f"Couldn't find a module script at {relative_to_absolute_path(combined_path)}. "

--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -622,7 +622,7 @@ def evaluation_module_factory(
                                 download_mode=download_mode,
                                 dynamic_modules_path=dynamic_modules_path,
                             ).get_module()
-                        except FileNotFoundError:
+                        except ConnectionError:
                             pass
                     raise FileNotFoundError
                 # if module_type provided load specific module_type

--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -650,11 +650,11 @@ def evaluation_module_factory(
                 if not isinstance(e1, FileNotFoundError):
                     raise e1 from None
                 raise FileNotFoundError(
-                    f"Couldn't find a metric script at {relative_to_absolute_path(combined_path)}. "
-                    f"Metric '{path}' doesn't exist on the Hugging Face Hub either."
+                    f"Couldn't find a module script at {relative_to_absolute_path(combined_path)}. "
+                    f"Module '{path}' doesn't exist on the Hugging Face Hub either."
                 ) from None
     else:
-        raise FileNotFoundError(f"Couldn't find a metric script at {relative_to_absolute_path(combined_path)}.")
+        raise FileNotFoundError(f"Couldn't find a module script at {relative_to_absolute_path(combined_path)}.")
 
 
 def load(


### PR DESCRIPTION
When switching from GitHub to Hugging Face Hub as a source of the scripts in #180 the error changed when a file is not found from `FileNotFoundError` (GitHub) to `ConnectionError`. When the `module_type` needs to be inferred this fails as the error is not caught.

This PR should fix this.