### PR TITLE
Clarify error message for ChrF no. references

### DIFF
--- a/metrics/chrf/chrf.py
+++ b/metrics/chrf/chrf.py
@@ -170,11 +170,11 @@ class ChrF(evaluate.Metric):
         # if only one reference is provided make sure we still use list of lists
         if isinstance(references[0], str):
             references = [[ref] for ref in references]
-
         references_per_prediction = len(references[0])
         if any(len(refs) != references_per_prediction for refs in references):
-            raise ValueError("ChrF, as implemented by sacrebleu, requires the same number of references for"
-                             " each prediction")
+            raise ValueError(
+                "ChrF, as implemented by sacrebleu, requires the same number of references for each prediction"
+            )
         transformed_references = [[refs[i] for refs in references] for i in range(references_per_prediction)]
 
         sb_chrf = CHRF(char_order, word_order, beta, lowercase, whitespace, eps_smoothing)

--- a/metrics/chrf/chrf.py
+++ b/metrics/chrf/chrf.py
@@ -173,7 +173,8 @@ class ChrF(evaluate.Metric):
 
         references_per_prediction = len(references[0])
         if any(len(refs) != references_per_prediction for refs in references):
-            raise ValueError("ChrF, as implemented by sacrebleu, requires the same number of references for each prediction")
+            raise ValueError("ChrF, as implemented by sacrebleu, requires the same number of references for"
+                             " each prediction")
         transformed_references = [[refs[i] for refs in references] for i in range(references_per_prediction)]
 
         sb_chrf = CHRF(char_order, word_order, beta, lowercase, whitespace, eps_smoothing)

--- a/metrics/chrf/chrf.py
+++ b/metrics/chrf/chrf.py
@@ -173,7 +173,7 @@ class ChrF(evaluate.Metric):
 
         references_per_prediction = len(references[0])
         if any(len(refs) != references_per_prediction for refs in references):
-            raise ValueError("Sacrebleu requires the same number of references for each prediction")
+            raise ValueError("ChrF, as implemented by sacrebleu, requires the same number of references for each prediction")
         transformed_references = [[refs[i] for refs in references] for i in range(references_per_prediction)]
 
         sb_chrf = CHRF(char_order, word_order, beta, lowercase, whitespace, eps_smoothing)


### PR DESCRIPTION
Currently, when you give a different number of references and hypotheses to chrf, you get this error:

> Sacrebleu requires the same number of references for each prediction

When you are only calculate chrf, it is clear that the error comes from calculating chrf. But if you do something like

```python
evaluate.combine(["chrf", "bleu"])
```

it takes a moment to realize that chrf is causing the error and not bleu. Clarifying/reminding the user that chrf is implemented through sacrebleu can help.