### PR TITLE
Add slow flag to two column parity test

### DIFF
--- a/tests/test_trainer_evaluator_parity.py
+++ b/tests/test_trainer_evaluator_parity.py
@@ -13,6 +13,8 @@ from transformers import AutoFeatureExtractor, AutoModelForImageClassification, 
 
 from evaluate import evaluator, load
 
+from .utils import slow
+
 
 class TestEvaluatorTrainerParity(unittest.TestCase):
     def setUp(self):
@@ -74,6 +76,7 @@ class TestEvaluatorTrainerParity(unittest.TestCase):
 
         self.assertEqual(transformers_results["eval_accuracy"], evaluator_results["accuracy"])
 
+    @slow
     def test_text_classification_parity_two_columns(self):
         model_name = "prajjwal1/bert-tiny-mnli"
         max_eval_samples = 150


### PR DESCRIPTION
Due to an issue in the MNLI script, the full `validation_unmatched` is always validated irrespective of the selected sample size (see https://github.com/huggingface/transformers/pull/18722). I suggest temporary setting the test to `slow` so it isn't run in the CI since it timed out several times. We can switch it back once the `transformers` PR is merged.

cc @fxmarty 