### PR TITLE
resolve #379 audio classification evaluator + docs 

### DIFF
--- a/docs/source/base_evaluator.mdx
+++ b/docs/source/base_evaluator.mdx
@@ -12,6 +12,7 @@ Currently supported tasks are:
 - `"summarization"`: will use the [`SummarizationEvaluator`].
 - `"translation"`: will use the [`TranslationEvaluator`].
 - `"automatic-speech-recognition"`: will use the [`AutomaticSpeechRecognitionEvaluator`].
+- `"audio-classification"`: will use the [`AudioClassificationEvaluator`].
 
 To run an `Evaluator` with several tasks in a single call, use the [EvaluationSuite](evaluation_suite), which runs evaluations on a collection of `SubTask`s.
 

--- a/docs/source/package_reference/evaluator_classes.mdx
+++ b/docs/source/package_reference/evaluator_classes.mdx
@@ -56,3 +56,8 @@ The base class for all evaluator classes:
 
 [[autodoc]] evaluate.AutomaticSpeechRecognitionEvaluator
     - compute
+
+### AudioClassificationEvaluator
+
+[[autodoc]] evaluate.AudioClassificationEvaluator
+    - compute

--- a/measurements/perplexity/perplexity.py
+++ b/measurements/perplexity/perplexity.py
@@ -49,6 +49,7 @@ Args:
     add_start_token (bool): whether to add the start token to the texts,
         so the perplexity can include the probability of the first word. Defaults to True.
     device (str): device to run on, defaults to 'cuda' when available
+    max_length (int): the maximum length to truncate input texts to. Should be set to the maximum length the model supports. Defaults to None.
 Returns:
     perplexity: dictionary containing the perplexity scores for the texts
         in the input list, as well as the mean perplexity. If one of the input texts is

--- a/metrics/bertscore/README.md
+++ b/metrics/bertscore/README.md
@@ -94,7 +94,7 @@ print(results)
 {'precision': [1.0, 1.0], 'recall': [1.0, 1.0], 'f1': [1.0, 1.0], 'hashcode': 'distilbert-base-uncased_L5_no-idf_version=0.3.10(hug_trans=4.10.3)'}
 ```
 
-Partial match with the `bert-base-uncased` model:
+Partial match with the `distilbert-base-uncased` model:
 
 ```python
 from evaluate import load

--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -28,6 +28,7 @@ del version
 
 from .evaluation_suite import EvaluationSuite
 from .evaluator import (
+    AudioClassificationEvaluator,
     AutomaticSpeechRecognitionEvaluator,
     Evaluator,
     ImageClassificationEvaluator,

--- a/src/evaluate/evaluator/__init__.py
+++ b/src/evaluate/evaluator/__init__.py
@@ -24,8 +24,8 @@ except ImportError:
 
 from typing import Dict, List
 
-from .automatic_speech_recognition import AutomaticSpeechRecognitionEvaluator
 from .audio_classification import AudioClassificationEvaluator
+from .automatic_speech_recognition import AutomaticSpeechRecognitionEvaluator
 from .base import Evaluator
 from .image_classification import ImageClassificationEvaluator
 from .question_answering import QuestionAnsweringEvaluator
@@ -75,7 +75,7 @@ SUPPORTED_EVALUATOR_TASKS = {
     "audio-classification": {
         "implementation": AudioClassificationEvaluator,
         "default_metric_name": "accuracy",
-    }
+    },
 }
 
 

--- a/src/evaluate/evaluator/__init__.py
+++ b/src/evaluate/evaluator/__init__.py
@@ -25,6 +25,7 @@ except ImportError:
 from typing import Dict, List
 
 from .automatic_speech_recognition import AutomaticSpeechRecognitionEvaluator
+from .audio_classification import AudioClassificationEvaluator
 from .base import Evaluator
 from .image_classification import ImageClassificationEvaluator
 from .question_answering import QuestionAnsweringEvaluator
