### PR TITLE
Allow EvaluationSuite to receive a Preprocessor

### DIFF
--- a/src/evaluate/evaluation_suite/__init__.py
+++ b/src/evaluate/evaluation_suite/__init__.py
@@ -3,6 +3,7 @@ import inspect
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, Optional, Union
+from abc import ABC, abstractmethod
 
 from datasets import Dataset, DownloadMode, load_dataset
 from datasets.fingerprint import Hasher
@@ -17,13 +18,19 @@ from ..utils.logging import get_logger
 logger = get_logger(__name__)
 
 
+class Preprocessor(ABC):
+    @abstractmethod
+    def run(self, dataset: Dataset) -> Dataset:
+        pass
+
+
 @dataclass
 class SubTask:
     task_type: str
     data: [Union[str, Dataset]] = None
     subset: Optional[str] = None
     split: Optional[str] = None
-    data_preprocessor: Optional[Callable] = None
+    data_preprocessor: Optional[Union[Callable, Preprocessor]] = None
     args_for_task: Optional[dict] = None
 
     def __post_init__(self):
@@ -117,7 +124,10 @@ class EvaluationSuite:
 
             if task.data_preprocessor:  # task requires extra preprocessing
                 ds = load_dataset(task.data, name=task.subset, split=task.split)
-                task.data = ds.map(task.data_preprocessor)
+                if issubclass(type(task.data_preprocessor), Preprocessor):
+                    task.data = task.data_preprocessor.run(ds)
+                else:
+                    task.data = ds.map(task.data_preprocessor)
 
             task_evaluator = evaluator(task.task_type)
             args_for_task = task.args_for_task


### PR DESCRIPTION
This is an optional alternative to passing a Callable which is mapped over the dataset, specifically for cases where more custom preprocessing is needed (flattening, filtering, shuffling, joining multiple datasets, etc.).

Opening this up as a draft for the moment until #337 is merged, and to take input on the API. If the API looks good, I can write tests for this.

Here's a sample Preprocessor, and it would be passed to the suite with `data_preprocessor=ToxicityPreprocessor()`.

```python
class ToxicityPreprocessor(Preprocessor):
    def run(self, dataset: Dataset) -> Dataset:
        dataset = dataset.flatten()
        dataset = dataset.shuffle().select(range(100))
        return dataset
```