### PR TITLE
Allow EvaluationSuite to receive a custom Evaluator

### DIFF
--- a/src/evaluate/evaluation_suite/__init__.py
+++ b/src/evaluate/evaluation_suite/__init__.py
@@ -7,7 +7,7 @@ from typing import Callable, Dict, Optional, Union
 from datasets import Dataset, DownloadMode, load_dataset
 from datasets.utils.version import Version
 
-from ..evaluator import evaluator
+from ..evaluator import Evaluator, evaluator
 from ..loading import evaluation_module_factory
 from ..utils.file_utils import DownloadConfig
 from ..utils.logging import get_logger
@@ -19,6 +19,7 @@ logger = get_logger(__name__)
 @dataclass
 class SubTask:
     task_type: str
+    evaluator: Optional[Evaluator] = None
     data: [Union[str, Dataset]] = None
     subset: Optional[str] = None
     split: Optional[str] = None
@@ -115,7 +116,7 @@ class EvaluationSuite:
                 ds = load_dataset(task.data, name=task.subset, split=task.split)
                 task.data = ds.map(task.data_preprocessor)
 
-            task_evaluator = evaluator(task.task_type)
+            task_evaluator = task.evaluator or evaluator(task.task_type)
             args_for_task = task.args_for_task
             args_for_task["model_or_pipeline"] = model_or_pipeline
             args_for_task["data"] = task.data


### PR DESCRIPTION
(Reopening from #348 

Users may have their own Evaluators that they may want to include in an evaluation suite. There are also certain metrics which require extra work (predictions processing, steps in the compute process, etc.) that could be easily served by subclassing existing Evaluators, which should still be compatible with the EvaluationSuite.

See here for an example: https://huggingface.co/spaces/society-ethics/bias-evaluation-suite/blob/main/bias-evaluation-suite.py#L115