@@ -71,6 +72,10 @@ SUPPORTED_EVALUATOR_TASKS = {
         "implementation": AutomaticSpeechRecognitionEvaluator,
         "default_metric_name": "wer",
     },
+    "audio-classification": {
+        "implementation": AudioClassificationEvaluator,
+        "default_metric_name": "accuracy",
+    }
 }
 
 

--- a/src/evaluate/evaluator/audio_classification.py
+++ b/src/evaluate/evaluator/audio_classification.py
@@ -25,9 +25,17 @@ from .base import EVALUATOR_COMPUTE_RETURN_DOCSTRING, EVALUTOR_COMPUTE_START_DOC
 
 TASK_DOCUMENTATION = r"""
     Examples:
+
+    <Tip>
+
+    Remember that, in order to process audio files, you need ffmpeg installed (https://ffmpeg.org/download.html)
+
+    </Tip>
+
     ```python
     >>> from evaluate import evaluator
     >>> from datasets import load_dataset
+
     >>> task_evaluator = evaluator("audio-classification")
     >>> data = load_dataset("superb", 'ks', split="test[:40]")
     >>> results = task_evaluator.compute(
@@ -35,6 +43,30 @@ TASK_DOCUMENTATION = r"""
     >>>     data=data,
     >>>     label_column="label",
     >>>     input_column="file",
+    >>>     metric="accuracy",
+    >>>     label_mapping={0: "yes", 1: "no", 2: "up", 3: "down"}
+    >>> )
+    ```
+
+    <Tip>
+
+    The evaluator supports raw audio data as well, in the form of a numpy array. However, be aware that calling
+    the audio column automatically decodes and resamples the audio files, which can be slow for large datasets.
+
+    </Tip>
+
+    ```python
+    >>> from evaluate import evaluator
+    >>> from datasets import load_dataset
+
+    >>> task_evaluator = evaluator("audio-classification")
+    >>> data = load_dataset("superb", 'ks', split="test[:40]")
+    >>> data = data.map(lambda example: {"audio": example["audio"]["array"]})
+    >>> results = task_evaluator.compute(
+    >>>     model_or_pipeline=""superb/wav2vec2-base-superb-ks"",
+    >>>     data=data,
+    >>>     label_column="label",
+    >>>     input_column="audio",
     >>>     metric="accuracy",
     >>>     label_mapping={0: "yes", 1: "no", 2: "up", 3: "down"}
     >>> )
@@ -47,7 +79,7 @@ class AudioClassificationEvaluator(Evaluator):
     Audio classification evaluator.
     This audio classification evaluator can currently be loaded from [`evaluator`] using the default task name
     `audio-classification`.
-    Methods in this class assume a data format compatible with the [`AudioClassificationPipeline`].
+    Methods in this class assume a data format compatible with the [`transformers.AudioClassificationPipeline`].
     """
 
     PIPELINE_KWARGS = {}
@@ -86,7 +118,7 @@ class AudioClassificationEvaluator(Evaluator):
 
         """
         input_column (`str`, defaults to `"file"`):
-            The name of the column containing the audio files in the dataset specified by `data`.
+            The name of the column containing either the audio files or a raw waveform, represented as a numpy array, in the dataset specified by `data`.
         label_column (`str`, defaults to `"label"`):
             The name of the column containing the labels in the dataset specified by `data`.
         label_mapping (`Dict[str, Number]`, *optional*, defaults to `None`):

