### PR TITLE
fix bug in TEMPLATE_REQUIRE: add comma

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ REQUIRED_PKGS = [
 
 TEMPLATE_REQUIRE = [
     # to populate metric template
-    "cookiecutter"
+    "cookiecutter",
     # for the gradio widget
     "gradio>=3.0.0"
 ]


### PR DESCRIPTION
Small but important bug in the setup file. There was no comma between `cookiecutter` and `gradio` so pip tried to resolve it as `cookiecuttergradio>=3.0.0`.

closes https://github.com/huggingface/evaluate/issues/249