### PR TITLE
fix outputs of WER/CER

### DIFF
--- a/metrics/cer/cer.py
+++ b/metrics/cer/cer.py
@@ -29,6 +29,7 @@ if PY_VERSION < version.parse("3.8"):
 else:
     import importlib.metadata as importlib_metadata
 
+RETURN_DICT = version.parase(evaluate.__version__) > version.parase("0.3.0")
 
 SENTENCE_DELIMITER = ""
 
@@ -102,7 +103,7 @@ Args:
     predictions: list of transcribtions to score.
     concatenate_texts: Whether or not to concatenate sentences before evaluation, set to True for more accurate result.
 Returns:
-    (float): the character error rate
+    (dict): the character error rate (before evaluate>0.3.0 returns just value)
 
 Examples:
 
@@ -110,7 +111,7 @@ Examples:
     >>> references = ["this is the reference", "there is another one"]
     >>> cer = evaluate.load("cer")
     >>> cer_score = cer.compute(predictions=predictions, references=references)
-    >>> print(cer_score)
+    >>> print(cer_score["cer"])
     0.34146341463414637
 """
 
@@ -137,12 +138,17 @@ class CER(evaluate.Metric):
 
     def _compute(self, predictions, references, concatenate_texts=False):
         if concatenate_texts:
-            return jiwer.compute_measures(
+            cer = jiwer.compute_measures(
                 references,
                 predictions,
                 truth_transform=cer_transform,
                 hypothesis_transform=cer_transform,
             )["wer"]
+            
+            if RETURN_DICT:
+                return {"cer": cer}
+            else:
+                return cer
 
         incorrect = 0
         total = 0
@@ -155,5 +161,7 @@ class CER(evaluate.Metric):
             )
             incorrect += measures["substitutions"] + measures["deletions"] + measures["insertions"]
             total += measures["substitutions"] + measures["deletions"] + measures["hits"]
-
-        return incorrect / total
+        if RETURN_DICT:
+            return {"cer": incorrect / total}
+        else:
+            return incorrect / total

--- a/metrics/wer/wer.py
+++ b/metrics/wer/wer.py
@@ -15,9 +15,12 @@
 
 import datasets
 from jiwer import compute_measures
+from packaging import version
 
 import evaluate
 
+
+RETURN_DICT = version.parase(evaluate.__version__) > version.parase("0.3.0")
 
 _CITATION = """\
 @inproceedings{inproceedings,
@@ -95,7 +98,10 @@ class WER(evaluate.Metric):
 
     def _compute(self, predictions=None, references=None, concatenate_texts=False):
         if concatenate_texts:
-            return compute_measures(references, predictions)["wer"]
+            if RETURN_DICT:
+                return {"wer": compute_measures(references, predictions)["wer"]}
+            else:
+                return compute_measures(references, predictions)["wer"]
         else:
             incorrect = 0
             total = 0
@@ -103,4 +109,8 @@ class WER(evaluate.Metric):
                 measures = compute_measures(reference, prediction)
                 incorrect += measures["substitutions"] + measures["deletions"] + measures["insertions"]
                 total += measures["substitutions"] + measures["deletions"] + measures["hits"]
-            return incorrect / total
+            
+            if RETURN_DICT:
+                return {"wer": incorrect / total}
+            else:
+                return incorrect / total


### PR DESCRIPTION
WER and CER still return floats instead of dictionaries. This PR fixes it so it's consistent with the other metrics and allows usage e.g. in `combine` or `Evaluator`.

However, this will break [one example](https://www.github.com/huggingface/transformers/blob/main/examples/pytorch/speech-recognition/run_speech_recognition_seq2seq.py) in transformers and the Whisper blog would need an update. Do you think we could update this if I simultaneously with the `evaluate` release open a PR on `transformers` and add a note to the blog? cc @LysandreJik @sgugger 