### PR TITLE
Fix `scikit-learn` install in spaces

### DIFF
--- a/measurements/word_count/requirements.txt
+++ b/measurements/word_count/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate.git@{COMMIT_PLACEHOLDER}
-sklearn~=0.0
+scikit-learn~=0.0

--- a/metrics/accuracy/requirements.txt
+++ b/metrics/accuracy/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-sklearn
+scikit-learn

--- a/metrics/brier_score/requirements.txt
+++ b/metrics/brier_score/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-sklearn
+scikit-learn

--- a/metrics/f1/requirements.txt
+++ b/metrics/f1/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-sklearn
+scikit-learn

--- a/metrics/glue/requirements.txt
+++ b/metrics/glue/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
 scipy
-sklearn
+scikit-learn

--- a/metrics/indic_glue/requirements.txt
+++ b/metrics/indic_glue/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
 scipy
-sklearn
+scikit-learn

--- a/metrics/mae/requirements.txt
+++ b/metrics/mae/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-sklearn
+scikit-learn

--- a/metrics/matthews_correlation/requirements.txt
+++ b/metrics/matthews_correlation/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-sklearn
+scikit-learn

--- a/metrics/mauve/requirements.txt
+++ b/metrics/mauve/requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
 faiss-cpu
-sklearn
+scikit-learn
 mauve-text

--- a/metrics/mse/requirements.txt
+++ b/metrics/mse/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-sklearn
+scikit-learn

--- a/metrics/precision/requirements.txt
+++ b/metrics/precision/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-sklearn
+scikit-learn

--- a/metrics/recall/requirements.txt
+++ b/metrics/recall/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-sklearn
+scikit-learn

--- a/metrics/roc_auc/requirements.txt
+++ b/metrics/roc_auc/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-sklearn
+scikit-learn

--- a/metrics/super_glue/requirements.txt
+++ b/metrics/super_glue/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-sklearn
+scikit-learn

--- a/metrics/xtreme_s/requirements.txt
+++ b/metrics/xtreme_s/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-sklearn
+scikit-learn


### PR DESCRIPTION
For some reason `sklearn` used to work as a dependency but the correct way to install `scikit-learn` is by it's full name and the short term is only used in the library itself. This PR fixes this.