### PR TITLE
Don't use eval for Evaluator instances in the doc

### DIFF
--- a/docs/source/a_quick_tour.mdx
+++ b/docs/source/a_quick_tour.mdx
@@ -265,9 +265,9 @@ metric = evaluate.load("accuracy")
 Then you can create an evaluator for text classification and pass the three objects to the `compute()` method. With the label mapping `evaluate` provides a method to align the pipeline outputs with the label column in the dataset:
 
 ```python
->>> eval = evaluator("text-classification")
+>>> task_evaluator = evaluator("text-classification")
 
->>> results = eval.compute(model_or_pipeline=pipe, data=data, metric=metric,
+>>> results = task_evaluator.compute(model_or_pipeline=pipe, data=data, metric=metric,
 ...                        label_mapping={"NEGATIVE": 0, "POSITIVE": 1},)
 
 >>> print(results)

--- a/docs/source/custom_evaluator.mdx
+++ b/docs/source/custom_evaluator.mdx
@@ -48,8 +48,8 @@ We can now pass this `pipeline` to the `evaluator`:
 ```py
 from evaluate import evaluator
 
-eval = evaluator("text-classification")
-eval.compute(pipe, ds["test"], "accuracy")
+task_evaluator = evaluator("text-classification")
+task_evaluator.compute(pipe, ds["test"], "accuracy")
 
 >>> {'accuracy': 0.82956}
 ```


### PR DESCRIPTION
This is to harmonize with the rest of the doc, we should avoid using `eval` as it is a python keyword.