### PR TITLE
Add `Evaluate` usage for `scikit-learn`

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -20,6 +20,8 @@
   - sections:
     - local: transformers_integrations
       title: Transformers
+    - local: sklearn_integrations
+      title: scikit-learn
     title: Using 🤗 Evaluate with other ML frameworks
   title: "How-to guides"
 - sections:

--- a/docs/source/sklearn_integrations.mdx
+++ b/docs/source/sklearn_integrations.mdx
@@ -1,6 +1,6 @@
 # Scikit-Learn
 
-To run the scikit-learn examples make sure you have installed the following libraries:
+To run the scikit-learn examples make sure you have installed the following library:
 
 ```bash
 pip install -U scikit-learn

--- a/docs/source/sklearn_integrations.mdx
+++ b/docs/source/sklearn_integrations.mdx
@@ -82,7 +82,7 @@ y_pred = y_pred.tolist()
 accuracy_metric = evaluate.load("accuracy")
 accuracy = accuracy_metric.compute(references=y_test, predictions=y_pred)
 print("Accuracy:", accuracy)
-# Accuracy: 0.xyz
+# Accuracy: 0.79
 ```
 
 You can use any suitable `evaluate` metric with the estimators as long as they are compatible with the task and predictions. 

--- a/docs/source/sklearn_integrations.mdx
+++ b/docs/source/sklearn_integrations.mdx
@@ -81,7 +81,8 @@ y_pred = y_pred.tolist()
 
 accuracy_metric = evaluate.load("accuracy")
 accuracy = accuracy_metric.compute(references=y_test, predictions=y_pred)
-print(accuracy)
+print("Accuracy:", accuracy)
+# Accuracy: 0.xyz
 ```
 
 You can use any suitable `evaluate` metric with the estimators as long as they are compatible with the task and predictions. 

--- a/docs/source/sklearn_integrations.mdx
+++ b/docs/source/sklearn_integrations.mdx
@@ -12,6 +12,7 @@ However, these metrics require that we generate the predictions from the model. 
 
 ```python
 import numpy as np
+np.random.seed(0)
 import evaluate
 from sklearn.compose import ColumnTransformer
 from sklearn.datasets import fetch_openml
@@ -20,19 +21,24 @@ from sklearn.impute import SimpleImputer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
+```
 
-np.random.seed(0)
+Load data from https://www.openml.org/d/40945
 
-# Load data from https://www.openml.org/d/40945
-
+```python
 X, y = fetch_openml("titanic", version=1, as_frame=True, return_X_y=True)
+```
 
-# Alternatively X and y can be obtained directly from the frame attribute:
-# X = titanic.frame.drop('survived', axis=1)
-# y = titanic.frame['survived']
+Alternatively X and y can be obtained directly from the frame attribute:
 
-# We create the preprocessing pipelines for both numeric and categorical data. Note that pclass could either be treated as a categorical or numeric feature.
+```python
+X = titanic.frame.drop('survived', axis=1)
+y = titanic.frame['survived']
+```
 
+We create the preprocessing pipelines for both numeric and categorical data. Note that pclass could either be treated as a categorical or numeric feature.
+
+```python
 numeric_features = ["age", "fare"]
 numeric_transformer = Pipeline(
     steps=[("imputer", SimpleImputer(strategy="median")), ("scaler", StandardScaler())]
@@ -47,9 +53,11 @@ preprocessor = ColumnTransformer(
         ("cat", categorical_transformer, categorical_features),
     ]
 )
+```
 
-# Append classifier to preprocessing pipeline. Now we have a full prediction pipeline.
+Append classifier to preprocessing pipeline. Now we have a full prediction pipeline.
 
+```python
 clf = Pipeline(
     steps=[("preprocessor", preprocessor), ("classifier", LogisticRegression())]
 )