--- a/src/evaluate/evaluator/audio_classification.py
+++ b/src/evaluate/evaluator/audio_classification.py
@@ -1,0 +1,115 @@
+# Copyright 2022 The HuggingFace Evaluate Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from numbers import Number
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+from datasets import Dataset
+from typing_extensions import Literal
+
+from ..module import EvaluationModule
+from ..utils.file_utils import add_end_docstrings, add_start_docstrings
+from .base import EVALUATOR_COMPUTE_RETURN_DOCSTRING, EVALUTOR_COMPUTE_START_DOCSTRING, Evaluator
+
+
+TASK_DOCUMENTATION = r"""
+    Examples:
+    ```python
+    >>> from evaluate import evaluator
+    >>> from datasets import load_dataset
+    >>> task_evaluator = evaluator("audio-classification")
+    >>> data = load_dataset("superb", 'ks', split="test[:40]")
+    >>> results = task_evaluator.compute(
+    >>>     model_or_pipeline=""superb/wav2vec2-base-superb-ks"",
+    >>>     data=data,
+    >>>     label_column="label",
+    >>>     input_column="file",
+    >>>     metric="accuracy",
+    >>>     label_mapping={0: "yes", 1: "no", 2: "up", 3: "down"}
+    >>> )
+    ```
+"""
+
+
+class AudioClassificationEvaluator(Evaluator):
+    """
+    Audio classification evaluator.
+    This audio classification evaluator can currently be loaded from [`evaluator`] using the default task name
+    `audio-classification`.
+    Methods in this class assume a data format compatible with the [`AudioClassificationPipeline`].
+    """
+
+    PIPELINE_KWARGS = {}
+
+    def __init__(self, task="audio-classification", default_metric_name=None):
+        super().__init__(task, default_metric_name=default_metric_name)
+
+    def predictions_processor(self, predictions, label_mapping):
+        pred_label = [max(pred, key=lambda x: x["score"])["label"] for pred in predictions]
+        pred_label = [label_mapping[pred] if label_mapping is not None else pred for pred in pred_label]
+
+        return {"predictions": pred_label}
+
+    @add_start_docstrings(EVALUTOR_COMPUTE_START_DOCSTRING)
+    @add_end_docstrings(EVALUATOR_COMPUTE_RETURN_DOCSTRING, TASK_DOCUMENTATION)
+    def compute(
+        self,
+        model_or_pipeline: Union[
+            str, "Pipeline", Callable, "PreTrainedModel", "TFPreTrainedModel"  # noqa: F821
+        ] = None,
+        data: Union[str, Dataset] = None,
+        subset: Optional[str] = None,
+        split: Optional[str] = None,
+        metric: Union[str, EvaluationModule] = None,
+        tokenizer: Optional[Union[str, "PreTrainedTokenizer"]] = None,  # noqa: F821
+        feature_extractor: Optional[Union[str, "FeatureExtractionMixin"]] = None,  # noqa: F821
+        strategy: Literal["simple", "bootstrap"] = "simple",
+        confidence_level: float = 0.95,
+        n_resamples: int = 9999,
+        device: int = None,
+        random_state: Optional[int] = None,
+        input_column: str = "file",
+        label_column: str = "label",
+        label_mapping: Optional[Dict[str, Number]] = None,
+    ) -> Tuple[Dict[str, float], Any]:
+
+        """
+        input_column (`str`, defaults to `"file"`):
+            The name of the column containing the audio files in the dataset specified by `data`.
+        label_column (`str`, defaults to `"label"`):
+            The name of the column containing the labels in the dataset specified by `data`.
+        label_mapping (`Dict[str, Number]`, *optional*, defaults to `None`):
+            We want to map class labels defined by the model in the pipeline to values consistent with those
+            defined in the `label_column` of the `data` dataset.
+        """
+
+        result = super().compute(
+            model_or_pipeline=model_or_pipeline,
+            data=data,
+            subset=subset,
+            split=split,
+            metric=metric,
+            tokenizer=tokenizer,
+            feature_extractor=feature_extractor,
+            strategy=strategy,
+            confidence_level=confidence_level,
+            n_resamples=n_resamples,
+            device=device,
+            random_state=random_state,
+            input_column=input_column,
+            label_column=label_column,
+            label_mapping=label_mapping,
+        )
+
+        return result

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -17,6 +17,7 @@
 from time import sleep
 from unittest import TestCase, mock
 
