### PR TITLE
Fix transfomers import in the evaluator

### DIFF
--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -18,7 +18,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 # Lint as: python3
 from datasets import Dataset, load_dataset
-from transformers import Pipeline
 
 from evaluate.evaluator.utils import choose_split
 
@@ -32,7 +31,7 @@ except ImportError:
 
 try:
     import transformers
-    from transformers import pipeline
+    from transformers import pipeline, Pipeline
 
     TRANSFORMERS_AVAILABLE = True
 except ImportError:

--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -31,7 +31,7 @@ except ImportError:
 
 try:
     import transformers
-    from transformers import pipeline, Pipeline
+    from transformers import Pipeline, pipeline
 
     TRANSFORMERS_AVAILABLE = True
 except ImportError:


### PR DESCRIPTION
Fixes a bug introduced in #287 which crashes in environments where `evaluate` is installed without `transformers`; this now uses the workaround where it only sets TRANSFORMERS_AVAILABLE=False instead of erroring.