### PR TITLE
make rouge support multi-ref

### DIFF
--- a/metrics/rouge/README.md
+++ b/metrics/rouge/README.md
@@ -42,10 +42,20 @@ At minimum, this metric takes as input a list of predictions and a list of refer
 {'rouge1': 1.0, 'rouge2': 1.0, 'rougeL': 1.0, 'rougeLsum': 1.0}
 ```
 
+It can also deal with lists of references for each predictions:
+```python
+>>> rouge = evaluate.load('rouge')
+>>> predictions = ["hello there", "general kenobi"]
+>>> references = [["hello", "there"], ["general kenobi", "general yoda"]]
+>>> results = rouge.compute(predictions=predictions,
+...                         references=references)
+>>> print(results)
+{'rouge1': 0.8333, 'rouge2': 0.5, 'rougeL': 0.8333, 'rougeLsum': 0.8333}```
+
 ### Inputs
 - **predictions** (`list`): list of predictions to score. Each prediction
         should be a string with tokens separated by spaces.
-- **references** (`list`): list of reference for each prediction. Each
+- **references** (`list` or `list[list]`): list of reference for each prediction or a list of several predictions. Each
         reference should be a string with tokens separated by spaces.
 - **rouge_types** (`list`): A list of rouge types to calculate. Defaults to `['rouge1', 'rouge2', 'rougeL', 'rougeLsum']`.
     - Valid rouge types:

--- a/metrics/rouge/README.md
+++ b/metrics/rouge/README.md
@@ -55,7 +55,7 @@ It can also deal with lists of references for each predictions:
 ### Inputs
 - **predictions** (`list`): list of predictions to score. Each prediction
         should be a string with tokens separated by spaces.
-- **references** (`list` or `list[list]`): list of reference for each prediction or a list of several predictions. Each
+- **references** (`list` or `list[list]`): list of reference for each prediction or a list of several references per prediction. Each
         reference should be a string with tokens separated by spaces.
 - **rouge_types** (`list`): A list of rouge types to calculate. Defaults to `['rouge1', 'rouge2', 'rougeL', 'rougeLsum']`.
     - Valid rouge types:

--- a/metrics/rouge/requirements.txt
+++ b/metrics/rouge/requirements.txt
@@ -2,4 +2,4 @@ git+https://github.com/huggingface/evaluate@a45df1eb9996eec64ec3282ebe554061cb36
 datasets~=2.0
 absl-py
 nltk
-rouge_score>=0.12.0
+rouge_score>=0.1.2

--- a/metrics/rouge/requirements.txt
+++ b/metrics/rouge/requirements.txt
@@ -2,4 +2,4 @@ git+https://github.com/huggingface/evaluate@a45df1eb9996eec64ec3282ebe554061cb36
 datasets~=2.0
 absl-py
 nltk
-rouge_score
+rouge_score>=0.12.0

--- a/metrics/rouge/rouge.py
+++ b/metrics/rouge/rouge.py
@@ -93,7 +93,6 @@ class Rouge(evaluate.Metric):
                         "predictions": datasets.Value("string", id="sequence"),
                         "references": datasets.Sequence(datasets.Value("string", id="sequence")),
                     }
-                
                 ),
                 datasets.Features(
                     {

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ TESTS_REQUIRE = [
     "torch",
     # metrics dependencies
     "bert_score>=0.3.6",
-    "rouge_score",
+    "rouge_score>=0.12.0",
     "sacrebleu",
     "sacremoses",
     "scipy",

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ TESTS_REQUIRE = [
     "torch",
     # metrics dependencies
     "bert_score>=0.3.6",
-    "rouge_score>=0.12.0",
+    "rouge_score>=0.1.2",
     "sacrebleu",
     "sacremoses",
     "scipy",


### PR DESCRIPTION
This PR makes use of the `score_multi` method added in `rouge_score==0.12.0` and allows to pass multiple references per prediction. This makes this metric now compatible with `bleu` and `meteor`.

Closes #118 