### PR TITLE
Performance improvement for `mean_iou`

### DIFF
--- a/metrics/mean_iou/mean_iou.py
+++ b/metrics/mean_iou/mean_iou.py
@@ -290,6 +290,7 @@ class MeanIoU(evaluate.Metric):
             reference_urls=[
                 "https://github.com/open-mmlab/mmsegmentation/blob/71c201b1813267d78764f306a297ca717827c4bf/mmseg/core/evaluation/metrics.py"
             ],
+            format="numpy",
         )
 
     def _compute(

--- a/src/evaluate/info.py
+++ b/src/evaluate/info.py
@@ -22,7 +22,7 @@ import os
 from dataclasses import asdict, dataclass, field
 from typing import List, Optional, Union
 
-from datasets.features import Features, Value
+from datasets.features import Features
 
 from . import config
 from .utils.logging import get_logger
@@ -59,15 +59,6 @@ class EvaluationModuleInfo:
     module_name: Optional[str] = None
     config_name: Optional[str] = None
     experiment_id: Optional[str] = None
-
-    def __post_init__(self):
-        if self.format is not None:
-            for key, value in self.features.items():
-                if not isinstance(value, Value):
-                    raise ValueError(
-                        f"When using 'numpy' format, all features should be a `datasets.Value` feature. "
-                        f"Here {key} is an instance of {value.__class__.__name__}"
-                    )
 
     def write_to_directory(self, metric_info_dir):
         """Write `EvaluationModuleInfo` as JSON to `metric_info_dir`.


### PR DESCRIPTION
Using `mean_iou` is quite slow for large arrays due to nested encoding in `datasets.Features`. This should speed it up.