### PR TITLE
Check for mismatch in device setup in evaluator

### DIFF
--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -179,6 +179,7 @@ class QuestionAnsweringEvaluator(Evaluator):
             should be set to `False`. If this parameter is not provided, the format will be automatically inferred.
         """
         result = {}
+        self.check_for_mismatch_in_device_setup(device, model_or_pipeline)
 
         data = self.load_data(data=data, split=split)
         metric_inputs, pipe_inputs = self.prepare_data(

--- a/src/evaluate/evaluator/text_classification.py
+++ b/src/evaluate/evaluator/text_classification.py
@@ -118,6 +118,8 @@ class TextClassificationEvaluator(Evaluator):
 
         result = {}
 
+        self.check_for_mismatch_in_device_setup(device, model_or_pipeline)
+
         # Prepare inputs
         metric_inputs, pipe_inputs = self.prepare_data(
             data=data, input_column=input_column, second_input_column=second_input_column, label_column=label_column

--- a/src/evaluate/evaluator/token_classification.py
+++ b/src/evaluate/evaluator/token_classification.py
@@ -238,6 +238,8 @@ class TokenClassificationEvaluator(Evaluator):
         """
         result = {}
 
+        self.check_for_mismatch_in_device_setup(device, model_or_pipeline)
+
         # Prepare inputs
         data = self.load_data(data=data, split=split)
         metric_inputs, pipe_inputs = self.prepare_data(


### PR DESCRIPTION
Per #285, we missed an edge case in the `compute` function for the evaluator where if you pass a pipeline which was already instantiated without a device then it won't run on device even if a device is later passed to `compute`.

Alternatives considered were:
* Change nothing, but warn the user that they've passed a device to compute but their pipeline doesn't have a device attached. Bad because users can mindlessly scroll past it/
* Override the device used in the pipeline when a device has been detected but not used, and throw a different warning to let them know. Seems error-prone in multi-device setups, and reinstantiating already-instantiated pipes seems very bad.
* 
So I went with @lhoestq's suggestion to raise an error to force the user to disambiguate. 

Tests with: 

```
from datasets import Dataset, load_dataset
from evaluate import evaluator
from transformers import pipeline

data = load_dataset("Maysee/tiny-imagenet", split="valid", use_auth_token=True)

pipe = pipeline(
    task="image-classification",
    model="google/vit-base-patch16-224",
    # device=0  # If this commented it will trigger an error
    )

task_evaluator = evaluator("image-classification")
eval_results = task_evaluator.compute(
    model_or_pipeline=pipe,
    data=data,
    metric="accuracy",
    label_mapping=pipe.model.config.label2id,
    device=0
)
```