@@ -75,6 +83,5 @@ accuracy_metric = evaluate.load("accuracy")
 accuracy = accuracy_metric.compute(references=y_test, predictions=y_pred)
 print(accuracy)
 ```
-
 
 You can use any suitable `evaluate` metric with the estimators as long as they are compatible with the task and predictions. 

--- a/docs/source/sklearn_integrations.mdx
+++ b/docs/source/sklearn_integrations.mdx
@@ -68,7 +68,7 @@ clf.fit(X_train, y_train)
 y_pred = clf.predict(X_test)
 ```
 
-As `Evaluate` metrics accept lists as inputs for values of references and predictions, we need to convert them to python lists.
+As `Evaluate` metrics use lists as inputs for references and predictions, we need to convert them to Python lists.
 
 
 ```python

--- a/docs/source/sklearn_integrations.mdx
+++ b/docs/source/sklearn_integrations.mdx
@@ -1,0 +1,80 @@
+# Scikit-Learn
+
+To run the scikit-learn examples make sure you have installed the following libraries:
+
+```bash
+pip install -U scikit-learn
+```
+
+The metrics in `evaluate` can be easily integrated with an Scikit-Learn estimator or [pipeline](https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html#sklearn.pipeline.Pipeline).  
+
+However, these metrics require that we generate the predictions from the model. The predictions and labels from the estimators can be passed to `evaluate` mertics to compute the required values.
+
+```python
+import numpy as np
+import evaluate
+from sklearn.compose import ColumnTransformer
+from sklearn.datasets import fetch_openml
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+from sklearn.preprocessing import StandardScaler, OneHotEncoder
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+
+np.random.seed(0)
+
+# Load data from https://www.openml.org/d/40945
+
+X, y = fetch_openml("titanic", version=1, as_frame=True, return_X_y=True)
+
+# Alternatively X and y can be obtained directly from the frame attribute:
+# X = titanic.frame.drop('survived', axis=1)
+# y = titanic.frame['survived']
+
+# We create the preprocessing pipelines for both numeric and categorical data. Note that pclass could either be treated as a categorical or numeric feature.
+
+numeric_features = ["age", "fare"]
+numeric_transformer = Pipeline(
+    steps=[("imputer", SimpleImputer(strategy="median")), ("scaler", StandardScaler())]
+)
+
+categorical_features = ["embarked", "sex", "pclass"]
+categorical_transformer = OneHotEncoder(handle_unknown="ignore")
+
+preprocessor = ColumnTransformer(
+    transformers=[
+        ("num", numeric_transformer, numeric_features),
+        ("cat", categorical_transformer, categorical_features),
+    ]
+)
+
+# Append classifier to preprocessing pipeline. Now we have a full prediction pipeline.
+
+clf = Pipeline(
+    steps=[("preprocessor", preprocessor), ("classifier", LogisticRegression())]
+)
+
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=0)
+
+clf.fit(X_train, y_train)
+y_pred = clf.predict(X_test)
+```
+
+As `Evaluate` metrics accept lists as inputs for values of references and predictions, we need to convert them to python lists.
+
+
+```python
+# Evaluate metrics accept lists as inputs for values of references and predictions
+
+y_test = y_test.tolist()
+y_pred = y_pred.tolist()
+
+# Accuracy
+
+accuracy_metric = evaluate.load("accuracy")
+accuracy = accuracy_metric.compute(references=y_test, predictions=y_pred)
+print(accuracy)
+```
+
+
+You can use any suitable `evaluate` metric with the estimators as long as they are compatible with the task and predictions. 

--- a/docs/source/sklearn_integrations.mdx
+++ b/docs/source/sklearn_integrations.mdx
@@ -23,7 +23,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 ```
 
-Load data from https://www.openml.org/d/40945
+Load data from https://www.openml.org/d/40945:
 
 ```python
 X, y = fetch_openml("titanic", version=1, as_frame=True, return_X_y=True)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #326 

#### What does this implement/fix? 
Adds an example demonstrating the integration of `evaluate` with the scikit-learn framework.

#### Note:
Instead of creating a section in `metrics_integrations.mdx`, I have decided to create `sklearn_integrations.mdx` so that it is consistent with the previous section on `Transformers`.

cc @lvwerra @osanseviero 