### PR TITLE
add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+env:
+  HF_ALLOW_CODE_EVAL: 1
+
+jobs:
+
+  check_code_quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.7"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[quality]
+      - name: Check quality
+        run: |
+          black --check tests src benchmarks metrics
+          isort --check-only tests src benchmarks metrics
+          flake8 tests src benchmarks metrics
+
+  test:
+    needs: check_code_quality
+    strategy:
+      matrix:
+        test: ['unit', 'parity']
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.7"
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Install dependencies
+        run: |
+          pip install .[tests]
+          pip install -r additional-tests-requirements.txt --no-deps
+      - name: Test with pytest
+        if: ${{ matrix.test == 'unit' }}
+        run: |
+          python -m pytest -n 2 --dist loadfile -sv ./tests/ --ignore=./tests/test_trainer_evaluator_parity.py
+      - name: Integration test with transformers
+        if: ${{ matrix.test == 'parity' }}
+        run: |
+          python -m pytest -n 2 --dist loadfile -sv ./tests/test_trainer_evaluator_parity.py


### PR DESCRIPTION
Migrates the CircleCI CI to GitHub actions and also splits the `transformers.Trainer` parity tests with the `Evaluator` to a separate workflow.