### PR TITLE
Add missing `split` and `subset` kwarg into other evaluators 

### DIFF
--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -302,18 +302,19 @@ class Evaluator(ABC):
                 )
 
     @staticmethod
-    def get_dataset_split(data, split):
+    def get_dataset_split(data, subset, split):
         """
         Infers which split to use if None is given.
 
         Args:
              data (`str`): Name of dataset
+             subset (`str`): Name of config for datasets with multiple configurations (e.g. 'glue/cola')
              split (`str`, defaults to None): Split to use
         Returns:
             `split`: `str` containing which split to use
         """
         if split is None:
-            split = choose_split(data)
+            split = choose_split(data, subset)
             logger.warning(f"Dataset split not defined! Automatically evaluating with split: {split.upper()}")
         return split
 
@@ -332,7 +333,7 @@ class Evaluator(ABC):
             data (`Dataset`): Loaded dataset which will be used for evaluation.
         """
         if isinstance(data, str):
-            split = self.get_dataset_split(data, split)
+            split = self.get_dataset_split(data, subset, split)
             data = load_dataset(data, name=subset, split=split)
             return data
         elif isinstance(data, Dataset):

--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -302,7 +302,7 @@ class Evaluator(ABC):
                 )
 
     @staticmethod
-    def get_dataset_split(data, subset, split):
+    def get_dataset_split(data, subset=None, split=None):
         """
         Infers which split to use if None is given.
 

--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -219,6 +219,7 @@ class Evaluator(ABC):
             str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"  # noqa: F821
         ] = None,
         data: Union[str, Dataset] = None,
+        subset: Optional[str] = None,
         split: Optional[str] = None,
         metric: Union[str, EvaluationModule] = None,
         tokenizer: Optional[Union[str, "PreTrainedTokenizer"]] = None,  # noqa: F821
@@ -238,7 +239,7 @@ class Evaluator(ABC):
         self.check_for_mismatch_in_device_setup(device, model_or_pipeline)
 
         # Prepare inputs
-        data = self.load_data(data=data, split=split)
+        data = self.load_data(data=data, subset=subset, split=split)
         metric_inputs, pipe_inputs = self.prepare_data(data=data, input_column=input_column, label_column=label_column)
         pipe = self.prepare_pipeline(
             model_or_pipeline=model_or_pipeline,

--- a/src/evaluate/evaluator/image_classification.py
+++ b/src/evaluate/evaluator/image_classification.py
@@ -69,6 +69,7 @@ class ImageClassificationEvaluator(Evaluator):
             str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"  # noqa: F821
         ] = None,
         data: Union[str, Dataset] = None,
+        subset: Optional[str] = None,
         split: Optional[str] = None,
         metric: Union[str, EvaluationModule] = None,
         tokenizer: Optional[Union[str, "PreTrainedTokenizer"]] = None,  # noqa: F821
@@ -96,6 +97,7 @@ class ImageClassificationEvaluator(Evaluator):
         result = super().compute(
             model_or_pipeline=model_or_pipeline,
             data=data,
+            subset=subset,
             split=split,
             metric=metric,
             tokenizer=tokenizer,

--- a/src/evaluate/evaluator/image_classification.py
+++ b/src/evaluate/evaluator/image_classification.py
@@ -69,6 +69,7 @@ class ImageClassificationEvaluator(Evaluator):
             str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"  # noqa: F821
         ] = None,
         data: Union[str, Dataset] = None,
+        split: Optional[str] = None,
         metric: Union[str, EvaluationModule] = None,
         tokenizer: Optional[Union[str, "PreTrainedTokenizer"]] = None,  # noqa: F821
         feature_extractor: Optional[Union[str, "FeatureExtractionMixin"]] = None,  # noqa: F821
@@ -95,6 +96,7 @@ class ImageClassificationEvaluator(Evaluator):
         result = super().compute(
             model_or_pipeline=model_or_pipeline,
             data=data,
+            split=split,
             metric=metric,
             tokenizer=tokenizer,
             feature_extractor=feature_extractor,

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -148,6 +148,7 @@ class QuestionAnsweringEvaluator(Evaluator):
             str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"  # noqa: F821
         ] = None,
         data: Union[str, Dataset] = None,
+        subset: Optional[str] = None,
         split: Optional[str] = None,
         metric: Union[str, EvaluationModule] = None,
         tokenizer: Optional[Union[str, "PreTrainedTokenizer"]] = None,  # noqa: F821
