### PR TITLE
[Docs] fixed a typo in bertscore readme

### DIFF
--- a/metrics/bertscore/README.md
+++ b/metrics/bertscore/README.md
@@ -94,7 +94,7 @@ print(results)
 {'precision': [1.0, 1.0], 'recall': [1.0, 1.0], 'f1': [1.0, 1.0], 'hashcode': 'distilbert-base-uncased_L5_no-idf_version=0.3.10(hug_trans=4.10.3)'}
 ```
 
-Partial match with the `bert-base-uncased` model:
+Partial match with the `distilbert-base-uncased` model:
 
 ```python
 from evaluate import load


### PR DESCRIPTION
Hi,

While I was reading the documentation for 'bertscore' metric. I found a typo in the code example. The example code used `distilbert-base-uncase` model as a backend to compute the metric but `bert-base-uncase` was mentioned. 

Not sure who to mention here but I saw @mathemakitten & @lvwerra are the contributors for `CONTRIBUTING.md`