### PR TITLE
Stop using model-defined truncation in perplexity calculation

### DIFF
--- a/measurements/perplexity/perplexity.py
+++ b/measurements/perplexity/perplexity.py
@@ -100,7 +100,7 @@ class Perplexity(evaluate.Measurement):
             reference_urls=["https://huggingface.co/docs/transformers/perplexity"],
         )
 
-    def _compute(self, data, model_id, batch_size: int = 16, add_start_token: bool = True, device=None):
+    def _compute(self, data, model_id, batch_size: int = 16, add_start_token: bool = True, device=None, max_length=None):
 
         if device is not None:
             assert device in ["gpu", "cpu", "cuda"], "device should be either gpu or cpu."
@@ -131,15 +131,15 @@ class Perplexity(evaluate.Measurement):
             assert (
                 tokenizer.bos_token is not None
             ), "Input model must already have a BOS token if using add_start_token=True. Please use a different model, or set add_start_token=False"
-            max_tokenized_len = model.config.max_length - 1
+            max_tokenized_len = max_length - 1
         else:
-            max_tokenized_len = model.config.max_length
+            max_tokenized_len = max_length
 
         encodings = tokenizer(
             data,
             add_special_tokens=False,
             padding=True,
-            truncation=True,
+            truncation=True if max_tokenized_len else False,
             max_length=max_tokenized_len,
             return_tensors="pt",
             return_attention_mask=True,

--- a/measurements/perplexity/perplexity.py
+++ b/measurements/perplexity/perplexity.py
@@ -100,7 +100,9 @@ class Perplexity(evaluate.Measurement):
             reference_urls=["https://huggingface.co/docs/transformers/perplexity"],
         )
 
-    def _compute(self, data, model_id, batch_size: int = 16, add_start_token: bool = True, device=None, max_length=None):
+    def _compute(
+        self, data, model_id, batch_size: int = 16, add_start_token: bool = True, device=None, max_length=None
+    ):
 
         if device is not None:
             assert device in ["gpu", "cpu", "cuda"], "device should be either gpu or cpu."

--- a/measurements/perplexity/perplexity.py
+++ b/measurements/perplexity/perplexity.py
@@ -128,7 +128,7 @@ class Perplexity(evaluate.Measurement):
             # assign one of the special tokens to also be the pad token
             tokenizer.add_special_tokens({"pad_token": existing_special_tokens[0]})
 
-        if add_start_token:
+        if add_start_token and max_length:
             # leave room for <BOS> token to be added:
             assert (
                 tokenizer.bos_token is not None

--- a/metrics/perplexity/perplexity.py
+++ b/metrics/perplexity/perplexity.py
@@ -128,7 +128,7 @@ class Perplexity(evaluate.Metric):
             # assign one of the special tokens to also be the pad token
             tokenizer.add_special_tokens({"pad_token": existing_special_tokens[0]})
 
-        if add_start_token:
+        if add_start_token and max_length:
             # leave room for <BOS> token to be added:
             assert (
                 tokenizer.bos_token is not None

--- a/metrics/perplexity/perplexity.py
+++ b/metrics/perplexity/perplexity.py
@@ -100,7 +100,9 @@ class Perplexity(evaluate.Metric):
             reference_urls=["https://huggingface.co/docs/transformers/perplexity"],
         )
 
-    def _compute(self, predictions, model_id, batch_size: int = 16, add_start_token: bool = True, device=None, max_length=None):
+    def _compute(
+        self, predictions, model_id, batch_size: int = 16, add_start_token: bool = True, device=None, max_length=None
+    ):
 
         if device is not None:
             assert device in ["gpu", "cpu", "cuda"], "device should be either gpu or cpu."

--- a/metrics/perplexity/perplexity.py
+++ b/metrics/perplexity/perplexity.py
@@ -100,7 +100,7 @@ class Perplexity(evaluate.Metric):
             reference_urls=["https://huggingface.co/docs/transformers/perplexity"],
         )
 
-    def _compute(self, predictions, model_id, batch_size: int = 16, add_start_token: bool = True, device=None):
+    def _compute(self, predictions, model_id, batch_size: int = 16, add_start_token: bool = True, device=None, max_length=None):
 
         if device is not None:
             assert device in ["gpu", "cpu", "cuda"], "device should be either gpu or cpu."
@@ -131,15 +131,15 @@ class Perplexity(evaluate.Metric):
             assert (
                 tokenizer.bos_token is not None
             ), "Input model must already have a BOS token if using add_start_token=True. Please use a different model, or set add_start_token=False"
-            max_tokenized_len = model.config.max_length - 1
+            max_tokenized_len = max_length - 1
         else:
-            max_tokenized_len = model.config.max_length
+            max_tokenized_len = max_length
 
         encodings = tokenizer(
             predictions,
             add_special_tokens=False,
             padding=True,
-            truncation=True,
+            truncation=True if max_tokenized_len else False,
             max_length=max_tokenized_len,
             return_tensors="pt",
             return_attention_mask=True,


### PR DESCRIPTION
If the user doesn't explicitly pass in `max_length`, we shouldn't truncate the inputs to perplexity at all. `model.config.max_length` is unreliable since it's named differently in every model (and sometimes not at all).

I'd also be in support of removing the truncation option in entirety, but this seems like a good compromise for retaining previous existing functionality.

Closes #332.