### PR TITLE
Force get_supported_tasks() to return a list instead of dict keys

### DIFF
--- a/src/evaluate/evaluator/__init__.py
+++ b/src/evaluate/evaluator/__init__.py
@@ -55,7 +55,7 @@ def get_supported_tasks() -> List[str]:
     """
     Returns a list of supported task strings.
     """
-    return SUPPORTED_EVALUATOR_TASKS.keys()
+    return list(SUPPORTED_EVALUATOR_TASKS.keys())
 
 
 def check_task(task: str) -> Dict:


### PR DESCRIPTION
Minor thing; the type signature says it returns a list but it currently returns a `dict_keys` object.