### PR TITLE
only track unique missing dependencies

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -258,12 +258,12 @@ def _download_additional_modules(
         local_imports.append((import_name, local_import_path))
 
     # Check library imports
-    needs_to_be_installed = []
+    needs_to_be_installed = set()
     for library_import_name, library_import_path in library_imports:
         try:
             lib = importlib.import_module(library_import_name)  # noqa F841
         except ImportError:
-            needs_to_be_installed.append((library_import_name, library_import_path))
+            needs_to_be_installed.add((library_import_name, library_import_path))
     if needs_to_be_installed:
         raise ImportError(
             f"To be able to use {name}, you need to install the following dependencies"


### PR DESCRIPTION
Currently, when you load a metric that loads the same metric twice, e.g., [chrF](https://huggingface.co/spaces/evaluate-metric/chrf/blob/main/chrf.py#L16-L18), the error message for the missing library will mention that library multiple times. For instance:

> `ImportError`: To be able to use evaluate-metric/chrf, you need to install the following dependencies['sacrebleu', 'sacrebleu'] using 'pip install sacrebleu sacrebleu' for instance'

This PR simply changes the tracked import errors with a set rather than a list so that **unique** missing libraries are collected.