### PR TITLE
Remove import statement in Measurement Card

### DIFF
--- a/measurements/label_distribution/README.md
+++ b/measurements/label_distribution/README.md
@@ -30,7 +30,6 @@ imbalance).
 The measurement takes a list of labels as input:
 
 ```python
-from evaluate import load
 >>> distribution = evaluate.load("label_distribution")
 >>> data = [1, 0, 2, 2, 0, 0, 0, 0, 0, 2]
 >>> results = distribution.compute(data=data)


### PR DESCRIPTION
This:
1 - handles fact that as-is it wasn't quite correct (should just be `import evaluate`)
2 - aligns the How to Use with the other ones for metrics (which don't show the import anyway)