@@ -181,7 +182,7 @@ class QuestionAnsweringEvaluator(Evaluator):
         result = {}
         self.check_for_mismatch_in_device_setup(device, model_or_pipeline)
 
-        data = self.load_data(data=data, split=split)
+        data = self.load_data(data=data, subset=subset, split=split)
         metric_inputs, pipe_inputs = self.prepare_data(
             data=data,
             question_column=question_column,

--- a/src/evaluate/evaluator/text_classification.py
+++ b/src/evaluate/evaluator/text_classification.py
@@ -90,6 +90,7 @@ class TextClassificationEvaluator(Evaluator):
             str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"  # noqa: F821
         ] = None,
         data: Union[str, Dataset] = None,
+        subset: Optional[str] = None,
         split: Optional[str] = None,
         metric: Union[str, EvaluationModule] = None,
         tokenizer: Optional[Union[str, "PreTrainedTokenizer"]] = None,  # noqa: F821
@@ -122,7 +123,7 @@ class TextClassificationEvaluator(Evaluator):
         self.check_for_mismatch_in_device_setup(device, model_or_pipeline)
 
         # Prepare inputs
-        data = self.load_data(data=data, split=split)
+        data = self.load_data(data=data, subset=subset, split=split)
         metric_inputs, pipe_inputs = self.prepare_data(
             data=data, input_column=input_column, second_input_column=second_input_column, label_column=label_column
         )

--- a/src/evaluate/evaluator/text_classification.py
+++ b/src/evaluate/evaluator/text_classification.py
@@ -90,6 +90,7 @@ class TextClassificationEvaluator(Evaluator):
             str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"  # noqa: F821
         ] = None,
         data: Union[str, Dataset] = None,
+        split: Optional[str] = None,
         metric: Union[str, EvaluationModule] = None,
         tokenizer: Optional[Union[str, "PreTrainedTokenizer"]] = None,  # noqa: F821
         feature_extractor: Optional[Union[str, "FeatureExtractionMixin"]] = None,  # noqa: F821
@@ -121,6 +122,7 @@ class TextClassificationEvaluator(Evaluator):
         self.check_for_mismatch_in_device_setup(device, model_or_pipeline)
 
         # Prepare inputs
+        data = self.load_data(data=data, split=split)
         metric_inputs, pipe_inputs = self.prepare_data(
             data=data, input_column=input_column, second_input_column=second_input_column, label_column=label_column
         )

--- a/src/evaluate/evaluator/token_classification.py
+++ b/src/evaluate/evaluator/token_classification.py
@@ -215,6 +215,7 @@ class TokenClassificationEvaluator(Evaluator):
             str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"  # noqa: F821
         ] = None,
         data: Union[str, Dataset] = None,
+        subset: Optional[str] = None,
         split: str = None,
         metric: Union[str, EvaluationModule] = None,
         tokenizer: Optional[Union[str, "PreTrainedTokenizer"]] = None,  # noqa: F821
@@ -241,7 +242,7 @@ class TokenClassificationEvaluator(Evaluator):
         self.check_for_mismatch_in_device_setup(device, model_or_pipeline)
 
         # Prepare inputs
-        data = self.load_data(data=data, split=split)
+        data = self.load_data(data=data, subset=subset, split=split)
         metric_inputs, pipe_inputs = self.prepare_data(
             data=data, input_column=input_column, label_column=label_column, join_by=join_by
         )

--- a/src/evaluate/evaluator/utils.py
+++ b/src/evaluate/evaluator/utils.py
@@ -18,8 +18,8 @@ class DatasetColumn(list):
         return (self.dataset[i][self.key] for i in range(len(self)))
 
 
-def choose_split(data):
-    available_splits = get_dataset_split_names(data)
+def choose_split(data, subset=None):
+    available_splits = get_dataset_split_names(data, subset)
     preferred_split_order = [
         "test",
         "testing",

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -243,6 +243,10 @@ class TestTextClassificationEvaluator(TestCase):
         data = self.evaluator.load_data("evaluate/glue-ci", subset="cola", split="test")
         self.assertEqual(isinstance(data, Dataset), True)
 
+        # Test loading subset of a dataset with the `name` field and having it infer the split
+        data = self.evaluator.load_data("evaluate/glue-ci", subset="cola")
+        self.assertEqual(isinstance(data, Dataset), True)
+
     def test_overwrite_default_metric(self):
         accuracy = load("accuracy")
         results = self.evaluator.compute(


### PR DESCRIPTION
Quick fix for two of the evaluators missing the new `split` kwarg for passing in data splits.