### PR TITLE
Add prefixes with metric name when using evaluate.combine()

### DIFF
--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -859,7 +859,16 @@ class CombinedEvaluations:
         for evaluation_module in self.evaluation_modules:
             batch = {"predictions": predictions, "references": references, **kwargs}
             batch = {input_name: batch[input_name] for input_name in evaluation_module._feature_names()}
-            results.append(evaluation_module.compute(**batch))
+            # Compute results
+            eval_results = {}
+            for score_name, score_value in evaluation_module.compute(**batch):
+                # If the metric's name is the same as the key, add a "_score" to it.
+                if evaluation_module.name == score_name:
+                    score_name = f"{evaluation_module.name}_score"
+                else: # Otherwise, prefix the metric's name to the score_name.
+                    score_name = f"{evaluation_module.name}_{score_name}"
+                eval_results[score_name] = score_value
+            results.append(eval_results)
 
         return self._merge_results(results)
 


### PR DESCRIPTION
This will avoid name clashes in `_merge_results` and also be a little more explicit when reading the combined metrics' dicitonary.