### PR TITLE
Adding regard measurement

### DIFF
--- a/measurements/regard/README.md
+++ b/measurements/regard/README.md
@@ -35,7 +35,7 @@ This measurement requires two lists of strings as input, enabling comparing the 
 
 ### Inputs
 - **data** (list of `str`): prediction/candidate sentences, e.g. sentences describing a given demographic group.
-- **references** (list of `str`): reference/comparison sentences, e.g. sentences describing a different demographic group to compare against.
+- **references** (list of `str`) (optional): reference/comparison sentences, e.g. sentences describing a different demographic group to compare against.
 - **aggregation** (`str`) (optional): determines the type of aggregation performed.
     If set to `None`, the difference between the regard scores for the two categories is returned.
      Otherwise:
@@ -44,10 +44,29 @@ This measurement requires two lists of strings as input, enabling comparing the 
 
 ### Output Values
 
+**With a single input**:
+
+`regard` : the regard scores of each string in the input list (if no aggregation is specified)
+```python
+{'neutral': 0.95, 'positive': 0.02, 'negative': 0.02, 'other': 0.01}
+{'negative': 0.97, 'other': 0.02, 'neutral': 0.01, 'positive': 0.0}
+```
+
+`average_regard`: the average regard for each category (negative, positive, neutral, other)  (if `aggregation` = `average`)
+```python
+{'neutral': 0.48, 'positive': 0.01, 'negative': 0.5, 'other': 0.01}
+```
+
+`max_regard`: the maximum regard across all input strings (if `aggregation` = `maximum`)
+```python
+{'neutral': 0.95, 'positive': 0.024, 'negative': 0.972, 'other': 0.019}
+```
+
+**With two lists of inputs**:
+
 By default, this measurement outputs a dictionary containing a list of regard scores, one for each category (negative, positive, neutral, other), representing the difference in regard between the two groups.
 
-```
->>> print({k: round(v, 2) for k, v in results['regard_difference'].items()})
+```python
 {'neutral': 0.35, 'negative': -0.36, 'other': 0.01, 'positive': 0.01}
 ```
 
@@ -65,10 +84,21 @@ With the `aggregation='average'` option, this measurement will output the averag
 
 ### Examples
 
-Example 1 (default behavior):
+Example 1 (single input):
 
 ```python
->>> regard = evaluate.load("regard", module_type="measurement")
+>>> regard = evaluate.load("regard")
+>>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
+>>> results = regard.compute(data = group1)
+>>> for d in results['regard']:
+...     print({l['label']: round(l['score'],2) for l in d})
+{'neutral': 0.95, 'positive': 0.02, 'negative': 0.02, 'other': 0.01}
+{'negative': 0.97, 'other': 0.02, 'neutral': 0.01, 'positive': 0.0}
+```
+
+Example 2 (comparison mode):
+```python
+>>> regard = evaluate.load("regard", "compare")
 >>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
 >>> group2 = ['xyz are known for making too much noise', 'xyz are described as often violent']
 >>> results = regard.compute(data = group1, references = group2)
@@ -76,21 +106,23 @@ Example 1 (default behavior):
 {'neutral': 0.46, 'positive': 0.01, 'negative': -0.46, 'other': -0.01}
 ```
 
-Example 2 (returns the maximum toxicity score):
+Example 3 (returns the maximum toxicity score):
 ```python
->>> regard = evaluate.load("regard", module_type="measurement")
->>> group1 = ['the girls were mean', 'women are too ambitious']
->>> group2 = ['boys make too much noise', 'men are often violent']
+>>> regard = evaluate.load("regard", "compare")
+>>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
+>>> group2 = ['xyz are known for making too much noise', 'xyz are described as often violent']
 >>> results = regard.compute(data = group1, references = group2, aggregation = "maximum")
->>> print({k: round(v,3) for k,v in results.items()})
-{'max_predictions_regard': 0.972, 'max_references_regard': 0.979}
+>>> print({k: round(v, 2) for k, v in results['max_data_regard'].items()})
+{'neutral': 0.95, 'positive': 0.02, 'negative': 0.97, 'other': 0.02}
+>>> print({k: round(v, 2) for k, v in results['max_references_regard'].items()})
+{'negative': 0.98, 'other': 0.04, 'neutral': 0.03, 'positive': 0.0}
 ```
 
-Example 3 (returns the average toxicity score):
+Example 4 (returns the average toxicity score):
 ```python
->>> regard = evaluate.load("regard", module_type="measurement")
->>> group1 = ['the girls were mean', 'women are too ambitious']
->>> group2 = ['boys make too much noise', 'men are often violent']
+>>> regard = evaluate.load("regard", "compare")
+>>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
+>>> group2 = ['xyz are known for making too much noise', 'xyz are described as often violent']
 >>> results = regard.compute(data = group1, references = group2, aggregation = "average")
 >>> print({k: round(v, 2) for k, v in results['average_data_regard'].items()})
 {'neutral': 0.48, 'positive': 0.01, 'negative': 0.5, 'other': 0.01}

--- a/measurements/regard/README.md
+++ b/measurements/regard/README.md
@@ -47,21 +47,20 @@ This measurement requires two lists of strings as input, enabling comparing the 
 By default, this measurement outputs a dictionary containing a list of regard scores, one for each category (negative, positive, neutral, other), representing the difference in regard between the two groups.
 
 ```
-{'regard_difference': {'neutral': 0.3451282191090286, 'negative': -0.36345648765563965, 'other': 0.010959412436932325, 'positive': 0.007368835678789765}}
+>>> print({k: round(v, 2) for k, v in results['regard_difference'].items()})
+{'neutral': 0.35, 'negative': -0.36, 'other': 0.01, 'positive': 0.01}
 ```
 
 With the `aggregation='maximum'` option, this measurement will output the maximum regard for each group:
 
 ```python
-{'max_data_regard': ('negative', 0.9497271180152893),
- 'max_references_regard': ('negative', 0.9757490158081055)}
+{'max_data_regard': 0.95, 'max_references_regard': 0.976}
 ```
 
 With the `aggregation='average'` option, this measurement will output the average regard for each category (negative, positive, neutral, other):
 
 ```python
-{'average_data_regard': {'neutral': 0.37027092883363366, 'negative': 0.5723073482513428, 'other': 0.04902498237788677, 'positive': 0.008396731078391895},
-'average_references_regard': {'negative': 0.9357638359069824, 'other': 0.03806556994095445, 'neutral': 0.025142709724605083, 'positive': 0.00102789539960213}}
+{'neutral': 0.37, 'negative': 0.57, 'other': 0.05, 'positive': 0.01}
 ```
 
 ### Examples
@@ -73,8 +72,8 @@ Example 1 (default behavior):
 >>> group1 = ['the girls were mean', 'women are too ambitious']
 >>> group2 = ['boys make too much noise', 'men are often violent']
 >>> results = regard.compute(data = group1, references = group2)
->>> print(results)
-{'regard_difference': {'neutral': 0.3451282191090286, 'negative': -0.36345648765563965, 'other': 0.010959412436932325, 'positive': 0.007368835678789765}}
+>>> print({k: round(v, 2) for k, v in results['regard_difference'].items()})
+{'neutral': 0.35, 'negative': -0.36, 'other': 0.01, 'positive': 0.01}
 ```
 
 Example 2 (returns the maximum toxicity score):
@@ -83,8 +82,8 @@ Example 2 (returns the maximum toxicity score):
 >>> group1 = ['the girls were mean', 'women are too ambitious']
 >>> group2 = ['boys make too much noise', 'men are often violent']
 >>> results = regard.compute(data = group1, references = group2, aggregation = "maximum")
->>> print(results)
-{'max_regard': {'negative': 0.6691194772720337, 'positive': 0.02632979303598404, 'neutral': 0.942646861076355, 'other': 0.22687028348445892}}
+>>> print({k: round(v,3) for k,v in results.items()})
+{'max_predictions_regard': 0.95, 'max_references_regard': 0.976}
 ```
 
 Example 3 (returns the average toxicity score):
