### PR TITLE
fix caching

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -541,7 +541,7 @@ class CachedEvaluationModuleFactory(_EvaluationModuleFactory):
         # get most recent
 
         def _get_modification_time(module_hash):
-            return (Path(importable_directory_path) / module_hash / (self.name + ".py")).stat().st_mtime
+            return (Path(importable_directory_path) / module_hash / (self.name.split("--")[-1] + ".py")).stat().st_mtime
 
         hash = sorted(hashes, key=_get_modification_time)[-1]
         logger.warning(
@@ -550,7 +550,7 @@ class CachedEvaluationModuleFactory(_EvaluationModuleFactory):
             f"couldn't be found locally at {self.name}, or remotely on the Hugging Face Hub."
         )
         # make the new module to be noticed by the import system
-        module_path = ".".join([os.path.basename(dynamic_modules_path), self.module_type, self.name, hash, self.name])
+        module_path = ".".join([os.path.basename(dynamic_modules_path), self.module_type, self.name, hash, self.name.split("--")[-1]])
         importlib.invalidate_caches()
         return ImportableModule(module_path, hash)
 
@@ -658,15 +658,23 @@ def evaluation_module_factory(
                     dynamic_modules_path=dynamic_modules_path,
                 ).get_module()
         except Exception as e1:  # noqa: all the attempts failed, before raising the error we should check if the module is already cached.
-            try:
-                return CachedEvaluationModuleFactory(path, dynamic_modules_path=dynamic_modules_path).get_module()
-            except Exception as e2:  # noqa: if it's not in the cache, then it doesn't exist.
-                if not isinstance(e1, (ConnectionError, FileNotFoundError)):
-                    raise e1 from None
-                raise FileNotFoundError(
-                    f"Couldn't find a module script at {relative_to_absolute_path(combined_path)}. "
-                    f"Module '{path}' doesn't exist on the Hugging Face Hub either."
-                ) from None
+            if path.count("/") == 0:
+                for current_type in ["metric", "comparison", "measurement"]:
+                    try:
+                        return CachedEvaluationModuleFactory(f"evaluate-{current_type}--{path}", dynamic_modules_path=dynamic_modules_path).get_module()
+                    except Exception as e2:  # noqa: if it's not in the cache, then it doesn't exist.
+                        raise e2
+            elif path.count("/") == 1:
+                try:
+                    return CachedEvaluationModuleFactory(path.replace("/", "--"), dynamic_modules_path=dynamic_modules_path).get_module()
+                except Exception as e2:  # noqa: if it's not in the cache, then it doesn't exist.
+                    pass
+            if not isinstance(e1, (ConnectionError, FileNotFoundError)):
+                raise e1 from None
+            raise FileNotFoundError(
+                f"Couldn't find a module script at {relative_to_absolute_path(combined_path)}. "
+                f"Module '{path}' doesn't exist on the Hugging Face Hub either."
+            ) from None
     else:
         raise FileNotFoundError(f"Couldn't find a module script at {relative_to_absolute_path(combined_path)}.")
 

--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -669,7 +669,7 @@ def evaluation_module_factory(
                             f"evaluate-{current_type}--{path}", dynamic_modules_path=dynamic_modules_path
                         ).get_module()
                     except Exception as e2:  # noqa: if it's not in the cache, then it doesn't exist.