+import numpy as np
 from datasets import ClassLabel, Dataset, Features, Sequence, Value
 from PIL import Image
 from transformers import (
@@ -1046,6 +1047,16 @@ class TestAudioClassificationEvaluator(TestCase):
         self.data = Dataset.from_dict(
             {"file": ["https://huggingface.co/datasets/Narsil/asr_dummy/resolve/main/1.flac"], "label": [11]}
         )
+        self.raw_data = Dataset.from_dict(
+            {
+                "audio": [
+                    np.array(
+                        [-0.00048828, -0.00018311, -0.00137329, 0.00079346, 0.00091553, 0.00085449], dtype=np.float32
+                    )
+                ],
+                "label": [11],
+            }
+        )
         self.default_model = "superb/wav2vec2-base-superb-ks"
         self.pipe = DummyAudioClassificationPipeline()
         self.evaluator = evaluator("audio-classification")
@@ -1056,6 +1067,12 @@ class TestAudioClassificationEvaluator(TestCase):
             model_or_pipeline=self.pipe,
             data=self.data,
             label_mapping=self.label_mapping,
+        )
+        self.assertEqual(results["accuracy"], 0)
+
+    def test_raw_pipe_init(self):
+        results = self.evaluator.compute(
+            model_or_pipeline=self.pipe, data=self.raw_data, label_mapping=self.label_mapping, input_column="audio"
         )
         self.assertEqual(results["accuracy"], 0)
 
@@ -1092,6 +1109,14 @@ class TestAudioClassificationEvaluator(TestCase):
             metric="accuracy",
             label_mapping=self.label_mapping,
         )
+        results_raw = evaluator.compute(
+            model_or_pipeline=self.pipe,
+            data=self.raw_data,
+            label_mapping=self.label_mapping,
+            metric="accuracy",
+            input_column="audio",
+        )
+        self.assertEqual(results_raw["accuracy"], 0)
         self.assertEqual(results["accuracy"], 0)
 
     @slow

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -22,8 +22,8 @@ from PIL import Image
 from transformers import (
     AutoConfig,
     AutoFeatureExtractor,
-    AutoModelForImageClassification,
     AutoModelForAudioClassification,
+    AutoModelForImageClassification,
     AutoModelForQuestionAnswering,
     AutoModelForSequenceClassification,
     AutoModelForTokenClassification,
@@ -128,12 +128,14 @@ class DummyAutomaticSpeechRecognitionPipeline:
     def __call__(self, inputs, **kwargs):
         return [{"text": "Lorem ipsum"} for _ in inputs]
 
+
 class DummyAudioClassificationPipeline:
     def __init__(self):
         self.task = "audio-classification"
 
     def __call__(self, audio, **kwargs):
         return [[{"score": 0.9, "label": "yes"}, {"score": 0.1, "label": "no"}] for i, _ in enumerate(audio)]
+
 
 class TestEvaluator(TestCase):
     def setUp(self):
@@ -1042,11 +1044,7 @@ class TestAutomaticSpeechRecognitionEvaluator(TestCase):
 class TestAudioClassificationEvaluator(TestCase):
     def setUp(self):
         self.data = Dataset.from_dict(
-            {
-                "file": ["https://huggingface.co/datasets/Narsil/asr_dummy/resolve/main/1.flac"],
-                "label": [11]
-
-            }
+            {"file": ["https://huggingface.co/datasets/Narsil/asr_dummy/resolve/main/1.flac"], "label": [11]}
         )
         self.default_model = "superb/wav2vec2-base-superb-ks"
         self.pipe = DummyAudioClassificationPipeline()


### PR DESCRIPTION
This is the PR addressing #379.

For testing, I used the audio file highlighted in the [Pipelines API](https://huggingface.co/docs/transformers/v4.25.1/en/main_classes/pipelines#transformers.AudioClassificationPipeline) example, mainly because the [superb](https://huggingface.co/datasets/superb) dataset requires manual download, which I felt was more cumbersome and less aligned with the other evaluators' tests.