### PR TITLE
Fix enforce string

### DIFF
--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -559,7 +559,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
                     self._enforce_nested_string_type(features, example)
                     features.encode_example(example)
                     return features
-                except ValueError:
+                except (ValueError, TypeError):
                     continue
         feature_strings = "\n".join([f"Feature option {i}: {feature}" for i, feature in enumerate(self.features)])
         error_msg = (

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -554,6 +554,16 @@ class TestMetric(TestCase):
         preds, refs = DummyMetric.predictions_and_references()
         expected_results = DummyMetric.expected_results()
         self.assertDictEqual(expected_results, metric.compute(predictions=preds, references=refs))
+
+        metric.info.features = [
+            Features({"predictions": Value("string"), "references": Value("string")}),
+            Features({"predictions": Value("int64"), "references": Value("int64")}),
+        ]
+
+        preds, refs = DummyMetric.predictions_and_references()
+        expected_results = DummyMetric.expected_results()
+        self.assertDictEqual(expected_results, metric.compute(predictions=preds, references=refs))
+
         del metric
 
 


### PR DESCRIPTION
Some casting operations throw `ValueError`s while others `TypeError`s. With this PR both are cought when inferring the type to make sure the iterative testing of feature types doesn't get interrupted. We didn't catch this so far because we had `Sequence` first and `str` second. I updated the test to include both cases, which would fail before and passes now.