-                        raise e2
+                        pass
             elif path.count("/") == 1:
                 try:
                     return CachedEvaluationModuleFactory(

--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -541,7 +541,9 @@ class CachedEvaluationModuleFactory(_EvaluationModuleFactory):
         # get most recent
 
         def _get_modification_time(module_hash):
-            return (Path(importable_directory_path) / module_hash / (self.name.split("--")[-1] + ".py")).stat().st_mtime
+            return (
+                (Path(importable_directory_path) / module_hash / (self.name.split("--")[-1] + ".py")).stat().st_mtime
+            )
 
         hash = sorted(hashes, key=_get_modification_time)[-1]
         logger.warning(
@@ -550,7 +552,9 @@ class CachedEvaluationModuleFactory(_EvaluationModuleFactory):
             f"couldn't be found locally at {self.name}, or remotely on the Hugging Face Hub."
         )
         # make the new module to be noticed by the import system
-        module_path = ".".join([os.path.basename(dynamic_modules_path), self.module_type, self.name, hash, self.name.split("--")[-1]])
+        module_path = ".".join(
+            [os.path.basename(dynamic_modules_path), self.module_type, self.name, hash, self.name.split("--")[-1]]
+        )
         importlib.invalidate_caches()
         return ImportableModule(module_path, hash)
 
@@ -661,12 +665,16 @@ def evaluation_module_factory(
             if path.count("/") == 0:
                 for current_type in ["metric", "comparison", "measurement"]:
                     try:
-                        return CachedEvaluationModuleFactory(f"evaluate-{current_type}--{path}", dynamic_modules_path=dynamic_modules_path).get_module()
+                        return CachedEvaluationModuleFactory(
+                            f"evaluate-{current_type}--{path}", dynamic_modules_path=dynamic_modules_path
+                        ).get_module()
                     except Exception as e2:  # noqa: if it's not in the cache, then it doesn't exist.
                         raise e2
             elif path.count("/") == 1:
                 try:
-                    return CachedEvaluationModuleFactory(path.replace("/", "--"), dynamic_modules_path=dynamic_modules_path).get_module()
+                    return CachedEvaluationModuleFactory(
+                        path.replace("/", "--"), dynamic_modules_path=dynamic_modules_path
+                    ).get_module()
                 except Exception as e2:  # noqa: if it's not in the cache, then it doesn't exist.
                     pass
             if not isinstance(e1, (ConnectionError, FileNotFoundError)):

--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -662,6 +662,7 @@ def evaluation_module_factory(
                     dynamic_modules_path=dynamic_modules_path,
                 ).get_module()
         except Exception as e1:  # noqa: all the attempts failed, before raising the error we should check if the module is already cached.
+            # if it's a canonical module we need to check if it's any of the types
             if path.count("/") == 0:
                 for current_type in ["metric", "comparison", "measurement"]:
                     try:
@@ -670,6 +671,7 @@ def evaluation_module_factory(
                         ).get_module()
                     except Exception as e2:  # noqa: if it's not in the cache, then it doesn't exist.
                         pass
+            # if it's a community module we just need to check on path
             elif path.count("/") == 1:
                 try:
                     return CachedEvaluationModuleFactory(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -6,7 +6,12 @@ from unittest import TestCase
 import pytest
 
 import evaluate
-from evaluate.loading import CachedEvaluationModuleFactory, HubEvaluationModuleFactory, LocalEvaluationModuleFactory
+from evaluate.loading import (
+    CachedEvaluationModuleFactory,
+    HubEvaluationModuleFactory,
+    LocalEvaluationModuleFactory,
+    evaluation_module_factory,
+)
 from evaluate.utils.file_utils import DownloadConfig
 
 from .utils import OfflineSimulationMode, offline
@@ -109,3 +114,27 @@ class ModuleFactoryTest(TestCase):
                 )
                 module_factory_result = factory.get_module()
                 assert importlib.import_module(module_factory_result.module_path) is not None
+
+    def test_cache_with_remote_canonical_module(self):
+        metric = "accuracy"
+        evaluation_module_factory(
+            metric, download_config=self.download_config, dynamic_modules_path=self.dynamic_modules_path
+        )
+
+        for offline_mode in OfflineSimulationMode:
+            with offline(offline_mode):
+                evaluation_module_factory(
+                    metric, download_config=self.download_config, dynamic_modules_path=self.dynamic_modules_path
+                )
+
+    def test_cache_with_remote_community_module(self):
+        metric = "lvwerra/test"
+        evaluation_module_factory(
+            metric, download_config=self.download_config, dynamic_modules_path=self.dynamic_modules_path
+        )
+
+        for offline_mode in OfflineSimulationMode:
+            with offline(offline_mode):
+                evaluation_module_factory(
+                    metric, download_config=self.download_config, dynamic_modules_path=self.dynamic_modules_path
+                )


### PR DESCRIPTION
The current caching from the hub is not working properly. The reason is that a canonical metric is internally converted to hub namespace including the organization and the caching replaces `/` with `--` in the cache directory name. Thus the following caching occurs:

`accuracy` --> `evaluate-metrics/accuracy` --> `evaluate-metrics--accuracy` 

However, when trying to load the cache only `accuracy` is searched which is why the caching always fails. Similarly for community metrics. This PR fixes that issue by fixing the lookup paths.

Fixes #294 