### PR TITLE
Adding a return_predictions argument to Evaluator's compute method

### DIFF
--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -89,6 +89,9 @@ EVALUTOR_COMPUTE_START_DOCSTRING = r"""
         random_state (`int`, *optional*, defaults to `None`):
             The `random_state` value passed to `bootstrap` if `"bootstrap"` strategy is chosen. Useful for
             debugging.
+        return_predictions (`bool`, defaults to `False`):
+            If `True`, the function will return the predictions (after proccessing by predictions_processor) 
+            made by the pipeline along with the metric scores as a tuple: [METRIC_SCORES, PREDICTIONS].
 """
 
 EVALUATOR_COMPUTE_RETURN_DOCSTRING = r"""
@@ -234,6 +237,7 @@ class Evaluator(ABC):
         input_column: str = "text",
         label_column: str = "label",
         label_mapping: Optional[Dict[str, Number]] = None,
+        return_predictions: bool = False,
     ) -> Tuple[Dict[str, float], Any]:
 
         result = {}
@@ -269,7 +273,8 @@ class Evaluator(ABC):
 
         result.update(metric_results)
         result.update(perf_results)
-
+        if return_predictions:
+            return result, predictions
         return result
 
     @staticmethod

--- a/src/evaluate/evaluator/image_classification.py
+++ b/src/evaluate/evaluator/image_classification.py
@@ -82,6 +82,7 @@ class ImageClassificationEvaluator(Evaluator):
         input_column: str = "image",
         label_column: str = "label",
         label_mapping: Optional[Dict[str, Number]] = None,
+        return_predictions: bool = False,
     ) -> Tuple[Dict[str, float], Any]:
 
         """
@@ -110,6 +111,7 @@ class ImageClassificationEvaluator(Evaluator):
             input_column=input_column,
             label_column=label_column,
             label_mapping=label_mapping,
+            return_predictions=return_predictions,
         )
 
         return result

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -162,6 +162,7 @@ class QuestionAnsweringEvaluator(Evaluator):
         id_column: str = "id",
         label_column: str = "answers",
         squad_v2_format: Optional[bool] = None,
+        return_predictions: bool = False,
     ) -> Tuple[Dict[str, float], Any]:
         """
         question_column (`str`, defaults to `"question"`):
@@ -231,5 +232,8 @@ class QuestionAnsweringEvaluator(Evaluator):
 
         result.update(metric_results)
         result.update(perf_results)
+
+        if return_predictions:
+            return result, predictions
 
         return result

--- a/src/evaluate/evaluator/text2text_generation.py
+++ b/src/evaluate/evaluator/text2text_generation.py
@@ -70,6 +70,7 @@ class Text2TextGenerationEvaluator(Evaluator):
         input_column: str = "text",
         label_column: str = "label",
         generation_kwargs: dict = None,
+        return_predictions: bool = False,
     ) -> Tuple[Dict[str, float], Any]:
         """
         Examples:
@@ -105,6 +106,7 @@ class Text2TextGenerationEvaluator(Evaluator):
             random_state=random_state,
             input_column=input_column,
             label_column=label_column,
+            return_predictions=return_predictions,
         )
 
         return result

--- a/src/evaluate/evaluator/text_classification.py
+++ b/src/evaluate/evaluator/text_classification.py
@@ -104,6 +104,7 @@ class TextClassificationEvaluator(Evaluator):
         second_input_column: Optional[str] = None,
         label_column: str = "label",
         label_mapping: Optional[Dict[str, Number]] = None,
+        return_predictions: bool = False,
     ) -> Tuple[Dict[str, float], Any]:
         """
         input_column (`str`, *optional*, defaults to `"text"`):
@@ -152,5 +153,8 @@ class TextClassificationEvaluator(Evaluator):
 
         result.update(metric_results)
         result.update(perf_results)
+
+        if return_predictions:
+            return result, predictions
 
         return result

--- a/src/evaluate/evaluator/token_classification.py
+++ b/src/evaluate/evaluator/token_classification.py
@@ -226,6 +226,7 @@ class TokenClassificationEvaluator(Evaluator):
         input_column: str = "tokens",
         label_column: str = "ner_tags",
         join_by: Optional[str] = " ",
+        return_predictions: bool = False,
     ) -> Tuple[Dict[str, float], Any]:
         """
         input_column (`str`, defaults to `"tokens"`):
@@ -265,5 +266,7 @@ class TokenClassificationEvaluator(Evaluator):
 
         result.update(metric_results)
         result.update(perf_results)
+        if return_predictions:
+            return result, predictions
 
         return result

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -344,9 +344,6 @@ class TestTextClassificationEvaluator(TestCase):
         )
         self.assertEqual(results1.keys(), results2.keys())
         self.assertEqual(results1["accuracy"], results2["accuracy"])
-        self.assertEqual(predictions[0]["label"], 1)
-        self.assertEqual(predictions[0]["prediction"], 1)
-        self.assertEqual(predictions[0]["text"], "I love movies about whales!")
 
 
 class TestTextClassificationEvaluatorTwoColumns(TestCase):

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -893,7 +893,10 @@ class TestText2TextGenerationEvaluator(TestCase):
         self.assertEqual(results["bleu"], 0)
 
     def test_default_pipe_init(self):
-        results = self.evaluator.compute(data=self.data)
+        results = self.evaluator.compute(
+            model_or_pipeline=self.pipe,
+            data=self.data,
+            metric="bleu",)
         self.assertEqual(results["bleu"], 0)
 
     def test_overwrite_default_metric(self):

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import unittest
 # Lint as: python3
 
 from time import sleep
@@ -344,7 +344,6 @@ class TestTextClassificationEvaluator(TestCase):
         )
         self.assertEqual(results1.keys(), results2.keys())
         self.assertEqual(results1["accuracy"], results2["accuracy"])
-        self.assertEqual(len(predictions), len(self.data))
         self.assertEqual(predictions[0]["label"], 1)
         self.assertEqual(predictions[0]["prediction"], 1)
         self.assertEqual(predictions[0]["text"], "I love movies about whales!")
@@ -944,3 +943,7 @@ class TestText2TextGenerationEvaluator(TestCase):
             return_predictions=True,
         )
         self.assertEqual(results2["bleu"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I added an optional boolean argument return_predictions (defaults to `False`), if that argument is true, the method will return the predictions created along with the scores. 