### PR TITLE
asr model evaluator addition + doc

### DIFF
--- a/docs/source/base_evaluator.mdx
+++ b/docs/source/base_evaluator.mdx
@@ -11,6 +11,7 @@ Currently supported tasks are:
 - `"text2text-generation"`: will use the [`Text2TextGenerationEvaluator`].
 - `"summarization"`: will use the [`SummarizationEvaluator`].
 - `"translation"`: will use the [`TranslationEvaluator`].
+- `"automatic-speech-recognition"`: will use the [`AutomaticSpeechRecognitionEvaluator`].
 
 
 Each task has its own set of requirements for the dataset format and pipeline output, make sure to check them out for your custom use case. Let's have a look at some of them and see how you can use the evaluator to evalute a single or multiple of models, datasets, and metrics at the same time.

--- a/docs/source/package_reference/evaluator_classes.mdx
+++ b/docs/source/package_reference/evaluator_classes.mdx
@@ -51,3 +51,8 @@ The base class for all evaluator classes:
 
 [[autodoc]] evaluate.TranslationEvaluator
     - compute
+
+### AutomaticSpeechRecognitionEvaluator
+
+[[autodoc]] evaluate.AutomaticSpeechRecognitionEvaluator
+    - compute

--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -28,6 +28,7 @@ del version
 
 from .evaluation_suite import EvaluationSuite
 from .evaluator import (
+    AutomaticSpeechRecognitionEvaluator,
     Evaluator,
     ImageClassificationEvaluator,
     QuestionAnsweringEvaluator,

--- a/src/evaluate/evaluator/__init__.py
+++ b/src/evaluate/evaluator/__init__.py
@@ -24,6 +24,7 @@ except ImportError:
 
 from typing import Dict, List
 
+from .automatic_speech_recognition import AutomaticSpeechRecognitionEvaluator
 from .base import Evaluator
 from .image_classification import ImageClassificationEvaluator
 from .question_answering import QuestionAnsweringEvaluator
@@ -65,6 +66,10 @@ SUPPORTED_EVALUATOR_TASKS = {
     "translation": {
         "implementation": TranslationEvaluator,
         "default_metric_name": "bleu",
+    },
+    "automatic-speech-recognition": {
+        "implementation": AutomaticSpeechRecognitionEvaluator,
+        "default_metric_name": "wer",
     },
 }
 

--- a/src/evaluate/evaluator/automatic_speech_recognition.py
+++ b/src/evaluate/evaluator/automatic_speech_recognition.py
@@ -1,0 +1,109 @@
+# Copyright 2022 The HuggingFace Evaluate Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+from datasets import Dataset
+from typing_extensions import Literal
+
+from ..module import EvaluationModule
+from ..utils.file_utils import add_start_docstrings
+from .base import EVALUATOR_COMPUTE_RETURN_DOCSTRING, EVALUTOR_COMPUTE_START_DOCSTRING, Evaluator
+
+
+TASK_DOCUMENTATION_KWARGS = r"""
+        input_column (`str`, defaults to `"path"`):
+            the name of the column containing the input audio path in the dataset specified by `data`.
+        label_column (`str`, defaults to `"sentence"`):
+            the name of the column containing the labels in the dataset specified by `data`.
+        generation_kwargs (`Dict`, *optional*, defaults to `None`):
+            The generation kwargs are passed to the pipeline and set the text generation strategy.
+"""
+
+
+class AutomaticSpeechRecognitionEvaluator(Evaluator):
+    """
+    Automatic speech recognition evaluator.
+    This automatic speech recognition evaluator can currently be loaded from [`evaluator`] using the default task name
+    `automatic-speech-recognition`.
+    Methods in this class assume a data format compatible with the [`AutomaticSpeechRecognitionPipeline`].
+    """
+
+    PIPELINE_KWARGS = {"truncation": True}
+
+    def __init__(self, task="automatic-speech-recognition", default_metric_name=None):
+        super().__init__(task, default_metric_name=default_metric_name)
+
+    def predictions_processor(self, predictions, label_mapping):
+        return {"predictions": [pred["text"] for pred in predictions]}
+
+    @add_start_docstrings(
+        EVALUTOR_COMPUTE_START_DOCSTRING, TASK_DOCUMENTATION_KWARGS, EVALUATOR_COMPUTE_RETURN_DOCSTRING
+    )
+    def compute(
+        self,
+        model_or_pipeline: Union[
+            str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"  # noqa: F821
+        ] = None,
+        data: Union[str, Dataset] = None,
+        subset: Optional[str] = None,
+        split: Optional[str] = None,
+        metric: Union[str, EvaluationModule] = None,
+        tokenizer: Optional[Union[str, "PreTrainedTokenizer"]] = None,  # noqa: F821
+        strategy: Literal["simple", "bootstrap"] = "simple",
+        confidence_level: float = 0.95,
+        n_resamples: int = 9999,
+        device: int = None,
+        random_state: Optional[int] = None,
+        input_column: str = "path",
+        label_column: str = "sentence",
+        generation_kwargs: dict = None,
+    ) -> Tuple[Dict[str, float], Any]:
+        """
+        Examples:
+        ```python
+        >>> from evaluate import evaluator
+        >>> from datasets import load_dataset
+        >>> task_evaluator = evaluator("automatic-speech-recognition")
+        >>> data = load_dataset("mozilla-foundation/common_voice_11_0", "en", split="validation[:40]")
+        >>> results = task_evaluator.compute(
+        >>>     model_or_pipeline="https://huggingface.co/openai/whisper-tiny.en",
+        >>>     data=data,
+        >>>     input_column="path",
+        >>>     label_column="sentence",
+        >>>     metric="wer",
+        >>> )
+        ```
+        """
+
+        if generation_kwargs is not None:
+            self.PIPELINE_KWARGS.update(generation_kwargs)
+
+        result = super().compute(
+            model_or_pipeline=model_or_pipeline,
+            data=data,
+            subset=subset,
+            split=split,
+            metric=metric,
+            tokenizer=tokenizer,
+            strategy=strategy,
+            confidence_level=confidence_level,
+            n_resamples=n_resamples,
+            device=device,
+            random_state=random_state,
+            input_column=input_column,
+            label_column=label_column,
+        )
+
+        return result

--- a/src/evaluate/evaluator/automatic_speech_recognition.py
+++ b/src/evaluate/evaluator/automatic_speech_recognition.py
@@ -18,17 +18,25 @@ from datasets import Dataset
 from typing_extensions import Literal
 
 from ..module import EvaluationModule
-from ..utils.file_utils import add_start_docstrings
+from ..utils.file_utils import add_end_docstrings, add_start_docstrings
 from .base import EVALUATOR_COMPUTE_RETURN_DOCSTRING, EVALUTOR_COMPUTE_START_DOCSTRING, Evaluator
 
 
-TASK_DOCUMENTATION_KWARGS = r"""
-        input_column (`str`, defaults to `"path"`):
-            the name of the column containing the input audio path in the dataset specified by `data`.
-        label_column (`str`, defaults to `"sentence"`):
-            the name of the column containing the labels in the dataset specified by `data`.
-        generation_kwargs (`Dict`, *optional*, defaults to `None`):
-            The generation kwargs are passed to the pipeline and set the text generation strategy.
+TASK_DOCUMENTATION = r"""
+    Examples:
+    ```python
+    >>> from evaluate import evaluator
+    >>> from datasets import load_dataset
+    >>> task_evaluator = evaluator("automatic-speech-recognition")
+    >>> data = load_dataset("mozilla-foundation/common_voice_11_0", "en", split="validation[:40]")
+    >>> results = task_evaluator.compute(
+    >>>     model_or_pipeline="https://huggingface.co/openai/whisper-tiny.en",
+    >>>     data=data,
+    >>>     input_column="path",
+    >>>     label_column="sentence",
+    >>>     metric="wer",
+    >>> )
+    ```
 """
 
 
@@ -48,9 +56,8 @@ class AutomaticSpeechRecognitionEvaluator(Evaluator):
     def predictions_processor(self, predictions, label_mapping):
         return {"predictions": [pred["text"] for pred in predictions]}
 
-    @add_start_docstrings(
-        EVALUTOR_COMPUTE_START_DOCSTRING, TASK_DOCUMENTATION_KWARGS, EVALUATOR_COMPUTE_RETURN_DOCSTRING
-    )
+    @add_start_docstrings(EVALUTOR_COMPUTE_START_DOCSTRING)
+    @add_end_docstrings(EVALUATOR_COMPUTE_RETURN_DOCSTRING, TASK_DOCUMENTATION)
     def compute(
         self,
         model_or_pipeline: Union[
@@ -71,20 +78,12 @@ class AutomaticSpeechRecognitionEvaluator(Evaluator):
         generation_kwargs: dict = None,
     ) -> Tuple[Dict[str, float], Any]:
         """
-        Examples:
-        ```python
-        >>> from evaluate import evaluator
-        >>> from datasets import load_dataset
-        >>> task_evaluator = evaluator("automatic-speech-recognition")
-        >>> data = load_dataset("mozilla-foundation/common_voice_11_0", "en", split="validation[:40]")
-        >>> results = task_evaluator.compute(
-        >>>     model_or_pipeline="https://huggingface.co/openai/whisper-tiny.en",
-        >>>     data=data,
-        >>>     input_column="path",
-        >>>     label_column="sentence",
-        >>>     metric="wer",
-        >>> )
-        ```
+        input_column (`str`, defaults to `"path"`):
+            the name of the column containing the input audio path in the dataset specified by `data`.
+        label_column (`str`, defaults to `"sentence"`):
+            the name of the column containing the labels in the dataset specified by `data`.
+        generation_kwargs (`Dict`, *optional*, defaults to `None`):
+            The generation kwargs are passed to the pipeline and set the text generation strategy.
         """
 
         if generation_kwargs is not None:

--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -267,6 +267,12 @@ class Evaluator(ABC):
             random_state=random_state,
         )
 
+        # TODO: To clarify why `wer` and `cer` return float
+        # even though metric.compute contract says that it
+        # returns Optional[dict].
+        if type(metric_results) == float:
+            metric_results = {metric.name: metric_results}
+
         result.update(metric_results)
         result.update(perf_results)
 


### PR DESCRIPTION
@lewtun  

As discussed https://github.com/huggingface/evaluate/issues/324, I am adding `automatic-speech-recognition` evaluator here.

Since `automatic-speech-recognition` pipeline already exists and it supports both `Wav2Vec2` and `Whisper`, I think it is safe addition.

I did have some concern where `wer` and `cer` metrics both returning `float` while contract says it should be `dict`.
So I kind of hacked the way around by checking the type, but definitely want to hear your opinion on this.

Thanks!