@@ -93,9 +92,10 @@ Example 3 (returns the average toxicity score):
 >>> group1 = ['the girls were mean', 'women are too ambitious']
 >>> group2 = ['boys make too much noise', 'men are often violent']
 >>> results = regard.compute(data = group1, references = group2, aggregation = "average")
->>> print(results)
-{'average_data_regard': {'neutral': 0.9492073953151703, 'positive': 0.033664701506495476, 'negative': 0.0111181172542274, 'other': 0.006009730044752359}, 'average_references_regard': {'negative': 0.9357638359069824, 'other': 0.03806556994095445, 'neutral': 0.025142709724605083, 'positive': 0.00102789539960213}}
-
+>>> print({k: round(v, 2) for k, v in results['average_data_regard'].items()})
+{'neutral': 0.37, 'negative': 0.57, 'other': 0.05, 'positive': 0.01}
+>>> print({k: round(v, 2) for k, v in results['average_references_regard'].items()})
+{'negative': 0.94, 'other': 0.04, 'neutral': 0.03, 'positive': 0.0}
 ```
 
 ## Citation(s)

--- a/measurements/regard/README.md
+++ b/measurements/regard/README.md
@@ -16,6 +16,7 @@ Regard aims to measure language polarity towards and social perceptions of a dem
 
 # Measurement Card for Regard
 
+
 ## Measurement Description
 
 The `regard` measurement returns the estimated language polarity towards and social perceptions of a demographic (e.g. gender, race, sexual orientation).

--- a/measurements/regard/README.md
+++ b/measurements/regard/README.md
@@ -90,7 +90,7 @@ Example 2 (returns the maximum toxicity score):
 Example 3 (returns the average toxicity score):
 ```python
 >>> regard = evaluate.load("regard", module_type="measurement")
->>> group1 =  group1 = ['the girls are smart', 'the women are impressive']
+>>> group1 = ['the girls were mean', 'women are too ambitious']
 >>> group2 = ['boys make too much noise', 'men are often violent']
 >>> results = regard.compute(predictions = group1, references = group2, aggregation = "average")
 >>> print(results)

--- a/measurements/regard/README.md
+++ b/measurements/regard/README.md
@@ -44,7 +44,7 @@ This measurement requires a list of strings as input:
 
 By default, this measurement outputs a dictionary containing a list of regard scores, one for each sentence in `predictions`
 
-```python
+```
 {'regard': [[{'label': 'negative', 'score': 0.6691194772720337}, {'label': 'other', 'score': 0.22687028348445892}, {'label': 'neutral', 'score': 0.0852026417851448}, {'label': 'positive', 'score': 0.018807603046298027}], [{'label': 'neutral', 'score': 0.942646861076355}, {'label': 'positive', 'score': 0.02632979303598404}, {'label': 'negative', 'score': 0.020616641268134117}, {'label': 'other', 'score': 0.010406642220914364}]]}
 ```
 

--- a/measurements/regard/README.md
+++ b/measurements/regard/README.md
@@ -69,11 +69,11 @@ Example 1 (default behavior):
 
 ```python
 >>> regard = evaluate.load("regard", module_type="measurement")
->>> group1 = ['the girls were mean', 'women are too ambitious']
->>> group2 = ['boys make too much noise', 'men are often violent']
+>>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
+>>> group2 = ['xyz are known for making too much noise', 'xyz are described as often violent']
 >>> results = regard.compute(data = group1, references = group2)
 >>> print({k: round(v, 2) for k, v in results['regard_difference'].items()})
-{'neutral': 0.35, 'negative': -0.36, 'other': 0.01, 'positive': 0.01}
+{'neutral': 0.46, 'positive': 0.01, 'negative': -0.46, 'other': -0.01}
 ```
 
 Example 2 (returns the maximum toxicity score):
@@ -83,7 +83,7 @@ Example 2 (returns the maximum toxicity score):
 >>> group2 = ['boys make too much noise', 'men are often violent']
 >>> results = regard.compute(data = group1, references = group2, aggregation = "maximum")
 >>> print({k: round(v,3) for k,v in results.items()})
-{'max_predictions_regard': 0.95, 'max_references_regard': 0.976}
+{'max_predictions_regard': 0.972, 'max_references_regard': 0.979}
 ```
 
 Example 3 (returns the average toxicity score):
@@ -93,9 +93,9 @@ Example 3 (returns the average toxicity score):
 >>> group2 = ['boys make too much noise', 'men are often violent']
 >>> results = regard.compute(data = group1, references = group2, aggregation = "average")
 >>> print({k: round(v, 2) for k, v in results['average_data_regard'].items()})
-{'neutral': 0.37, 'negative': 0.57, 'other': 0.05, 'positive': 0.01}
+{'neutral': 0.48, 'positive': 0.01, 'negative': 0.5, 'other': 0.01}
 >>> print({k: round(v, 2) for k, v in results['average_references_regard'].items()})
-{'negative': 0.94, 'other': 0.04, 'neutral': 0.03, 'positive': 0.0}
+{'negative': 0.96, 'other': 0.02, 'neutral': 0.02, 'positive': 0.0}
 ```
 
 ## Citation(s)

--- a/measurements/regard/README.md
+++ b/measurements/regard/README.md
@@ -28,8 +28,8 @@ This measurement requires two lists of strings as input, enabling comparing the 
 
 ```python
 >>> regard = evaluate.load("regard", module_type="measurement")
->>> group1 = ['the girls were mean', 'women are too ambitious']
->>> group2 = ['boys make too much noise', 'men are often violent']
+>>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
+>>> group2 = ['xyz are known for making too much noise', 'xyz are described as often violent']
 >>> regard.compute(data = group1, references = group2)
 ```
 
@@ -73,7 +73,7 @@ By default, this measurement outputs a dictionary containing a list of regard sc
 With the `aggregation='maximum'` option, this measurement will output the maximum regard for each group:
 
 ```python
-{'max_data_regard': 0.95, 'max_references_regard': 0.976}
+{'negative': 0.98, 'other': 0.04, 'neutral': 0.03, 'positive': 0.0}
 ```
 
 With the `aggregation='average'` option, this measurement will output the average regard for each category (negative, positive, neutral, other):
@@ -106,7 +106,7 @@ Example 2 (comparison mode):
 {'neutral': 0.46, 'positive': 0.01, 'negative': -0.46, 'other': -0.01}
 ```
 
-Example 3 (returns the maximum toxicity score):
+Example 3 (returns the maximum regard score):
 ```python
 >>> regard = evaluate.load("regard", "compare")
 >>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
@@ -118,7 +118,7 @@ Example 3 (returns the maximum toxicity score):
 {'negative': 0.98, 'other': 0.04, 'neutral': 0.03, 'positive': 0.0}
 ```
 
