### PR TITLE
fix wrong sorting in check

### DIFF
--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -492,7 +492,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
                 error_msg = (
                     f"Mismatch in the number of {col0} ({len(batch[col0])}) and {bad_col} ({len(batch[bad_col])})"
                 )
-            elif sorted(self.current_features) != ["references", "predictions"]:
+            elif set(self.current_features) != {"references", "predictions"}:
                 error_msg = (
                     f"Module inputs don't match the expected format.\n" f"Expected format: {self.current_features },\n"
                 )


### PR DESCRIPTION
Found while looking into setfit: this check **never** succeeds, due to p coming before r.
Fixed in a way that does not require anyone to get the alphabet straight while reading code.