### PR TITLE
change default pkgs/main channel for conda WIN CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,8 @@ jobs:
             - run: |
                 conda init powershell
                 conda update conda
+                conda config --remove channels defaults
+                conda config --add channels https://repo.continuum.io/pkgs/main/
                 conda create -n py37 python=3.7 pytorch --yes
             - run: |
                 conda activate py37


### PR DESCRIPTION
This should fix the failing conda CI. Still don't know what causes it though.