-Example 4 (returns the average toxicity score):
+Example 4 (returns the average regard score):
 ```python
 >>> regard = evaluate.load("regard", "compare")
 >>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']

--- a/measurements/regard/README.md
+++ b/measurements/regard/README.md
@@ -24,40 +24,44 @@ It uses a model trained on labelled data from the paper ["The Woman Worked as a 
 
 ## How to Use
 
-This measurement requires a list of strings as input:
+This measurement requires two lists of strings as input, enabling comparing the estimated polarity between the groups.
 
 ```python
 >>> regard = evaluate.load("regard", module_type="measurement")
->>> input_texts = ["these girls are silly", "these boys are lost"]
->>> results = regard.compute(predictions=input_texts)
+>>> group1 = ['the girls were mean', 'women are too ambitious']
+>>> group2 = ['boys make too much noise', 'men are often violent']
+>>> regard.compute(predictions = group1, references = group2)
 ```
 
 ### Inputs
-- **predictions** (list of `str`): A list of prediction/candidate sentences
-- **aggregation** (`str`) (optional): determines the type of aggregation performed on the data.
-    If set to `None`, the scores for each sentences are returned.
+- **predictions** (list of `str`): prediction/candidate sentences, e.g. sentences describing a given demographic group.
+- **references** (list of `str`): reference/comparison sentences, e.g. sentences describing a different demographic group to compare against.
+- **aggregation** (`str`) (optional): determines the type of aggregation performed.
+    If set to `None`, the difference between the regard scores for the two categories is returned.
      Otherwise:
-        - `average` : returns the average regard for each category (negative, positive, neutral, other)
-        - `maximum`: returns the maximum regard for each category
+        - `average` : returns the average regard for each category (negative, positive, neutral, other) for each group
+        - `maximum`: returns the maximum regard for each group
 
 ### Output Values
 
-By default, this measurement outputs a dictionary containing a list of regard scores, one for each sentence in `predictions`
+By default, this measurement outputs a dictionary containing a list of regard scores, one for each category (negative, positive, neutral, other), representing the difference in regard between the two groups.
 
 ```
-{'regard': [[{'label': 'negative', 'score': 0.6691194772720337}, {'label': 'other', 'score': 0.22687028348445892}, {'label': 'neutral', 'score': 0.0852026417851448}, {'label': 'positive', 'score': 0.018807603046298027}], [{'label': 'neutral', 'score': 0.942646861076355}, {'label': 'positive', 'score': 0.02632979303598404}, {'label': 'negative', 'score': 0.020616641268134117}, {'label': 'other', 'score': 0.010406642220914364}]]}
+{'regard_difference': {'neutral': 0.3451282191090286, 'negative': -0.36345648765563965, 'other': 0.010959412436932325, 'positive': 0.007368835678789765}}
 ```
 
-With the `aggregation='maximum'` option, this measurement will output the maximum regard for each category (negative, positive, neutral, other):
+With the `aggregation='maximum'` option, this measurement will output the maximum regard for each group:
 
 ```python
-{'max_regard': {'negative': 0.6691194772720337, 'positive': 0.02632979303598404, 'neutral': 0.942646861076355, 'other': 0.22687028348445892}}
+{'max_predictions_regard': ('negative', 0.9497271180152893),
+ 'max_references_regard': ('negative', 0.9757490158081055)}
 ```
 
 With the `aggregation='average'` option, this measurement will output the average regard for each category (negative, positive, neutral, other):
 
 ```python
-{'average_regard': {'negative': 0.3448680592700839, 'positive': 0.022568698041141033, 'neutral': 0.5139247514307499, 'other': 0.11863846285268664}}
+{'average_predictions_regard': {'neutral': 0.37027092883363366, 'negative': 0.5723073482513428, 'other': 0.04902498237788677, 'positive': 0.008396731078391895},
+'average_references_regard': {'negative': 0.9357638359069824, 'other': 0.03806556994095445, 'neutral': 0.025142709724605083, 'positive': 0.00102789539960213}}
 ```
 
 ### Examples
@@ -66,17 +70,19 @@ Example 1 (default behavior):
 
 ```python
 >>> regard = evaluate.load("regard", module_type="measurement")
->>> input_texts = ["these girls are silly", "these boys are lost"]
->>> results = regard.compute(predictions=input_texts)
+>>> group1 = ['the girls were mean', 'women are too ambitious']
+>>> group2 = ['boys make too much noise', 'men are often violent']
+>>> results = regard.compute(predictions = group1, references = group2)
 >>> print(results)
-{'regard': [[{'label': 'negative', 'score': 0.6691194772720337}, {'label': 'other', 'score': 0.22687028348445892}, {'label': 'neutral', 'score': 0.0852026417851448}, {'label': 'positive', 'score': 0.018807603046298027}], [{'label': 'neutral', 'score': 0.942646861076355}, {'label': 'positive', 'score': 0.02632979303598404}, {'label': 'negative', 'score': 0.020616641268134117}, {'label': 'other', 'score': 0.010406642220914364}]]}
+{'regard_difference': {'neutral': 0.3451282191090286, 'negative': -0.36345648765563965, 'other': 0.010959412436932325, 'positive': 0.007368835678789765}}
 ```
 
 Example 2 (returns the maximum toxicity score):
 ```python
 >>> regard = evaluate.load("regard", module_type="measurement")
->>> input_texts = ["these girls are silly", "these boys are lost"]
->>> results = toxicity.compute(predictions=input_texts, aggregation = "maximum")
+>>> group1 = ['the girls were mean', 'women are too ambitious']
+>>> group2 = ['boys make too much noise', 'men are often violent']
+>>> results = regard.compute(predictions = group1, references = group2, aggregation = "maximum")
 >>> print(results)
 {'max_regard': {'negative': 0.6691194772720337, 'positive': 0.02632979303598404, 'neutral': 0.942646861076355, 'other': 0.22687028348445892}}
 ```
@@ -84,10 +90,12 @@ Example 2 (returns the maximum toxicity score):
 Example 3 (returns the average toxicity score):
 ```python
 >>> regard = evaluate.load("regard", module_type="measurement")
->>> input_texts = ["these girls are silly", "these boys are lost"]
->>> results = toxicity.compute(predictions=input_texts, aggregation = "average")
+>>> group1 =  group1 = ['the girls are smart', 'the women are impressive']
+>>> group2 = ['boys make too much noise', 'men are often violent']
+>>> results = regard.compute(predictions = group1, references = group2, aggregation = "average")
 >>> print(results)
-{'average_regard': {'negative': 0.3448680592700839, 'positive': 0.022568698041141033, 'neutral': 0.5139247514307499, 'other': 0.11863846285268664}}
+{'average_predictions_regard': {'neutral': 0.9492073953151703, 'positive': 0.033664701506495476, 'negative': 0.0111181172542274, 'other': 0.006009730044752359}, 'average_references_regard': {'negative': 0.9357638359069824, 'other': 0.03806556994095445, 'neutral': 0.025142709724605083, 'positive': 0.00102789539960213}}
+
 ```
 
 ## Citation(s)

--- a/measurements/regard/README.md
+++ b/measurements/regard/README.md
@@ -30,11 +30,11 @@ This measurement requires two lists of strings as input, enabling comparing the 
 >>> regard = evaluate.load("regard", module_type="measurement")
 >>> group1 = ['the girls were mean', 'women are too ambitious']
 >>> group2 = ['boys make too much noise', 'men are often violent']
->>> regard.compute(predictions = group1, references = group2)
+>>> regard.compute(data = group1, references = group2)
 ```
 
 ### Inputs
-- **predictions** (list of `str`): prediction/candidate sentences, e.g. sentences describing a given demographic group.
+- **data** (list of `str`): prediction/candidate sentences, e.g. sentences describing a given demographic group.
 - **references** (list of `str`): reference/comparison sentences, e.g. sentences describing a different demographic group to compare against.
 - **aggregation** (`str`) (optional): determines the type of aggregation performed.
     If set to `None`, the difference between the regard scores for the two categories is returned.
@@ -53,14 +53,14 @@ By default, this measurement outputs a dictionary containing a list of regard sc
 With the `aggregation='maximum'` option, this measurement will output the maximum regard for each group:
 
 ```python
-{'max_predictions_regard': ('negative', 0.9497271180152893),
+{'max_data_regard': ('negative', 0.9497271180152893),
  'max_references_regard': ('negative', 0.9757490158081055)}
 ```
 
 With the `aggregation='average'` option, this measurement will output the average regard for each category (negative, positive, neutral, other):
 
 ```python
-{'average_predictions_regard': {'neutral': 0.37027092883363366, 'negative': 0.5723073482513428, 'other': 0.04902498237788677, 'positive': 0.008396731078391895},
+{'average_data_regard': {'neutral': 0.37027092883363366, 'negative': 0.5723073482513428, 'other': 0.04902498237788677, 'positive': 0.008396731078391895},
 'average_references_regard': {'negative': 0.9357638359069824, 'other': 0.03806556994095445, 'neutral': 0.025142709724605083, 'positive': 0.00102789539960213}}
 ```
 
@@ -72,7 +72,7 @@ Example 1 (default behavior):
 >>> regard = evaluate.load("regard", module_type="measurement")
 >>> group1 = ['the girls were mean', 'women are too ambitious']
 >>> group2 = ['boys make too much noise', 'men are often violent']
->>> results = regard.compute(predictions = group1, references = group2)
+>>> results = regard.compute(data = group1, references = group2)
 >>> print(results)
 {'regard_difference': {'neutral': 0.3451282191090286, 'negative': -0.36345648765563965, 'other': 0.010959412436932325, 'positive': 0.007368835678789765}}
 ```
@@ -82,7 +82,7 @@ Example 2 (returns the maximum toxicity score):
 >>> regard = evaluate.load("regard", module_type="measurement")
 >>> group1 = ['the girls were mean', 'women are too ambitious']
 >>> group2 = ['boys make too much noise', 'men are often violent']
->>> results = regard.compute(predictions = group1, references = group2, aggregation = "maximum")
+>>> results = regard.compute(data = group1, references = group2, aggregation = "maximum")
 >>> print(results)
 {'max_regard': {'negative': 0.6691194772720337, 'positive': 0.02632979303598404, 'neutral': 0.942646861076355, 'other': 0.22687028348445892}}
 ```
@@ -92,9 +92,9 @@ Example 3 (returns the average toxicity score):
 >>> regard = evaluate.load("regard", module_type="measurement")
 >>> group1 = ['the girls were mean', 'women are too ambitious']
 >>> group2 = ['boys make too much noise', 'men are often violent']
->>> results = regard.compute(predictions = group1, references = group2, aggregation = "average")
+>>> results = regard.compute(data = group1, references = group2, aggregation = "average")
 >>> print(results)
-{'average_predictions_regard': {'neutral': 0.9492073953151703, 'positive': 0.033664701506495476, 'negative': 0.0111181172542274, 'other': 0.006009730044752359}, 'average_references_regard': {'negative': 0.9357638359069824, 'other': 0.03806556994095445, 'neutral': 0.025142709724605083, 'positive': 0.00102789539960213}}
+{'average_data_regard': {'neutral': 0.9492073953151703, 'positive': 0.033664701506495476, 'negative': 0.0111181172542274, 'other': 0.006009730044752359}, 'average_references_regard': {'negative': 0.9357638359069824, 'other': 0.03806556994095445, 'neutral': 0.025142709724605083, 'positive': 0.00102789539960213}}
 
 ```
 

--- a/measurements/regard/README.md
+++ b/measurements/regard/README.md
@@ -1,0 +1,105 @@
+---
+title: Regard
+emoji: 🤗
+colorFrom: green
+colorTo: purple
+sdk: gradio
+sdk_version: 3.0.2
+app_file: app.py
+pinned: false
+tags:
+- evaluate
+- measurement
+description: >-
+Regard aims to measure language polarity towards and social perceptions of a demographic (e.g. gender, race, sexual orientation).
+---
+
+# Measurement Card for Regard
+
+## Measurement Description
+
+The `regard` measurement returns the estimated language polarity towards and social perceptions of a demographic (e.g. gender, race, sexual orientation).
+
+It uses a model trained on labelled data from the paper ["The Woman Worked as a Babysitter: On Biases in Language Generation" (EMNLP 2019)](https://arxiv.org/abs/1909.01326)
+
+## How to Use
+
+This measurement requires a list of strings as input:
+
+```python
+>>> regard = evaluate.load("regard", module_type="measurement")
+>>> input_texts = ["these girls are silly", "these boys are lost"]
+>>> results = regard.compute(predictions=input_texts)
+```
+
+### Inputs
+- **predictions** (list of `str`): A list of prediction/candidate sentences
+- **aggregation** (`str`) (optional): determines the type of aggregation performed on the data.
+    If set to `None`, the scores for each sentences are returned.
+     Otherwise:
+        - `average` : returns the average regard for each category (negative, positive, neutral, other)
+        - `maximum`: returns the maximum regard for each category
+
+### Output Values
+
+By default, this measurement outputs a dictionary containing a list of regard scores, one for each sentence in `predictions`
+
+```python
+{'regard': [[{'label': 'negative', 'score': 0.6691194772720337}, {'label': 'other', 'score': 0.22687028348445892}, {'label': 'neutral', 'score': 0.0852026417851448}, {'label': 'positive', 'score': 0.018807603046298027}], [{'label': 'neutral', 'score': 0.942646861076355}, {'label': 'positive', 'score': 0.02632979303598404}, {'label': 'negative', 'score': 0.020616641268134117}, {'label': 'other', 'score': 0.010406642220914364}]]}
+```
+
+With the `aggregation='maximum'` option, this measurement will output the maximum regard for each category (negative, positive, neutral, other):
+
+```python
+{'max_regard': {'negative': 0.6691194772720337, 'positive': 0.02632979303598404, 'neutral': 0.942646861076355, 'other': 0.22687028348445892}}
+```
+
+With the `aggregation='average'` option, this measurement will output the average regard for each category (negative, positive, neutral, other):
+
+```python
+{'average_regard': {'negative': 0.3448680592700839, 'positive': 0.022568698041141033, 'neutral': 0.5139247514307499, 'other': 0.11863846285268664}}
+```
+
+### Examples
+
+Example 1 (default behavior):
+
+```python
+>>> regard = evaluate.load("regard", module_type="measurement")
+>>> input_texts = ["these girls are silly", "these boys are lost"]
+>>> results = regard.compute(predictions=input_texts)
+>>> print(results)
+{'regard': [[{'label': 'negative', 'score': 0.6691194772720337}, {'label': 'other', 'score': 0.22687028348445892}, {'label': 'neutral', 'score': 0.0852026417851448}, {'label': 'positive', 'score': 0.018807603046298027}], [{'label': 'neutral', 'score': 0.942646861076355}, {'label': 'positive', 'score': 0.02632979303598404}, {'label': 'negative', 'score': 0.020616641268134117}, {'label': 'other', 'score': 0.010406642220914364}]]}
+```
+
+Example 2 (returns the maximum toxicity score):
+```python
+>>> regard = evaluate.load("regard", module_type="measurement")
+>>> input_texts = ["these girls are silly", "these boys are lost"]
+>>> results = toxicity.compute(predictions=input_texts, aggregation = "maximum")
+>>> print(results)
+{'max_regard': {'negative': 0.6691194772720337, 'positive': 0.02632979303598404, 'neutral': 0.942646861076355, 'other': 0.22687028348445892}}
+```
+
+Example 3 (returns the average toxicity score):
+```python
+>>> regard = evaluate.load("regard", module_type="measurement")
+>>> input_texts = ["these girls are silly", "these boys are lost"]
+>>> results = toxicity.compute(predictions=input_texts, aggregation = "average")
+>>> print(results)
+{'average_regard': {'negative': 0.3448680592700839, 'positive': 0.022568698041141033, 'neutral': 0.5139247514307499, 'other': 0.11863846285268664}}
+```
+
+## Citation(s)
+@article{https://doi.org/10.48550/arxiv.1909.01326,
+  doi = {10.48550/ARXIV.1909.01326},
+  url = {https://arxiv.org/abs/1909.01326},
+  author = {Sheng, Emily and Chang, Kai-Wei and Natarajan, Premkumar and Peng, Nanyun},
+  title = {The Woman Worked as a Babysitter: On Biases in Language Generation},
+  publisher = {arXiv},
+  year = {2019}
+}
+
+
+## Further References
+- [`nlg-bias` library](https://github.com/ewsheng/nlg-bias/)

--- a/measurements/regard/app.py
+++ b/measurements/regard/app.py
@@ -1,0 +1,6 @@
+import evaluate
+from evaluate.utils import launch_gradio_widget
+
+
+module = evaluate.load("regard")
+launch_gradio_widget(module)

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -138,11 +138,8 @@ class Regard(evaluate.Measurement):
         aggregation=None,
     ):
         pred_regard, ref_regard = regard(data, references, self.regard_classifier)
-        pred_average, ref_average = {}, {}
-        for k, v in pred_regard.items():
-            pred_average[k] = mean(v)
-        for k, v in ref_regard.items():
-            ref_average[k] = mean(v)
+        pred_mean = {k: mean(v) for  k, v in pred_regard.items()}
+        ref_mean = {k: mean(v) for  k, v in ref_regard.items()}
         if aggregation == "maximum":
             return {
                 "max_predictions_regard": max([max(v) for v in pred_regard.values()]),

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -95,7 +95,7 @@ def regard(preds, regard_classifier):
             elif s["label"] == "positive":
                 pos_scores.append(s["score"])
             elif s["label"] == "neutral":
-                neut_scores.append(s["score"])
+                neutral_scores.append(s["score"])
             else:
                 other_scores.append(s["score"])
         regard_scores["negative"] = neg_scores

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -118,14 +118,8 @@ def regard(group, regard_classifier):
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Regard(evaluate.Measurement):
     def _info(self):
-    if self.config_name not in [
-            "compare",
-            "default"
-        ]:
-            raise KeyError(
-                "You should supply a configuration name selected in "
-                '["config", "default"]'
-            )
+        if self.config_name not in ["compare", "default"]:
+            raise KeyError("You should supply a configuration name selected in " '["config", "default"]')
         return evaluate.MeasurementInfo(
             module_type="measurement",
             description=_DESCRIPTION,

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -1,0 +1,147 @@
+# Copyright 2020 The HuggingFace Evaluate Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Regard measurement. """
+
+import datasets
+from transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline
+
+import evaluate
+from statistics import mean
+
+logger = evaluate.logging.get_logger(__name__)
+
+
+_CITATION = """
+@article{https://doi.org/10.48550/arxiv.1909.01326,
+  doi = {10.48550/ARXIV.1909.01326},
+  url = {https://arxiv.org/abs/1909.01326},
+  author = {Sheng, Emily and Chang, Kai-Wei and Natarajan, Premkumar and Peng, Nanyun},
+  title = {The Woman Worked as a Babysitter: On Biases in Language Generation},
+  publisher = {arXiv},
+  year = {2019}
+}
+
+"""
+
+_DESCRIPTION = """\
+Regard aims to measure language polarity towards and social perceptions of a demographic (e.g. gender, race, sexual orientation).
+"""
+
+_KWARGS_DESCRIPTION = """
+Compute the regard of the input sentences.
+
+Args:
+    `predictions` (list of str): prediction/candidate sentences
+    `aggregation` (str) (optional): determines the type of aggregation performed on the data.
+    If set to `None`, the scores for each sentences are returned.
+     Otherwise:
+        - 'average' : returns the average regard for each category (negative, positive, neutral, other)
+        - 'maximum': returns the maximum regard for each category
+
+Returns:
+    `regard`: a list of regard scores, one for each sentence in `predictions` (default behavior)
+    `average_regard`: the average regard for each category (negative, positive, neutral, other)  (if `aggregation` = `average`)
+    `max_regard`: the maximum regard for each category  (if `aggregation` = `maximum`)
+
+Examples:
+    Example 1 (default behavior):
+    >>> regard = evaluate.load("regard", module_type="measurement")
+    >>> input_texts = ["these girls are silly", "these boys are lost"]
+    >>> results = regard.compute(predictions=input_texts)
+    >>> print(results)
+    {'regard': [[{'label': 'negative', 'score': 0.6691194772720337}, {'label': 'other', 'score': 0.22687028348445892}, {'label': 'neutral', 'score': 0.0852026417851448}, {'label': 'positive', 'score': 0.018807603046298027}], [{'label': 'neutral', 'score': 0.942646861076355}, {'label': 'positive', 'score': 0.02632979303598404}, {'label': 'negative', 'score': 0.020616641268134117}, {'label': 'other', 'score': 0.010406642220914364}]]}
+Example 2 (returns the maximum toxicity score):
+    >>> regard = evaluate.load("regard", module_type="measurement")
+    >>> input_texts = ["these girls are silly", "these boys are lost"]
+    >>> results = toxicity.compute(predictions=input_texts, aggregation = "maximum")
+    >>> print(results)
+    {'max_regard': {'negative': 0.6691194772720337, 'positive': 0.02632979303598404, 'neutral': 0.942646861076355, 'other': 0.22687028348445892}}
+Example 3 (returns the average toxicity score):
+    >>> regard = evaluate.load("regard", module_type="measurement")
+    >>> input_texts = ["these girls are silly", "these boys are lost"]
+    >>> results = toxicity.compute(predictions=input_texts, aggregation = "average")
+    >>> print(results)
+    {'average_regard': {'negative': 0.3448680592700839, 'positive': 0.022568698041141033, 'neutral': 0.5139247514307499, 'other': 0.11863846285268664}}
+"""
+
+
+def regard(preds, regard_classifier):
+    neg_scores = []
+    pos_scores = []
+    neut_scores = []
+    other_scores = []
+    regard_scores = {}
+    all_regard= []
+    for pred in preds:
+        regard = regard_classifier(pred)
+        all_regard.append(regard)
+        for s in regard:
+            if s['label'] == 'negative':
+                neg_scores.append(s['score'])
+            elif s['label'] == 'positive':
+                pos_scores.append(s['score'])
+            elif s['label'] == 'neutral':
+                neut_scores.append(s['score'])
+            else:
+                other_scores.append(s['score'])
+        regard_scores['negative'] = neg_scores
+        regard_scores['positive'] = pos_scores
+        regard_scores['neutral'] = neut_scores
+        regard_scores['other'] = other_scores
+    return all_regard, regard_scores
+
+
+@evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
+class Regard(evaluate.Measurement):
+    def _info(self):
+        return evaluate.MeasurementInfo(
+            module_type="measurement",
+            description=_DESCRIPTION,
+            citation=_CITATION,
+            inputs_description=_KWARGS_DESCRIPTION,
+            features=datasets.Features(
+                {
+                    "predictions": datasets.Value("string", id="sequence"),
+                }
+            ),
+            codebase_urls=[],
+            reference_urls=[],
+        )
+
+    def _download_and_prepare(self, dl_manager):
+        regard_tokenizer = AutoTokenizer.from_pretrained("sasha/regardv3")
+        regard_model = AutoModelForSequenceClassification.from_pretrained("sasha/regardv3")
+        self.regard_classifier = pipeline(
+            "text-classification", model=regard_model, top_k=4, tokenizer=regard_tokenizer, truncation=True
+        )
+
+    def _compute(
+        self,
+        predictions,
+        aggregation="all",
+    ):
+        all, scores = regard(predictions, self.regard_classifier)
+        if aggregation == "maximum":
+            max_dict = {}
+            for i in scores.items():
+                max_dict[i[0]] = max(i[1])
+            return {"max_regard": max_dict}
+        elif aggregation == "average":
+            av_dict = {}
+            for i in scores.items():
+                av_dict[i[0]] = mean(i[1])
+            return {"average_regard": av_dict}
+        else:
+            return {"regard": all}

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -146,6 +146,6 @@ class Regard(evaluate.Measurement):
                 "max_references_regard": max([max(v) for v in ref_regard.values()]),
             }
         elif aggregation == "average":
-            return {"average_data_regard": pred_average, "average_references_regard": ref_average}
+            return {"average_data_regard": pred_mean, "average_references_regard": ref_mean}
         else:
-            return {"regard_difference": {key: pred_average[key] - ref_average.get(key, 0) for key in pred_average}}
+            return {"regard_difference": {key: pred_mean[key] - ref_mean.get(key, 0) for key in pred_mean}}

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -118,6 +118,14 @@ def regard(group, regard_classifier):
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
 class Regard(evaluate.Measurement):
     def _info(self):
+    if self.config_name not in [
+            "compare",
+            "default"
+        ]:
+            raise KeyError(
+                "You should supply a configuration name selected in "
+                '["config", "default"]'
+            )
         return evaluate.MeasurementInfo(
             module_type="measurement",
             description=_DESCRIPTION,

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -67,8 +67,8 @@ Example 1 (default behavior):
 >>> group1 = ['the girls were mean', 'women are too ambitious']
 >>> group2 = ['boys make too much noise', 'men are often violent']
 >>> results = regard.compute(predictions = group1, references = group2)
->>> print(results)
-{'regard_difference': {'neutral': 0.3451282191090286, 'negative': -0.36345648765563965, 'other': 0.010959412436932325, 'positive': 0.007368835678789765}}
+>>> print({k: round(v, 2) for k, v in results['regard_difference'].items()})
+{'neutral': 0.35, 'negative': -0.36, 'other': 0.01, 'positive': 0.01}
 
 
 Example 2 (returns the maximum toxicity score):
@@ -76,21 +76,20 @@ Example 2 (returns the maximum toxicity score):
 >>> group1 = ['the girls were mean', 'women are too ambitious']
 >>> group2 = ['boys make too much noise', 'men are often violent']
 >>> results = regard.compute(predictions = group1, references = group2, aggregation = "maximum")
->>> print(results)
-{'max_regard': {'negative': 0.6691194772720337, 'positive': 0.02632979303598404, 'neutral': 0.942646861076355, 'other': 0.22687028348445892}}
-
+>>> print({k: round(v[1],3) for k,v in results.items()})
+{'max_predictions_regard': 0.95, 'max_references_regard': 0.976}
 
 Example 3 (returns the average toxicity score):
 
 >>> regard = evaluate.load("regard", module_type="measurement")
->>> group1 =  group1 = ['the girls are smart', 'the women are impressive']
+>>> group1 = ['the girls were mean', 'women are too ambitious']
 >>> group2 = ['boys make too much noise', 'men are often violent']
 >>> results = regard.compute(predictions = group1, references = group2, aggregation = "average")
->>> print(results)
-{'average_predictions_regard': {'neutral': 0.9492073953151703, 'positive': 0.033664701506495476, 'negative': 0.0111181172542274, 'other': 0.006009730044752359},
-'average_references_regard': {'negative': 0.9357638359069824, 'other': 0.03806556994095445, 'neutral': 0.025142709724605083, 'positive': 0.00102789539960213}}
+>>> print({k: round(v, 2) for k, v in results['average_predictions_regard'].items()})
+{'neutral': 0.37, 'negative': 0.57, 'other': 0.05, 'positive': 0.01}
+>>> print({k: round(v, 2) for k, v in results['average_references_regard'].items()})
+{'negative': 0.94, 'other': 0.04, 'neutral': 0.03, 'positive': 0.0}
 """
-
 
 def regard(preds, refs, regard_classifier):
     pred_scores = defaultdict(list)

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -76,8 +76,8 @@ Example 2 (returns the maximum toxicity score):
 >>> group1 = ['the girls were mean', 'women are too ambitious']
 >>> group2 = ['boys make too much noise', 'men are often violent']
 >>> results = regard.compute(data = group1, references = group2, aggregation = "maximum")
->>> print({k: round(v[1],3) for k,v in results.items()})
-{'max_data_regard': 0.95, 'max_references_regard': 0.976}
+>>> print({k: round(v,3) for k,v in results.items()})
+{'max_predictions_regard': 0.95, 'max_references_regard': 0.976}
 
 Example 3 (returns the average toxicity score):
 

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -47,7 +47,7 @@ Compute the regard of the input sentences.
 
 Args:
     `predictions` (list of str): prediction/candidate sentences, e.g. sentences describing a given demographic group.
-    `references` (list of str): reference/comparison sentences, e.g. sentences decribing a different demographic group to compare against.
+    `references` (list of str): reference/comparison sentences, e.g. sentences describing a different demographic group to compare against.
     `aggregation` (str) (optional): determines the type of aggregation performed on the data.
     If set to `None`, the difference between the regard scores for the two categories is returned.
      Otherwise:

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -91,6 +91,7 @@ Example 3 (returns the average toxicity score):
 {'negative': 0.94, 'other': 0.04, 'neutral': 0.03, 'positive': 0.0}
 """
 
+
 def regard(preds, refs, regard_classifier):
     pred_scores = defaultdict(list)
     ref_scores = defaultdict(list)

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -100,7 +100,7 @@ def regard(preds, regard_classifier):
                 other_scores.append(s["score"])
         regard_scores["negative"] = neg_scores
         regard_scores["positive"] = pos_scores
-        regard_scores["neutral"] = neut_scores
+        regard_scores["neutral"] = neutral_scores
         regard_scores["other"] = other_scores
     return all_regard, regard_scores
 

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -138,8 +138,8 @@ class Regard(evaluate.Measurement):
         aggregation=None,
     ):
         pred_regard, ref_regard = regard(data, references, self.regard_classifier)
-        pred_mean = {k: mean(v) for  k, v in pred_regard.items()}
-        ref_mean = {k: mean(v) for  k, v in ref_regard.items()}
+        pred_mean = {k: mean(v) for k, v in pred_regard.items()}
+        ref_mean = {k: mean(v) for k, v in ref_regard.items()}
         if aggregation == "maximum":
             return {
                 "max_predictions_regard": max([max(v) for v in pred_regard.values()]),

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -64,12 +64,11 @@ Examples:
 
 Example 1 (default behavior):
 >>> regard = evaluate.load("regard", module_type="measurement")
->>> group1 = ['the girls were mean', 'women are too ambitious']
->>> group2 = ['boys make too much noise', 'men are often violent']
+>>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
+>>> group2 = ['xyz are known for making too much noise', 'xyz are described as often violent']
 >>> results = regard.compute(data = group1, references = group2)
 >>> print({k: round(v, 2) for k, v in results['regard_difference'].items()})
-{'neutral': 0.35, 'negative': -0.36, 'other': 0.01, 'positive': 0.01}
-
+{'neutral': 0.46, 'positive': 0.01, 'negative': -0.46, 'other': -0.01}
 
 Example 2 (returns the maximum toxicity score):
 >>> regard = evaluate.load("regard", module_type="measurement")
@@ -77,18 +76,17 @@ Example 2 (returns the maximum toxicity score):
 >>> group2 = ['boys make too much noise', 'men are often violent']
 >>> results = regard.compute(data = group1, references = group2, aggregation = "maximum")
 >>> print({k: round(v,3) for k,v in results.items()})
-{'max_predictions_regard': 0.95, 'max_references_regard': 0.976}
+{'max_predictions_regard': 0.972, 'max_references_regard': 0.979}
 
 Example 3 (returns the average toxicity score):
-
 >>> regard = evaluate.load("regard", module_type="measurement")
 >>> group1 = ['the girls were mean', 'women are too ambitious']
 >>> group2 = ['boys make too much noise', 'men are often violent']
 >>> results = regard.compute(data = group1, references = group2, aggregation = "average")
 >>> print({k: round(v, 2) for k, v in results['average_data_regard'].items()})
-{'neutral': 0.37, 'negative': 0.57, 'other': 0.05, 'positive': 0.01}
+{'neutral': 0.48, 'positive': 0.01, 'negative': 0.5, 'other': 0.01}
 >>> print({k: round(v, 2) for k, v in results['average_references_regard'].items()})
-{'negative': 0.94, 'other': 0.04, 'neutral': 0.03, 'positive': 0.0}
+{'negative': 0.96, 'other': 0.02, 'neutral': 0.02, 'positive': 0.0}
 """
 
 

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -82,7 +82,7 @@ Example 3 (returns the average toxicity score):
 def regard(preds, regard_classifier):
     neg_scores = []
     pos_scores = []
-    neut_scores = []
+    neutral_scores = []
     other_scores = []
     regard_scores = {}
     all_regard = []

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -144,14 +144,9 @@ class Regard(evaluate.Measurement):
         for k, v in ref_regard.items():
             ref_average[k] = mean(v)
         if aggregation == "maximum":
-            pred_max, ref_max = {}, {}
-            for k, v in pred_regard.items():
-                pred_max[k] = max(v)
-            for k, v in ref_regard.items():
-                ref_max[k] = max(v)
             return {
-                "max_data_regard": max(pred_max.items(), key=itemgetter(1)),
-                "max_references_regard": max(ref_max.items(), key=itemgetter(1)),
+                "max_predictions_regard": max([max(v) for v in pred_regard.values()]),
+                "max_references_regard": max([max(v) for v in ref_regard.values()]),
             }
         elif aggregation == "average":
             return {"average_data_regard": pred_average, "average_references_regard": ref_average}

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -48,7 +48,7 @@ Compute the regard of the input sentences.
 
 Args:
     `data` (list of str): prediction/candidate sentences, e.g. sentences describing a given demographic group.
-    `references` (list of str): reference/comparison sentences, e.g. sentences describing a different demographic group to compare against.
+    `references` (list of str) (optional): reference/comparison sentences, e.g. sentences describing a different demographic group to compare against.
     `aggregation` (str) (optional): determines the type of aggregation performed.
     If set to `None`, the difference between the regard scores for the two categories is returned.
      Otherwise:
@@ -56,32 +56,48 @@ Args:
         - 'maximum': returns the maximum regard for each group
 
 Returns:
-    `regard_difference`: the difference between the regard scores for the two groups
-    `average_data_regard` and 'average_references_regard': the average regard for each category (negative, positive, neutral, other)  (if `aggregation` = `average`)
-    `max_data_regard` and 'max_references_regard': the maximum regard for each group  (if `aggregation` = `maximum`)
+    With only `data` as input (default config):
+        `regard` : the regard scores of each string in the input list (if no aggregation is specified)
+        `average_regard`: the average regard for each category (negative, positive, neutral, other)  (if `aggregation` = `average`)
+        `max_regard`: the maximum regard across all input strings (if `aggregation` = `maximum`)
+    With `data` and `references` as input (`compare` config):
+        `regard_difference`: the difference between the regard scores for the two groups (if no aggregation is specified)
+        `average_data_regard` and 'average_references_regard': the average regard for each category (negative, positive, neutral, other)  (if `aggregation` = `average`)
+        `max_data_regard` and 'max_references_regard': the maximum regard for each group  (if `aggregation` = `maximum`)
 
 Examples:
 
-Example 1 (default behavior):
->>> regard = evaluate.load("regard", module_type="measurement")
+Example 1 (single input):
+>>> regard = evaluate.load("regard")
+>>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
+>>> results = regard.compute(data = group1)
+>>> for d in results['regard']:
+...     print({l['label']: round(l['score'],2) for l in d})
+{'neutral': 0.95, 'positive': 0.02, 'negative': 0.02, 'other': 0.01}
+{'negative': 0.97, 'other': 0.02, 'neutral': 0.01, 'positive': 0.0}
+
+Example 2 (comparison mode):
+>>> regard = evaluate.load("regard", "compare")
 >>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
 >>> group2 = ['xyz are known for making too much noise', 'xyz are described as often violent']
 >>> results = regard.compute(data = group1, references = group2)
 >>> print({k: round(v, 2) for k, v in results['regard_difference'].items()})
 {'neutral': 0.46, 'positive': 0.01, 'negative': -0.46, 'other': -0.01}
 
-Example 2 (returns the maximum toxicity score):
->>> regard = evaluate.load("regard", module_type="measurement")
->>> group1 = ['the girls were mean', 'women are too ambitious']
->>> group2 = ['boys make too much noise', 'men are often violent']
+Example 3 (returns the maximum toxicity score per category):
+>>> regard = evaluate.load("regard", "compare")
+>>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
+>>> group2 = ['xyz are known for making too much noise', 'xyz are described as often violent']
 >>> results = regard.compute(data = group1, references = group2, aggregation = "maximum")
->>> print({k: round(v,3) for k,v in results.items()})
-{'max_predictions_regard': 0.972, 'max_references_regard': 0.979}
+>>> print({k: round(v, 2) for k, v in results['max_data_regard'].items()})
+{'neutral': 0.95, 'positive': 0.02, 'negative': 0.97, 'other': 0.02}
+>>> print({k: round(v, 2) for k, v in results['max_references_regard'].items()})
+{'negative': 0.98, 'other': 0.04, 'neutral': 0.03, 'positive': 0.0}
 
-Example 3 (returns the average toxicity score):
->>> regard = evaluate.load("regard", module_type="measurement")
->>> group1 = ['the girls were mean', 'women are too ambitious']
->>> group2 = ['boys make too much noise', 'men are often violent']
+Example 4 (returns the average toxicity score):
+>>> regard = evaluate.load("regard", "compare")
+>>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
+>>> group2 = ['xyz are known for making too much noise', 'xyz are described as often violent']
 >>> results = regard.compute(data = group1, references = group2, aggregation = "average")
 >>> print({k: round(v, 2) for k, v in results['average_data_regard'].items()})
 {'neutral': 0.48, 'positive': 0.01, 'negative': 0.5, 'other': 0.01}
@@ -90,18 +106,13 @@ Example 3 (returns the average toxicity score):
 """
 
 
-def regard(preds, refs, regard_classifier):
-    pred_scores = defaultdict(list)
-    ref_scores = defaultdict(list)
-    pred_regard = regard_classifier(preds)
-    ref_regard = regard_classifier(refs)
-    for pred in pred_regard:
+def regard(group, regard_classifier):
+    group_scores = defaultdict(list)
+    group_regard = regard_classifier(group)
+    for pred in group_regard:
         for pred_score in pred:
-            pred_scores[pred_score["label"]].append(pred_score["score"])
-    for ref in ref_regard:
-        for ref_score in ref:
-            ref_scores[ref_score["label"]].append(ref_score["score"])
-    return dict(pred_scores), dict(ref_scores)
+            group_scores[pred_score["label"]].append(pred_score["score"])
+    return group_regard, dict(group_scores)
 
 
 @evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
@@ -116,6 +127,10 @@ class Regard(evaluate.Measurement):
                 {
                     "data": datasets.Value("string", id="sequence"),
                     "references": datasets.Value("string", id="sequence"),
+                }
+                if self.config_name == "compare"
+                else {
+                    "data": datasets.Value("string", id="sequence"),
                 }
             ),
             codebase_urls=[],
@@ -132,18 +147,32 @@ class Regard(evaluate.Measurement):
     def _compute(
         self,
         data,
-        references,
+        references=None,
         aggregation=None,
     ):
-        pred_regard, ref_regard = regard(data, references, self.regard_classifier)
-        pred_mean = {k: mean(v) for k, v in pred_regard.items()}
-        ref_mean = {k: mean(v) for k, v in ref_regard.items()}
-        if aggregation == "maximum":
-            return {
-                "max_predictions_regard": max([max(v) for v in pred_regard.values()]),
-                "max_references_regard": max([max(v) for v in ref_regard.values()]),
-            }
-        elif aggregation == "average":
-            return {"average_data_regard": pred_mean, "average_references_regard": ref_mean}
+        if self.config_name == "compare":
+            pred_scores, pred_regard = regard(data, self.regard_classifier)
+            ref_scores, ref_regard = regard(references, self.regard_classifier)
+            pred_mean = {k: mean(v) for k, v in pred_regard.items()}
+            pred_max = {k: max(v) for k, v in pred_regard.items()}
+            ref_mean = {k: mean(v) for k, v in ref_regard.items()}
+            ref_max = {k: max(v) for k, v in ref_regard.items()}
+            if aggregation == "maximum":
+                return {
+                    "max_data_regard": pred_max,
+                    "max_references_regard": ref_max,
+                }
+            elif aggregation == "average":
+                return {"average_data_regard": pred_mean, "average_references_regard": ref_mean}
+            else:
+                return {"regard_difference": {key: pred_mean[key] - ref_mean.get(key, 0) for key in pred_mean}}
         else:
-            return {"regard_difference": {key: pred_mean[key] - ref_mean.get(key, 0) for key in pred_mean}}
+            pred_scores, pred_regard = regard(data, self.regard_classifier)
+            pred_mean = {k: mean(v) for k, v in pred_regard.items()}
+            pred_max = {k: max(v) for k, v in pred_regard.items()}
+            if aggregation == "maximum":
+                return {"max_regard": pred_max}
+            elif aggregation == "average":
+                return {"average_regard": pred_mean}
+            else:
+                return {"regard": pred_scores}

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -84,7 +84,7 @@ Example 2 (comparison mode):
 >>> print({k: round(v, 2) for k, v in results['regard_difference'].items()})
 {'neutral': 0.46, 'positive': 0.01, 'negative': -0.46, 'other': -0.01}
 
-Example 3 (returns the maximum toxicity score per category):
+Example 3 (returns the maximum regard score per category):
 >>> regard = evaluate.load("regard", "compare")
 >>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
 >>> group2 = ['xyz are known for making too much noise', 'xyz are described as often violent']
@@ -94,7 +94,7 @@ Example 3 (returns the maximum toxicity score per category):
 >>> print({k: round(v, 2) for k, v in results['max_references_regard'].items()})
 {'negative': 0.98, 'other': 0.04, 'neutral': 0.03, 'positive': 0.0}
 
-Example 4 (returns the average toxicity score):
+Example 4 (returns the average regard score):
 >>> regard = evaluate.load("regard", "compare")
 >>> group1 = ['xyz are described as mean', 'xyz are thought of as being too ambitious']
 >>> group2 = ['xyz are known for making too much noise', 'xyz are described as often violent']

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -14,11 +14,13 @@
 
 """ Regard measurement. """
 
+from statistics import mean
+
 import datasets
 from transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline
 
 import evaluate
-from statistics import mean
+
 
 logger = evaluate.logging.get_logger(__name__)
 
@@ -83,23 +85,23 @@ def regard(preds, regard_classifier):
     neut_scores = []
     other_scores = []
     regard_scores = {}
-    all_regard= []
+    all_regard = []
     for pred in preds:
         regard = regard_classifier(pred)
         all_regard.append(regard)
         for s in regard:
-            if s['label'] == 'negative':
-                neg_scores.append(s['score'])
-            elif s['label'] == 'positive':
-                pos_scores.append(s['score'])
-            elif s['label'] == 'neutral':
-                neut_scores.append(s['score'])
+            if s["label"] == "negative":
+                neg_scores.append(s["score"])
+            elif s["label"] == "positive":
+                pos_scores.append(s["score"])
+            elif s["label"] == "neutral":
+                neut_scores.append(s["score"])
             else:
-                other_scores.append(s['score'])
-        regard_scores['negative'] = neg_scores
-        regard_scores['positive'] = pos_scores
-        regard_scores['neutral'] = neut_scores
-        regard_scores['other'] = other_scores
+                other_scores.append(s["score"])
+        regard_scores["negative"] = neg_scores
+        regard_scores["positive"] = pos_scores
+        regard_scores["neutral"] = neut_scores
+        regard_scores["other"] = other_scores
     return all_regard, regard_scores
 
 

--- a/measurements/regard/requirements.txt
+++ b/measurements/regard/requirements.txt
@@ -1,0 +1,4 @@
+git+https://github.com/huggingface/evaluate.git@{COMMIT_PLACEHOLDER}
+transformers
+datasets
+evaluate

--- a/measurements/regard/requirements.txt
+++ b/measurements/regard/requirements.txt
@@ -1,4 +1,2 @@
 git+https://github.com/huggingface/evaluate.git@{COMMIT_PLACEHOLDER}
 transformers
-datasets
-evaluate


### PR DESCRIPTION
This code is pretty clunky, so I would love thoughts about how to get the list comprehension to work better, @mathemakitten !

Also, one of the initial use cases for regard was to compare the values for several populations (e.g. men and women, for instance), so would it make sense to have either the default or optional behavior to be something like:

```
results = regard.compute(group1 = ['he is a soldier', 'the men are violent', 'George is a gangster'], group2= ['she is a nice girl', 'the women are housewives', 'Kelly is an actress'])
```

and then the result would be the *difference* in regard between the two groups?