### PR TITLE
[WIP] Add Panoptic Quality (PQ)

### DIFF
--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -353,33 +353,44 @@ class PanopticQuality(evaluate.Metric):
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
-                # 1st Seq - height dim, 2nd - width dim
                 {
                     "predictions": datasets.Image(),
                     "references": datasets.Image(),
-                    # "predicted_annotations": dict("segments_info"),
-                    # "reference_annotations": dict("segments_info"),
+                    "predicted_annotations": {
+                        "segments_info": datasets.Sequence(
+                            {
+                                "id": datasets.Value("uint16"),
+                                "category_id": datasets.Value("uint16"),
+                            }
+                        )
+                    },
+                    "reference_annotations": {
+                        "segments_info": datasets.Sequence(
+                            {
+                                "id": datasets.Value("uint16"),
+                                "category_id": datasets.Value("uint16"),
+                            }
+                        )
+                    },
                 }
             ),
-            reference_urls=[
-                "https://github.com/cocodataset/panopticapi/blob/master/panopticapi/evaluation.py"
-            ],
+            reference_urls=["https://github.com/cocodataset/panopticapi/blob/master/panopticapi/evaluation.py"],
         )
 
     def _compute(
         self,
-        predictions, # this corresponds to the png_string key of DetrPostProcess
+        predictions,  # this corresponds to the png_string key of DetrPostProcess
         references,
-        predicted_annotations, # list of dicts, each dict containing `segments_info`. Segments info is a list of dicts, each dict containing category_id, id, iscrowd, area, bbox
+        predicted_annotations,  # list of dicts, each dict containing `segments_info`. Segments info is a list of dicts, each dict containing category_id, id, iscrowd, area, bbox
         reference_annotations,
         categories=None,
         # image_ids=None,
         # output_dir=None,
         # gt_folder=None,
         #  gt_json=None,
-    ):          
+    ):
         result = pq_compute(predictions, references, predicted_annotations, reference_annotations, categories)
-        
+
         return result
 
 
@@ -390,11 +401,11 @@ class PanopticQuality(evaluate.Metric):
 #     f.write(json.dumps(gt_json_data))
 
 # # step 4
-        # gt_folder = os.path.join(output_dir, "gt")
-        # if not os.path.exists(gt_folder):
-        #     os.mkdir(gt_folder)
-        # for ref in reference_annotations:
-        #     image_id = ref["image_id"]
-        #     file_name = f"{image_id:012d}.png"
-        #     with open(os.path.join(gt_folder, file_name), "wb") as f:
-        #         f.write(ref["segmentation"])
+# gt_folder = os.path.join(output_dir, "gt")
+# if not os.path.exists(gt_folder):
+#     os.mkdir(gt_folder)
+# for ref in reference_annotations:
+#     image_id = ref["image_id"]
+#     file_name = f"{image_id:012d}.png"
+#     with open(os.path.join(gt_folder, file_name), "wb") as f:
+#         f.write(ref["segmentation"])

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -199,23 +199,38 @@ def pq_compute_single_core(proc_id, annotation_set, predictions, references, cat
             if label not in pred_segms:
                 if label == VOID:
                     continue
+                # raise KeyError(
+                #     "In the image with ID {} segment with ID {} is presented in PNG and not presented in JSON.".format(
+                #         gt_ann["image_id"], label
+                #     )
+                # )
                 raise KeyError(
-                    "In the image with ID {} segment with ID {} is presented in PNG and not presented in JSON.".format(
-                        gt_ann["image_id"], label
+                    "The segment with ID {} is presented in PNG and not presented in JSON.".format(
+                        label
                     )
                 )
             pred_segms[label]["area"] = label_cnt
             pred_labels_set.remove(label)
             if pred_segms[label]["category_id"] not in categories:
+                # raise KeyError(
+                #     "In the image with ID {} segment with ID {} has unknown category_id {}.".format(
+                #         gt_ann["image_id"], label, pred_segms[label]["category_id"]
+                #     )
+                # )
                 raise KeyError(
-                    "In the image with ID {} segment with ID {} has unknown category_id {}.".format(
-                        gt_ann["image_id"], label, pred_segms[label]["category_id"]
+                    "The segment with ID {} has unknown category_id {}.".format(
+                        label, pred_segms[label]["category_id"]
                     )
                 )
         if len(pred_labels_set) != 0:
+            # raise KeyError(
+            #     "In the image with ID {} the following segment IDs {} are presented in JSON and not presented in PNG.".format(
+            #         gt_ann["image_id"], list(pred_labels_set)
+            #     )
+            # )
             raise KeyError(
-                "In the image with ID {} the following segment IDs {} are presented in JSON and not presented in PNG.".format(
-                    gt_ann["image_id"], list(pred_labels_set)
+                "The following segment IDs {} are presented in JSON and not presented in PNG.".format(
+                    list(pred_labels_set)
                 )
             )
 
@@ -369,8 +384,8 @@ class PanopticQuality(evaluate.Metric):
                             {
                                 "id": datasets.Value("int32"),
                                 "category_id": datasets.Value("int32"),
-                                "was_fused": datasets.Value("bool"),
-                                "score": datasets.Value("float32"),
+                                # "was_fused": datasets.Value("bool"),
+                                # "score": datasets.Value("float32"),
                             }
                     ),
                     "reference_annotations": datasets.Sequence(
@@ -379,7 +394,7 @@ class PanopticQuality(evaluate.Metric):
                                 "category_id": datasets.Value("int32"),
                                 "iscrowd": datasets.Value("int32"),
                                 "area": datasets.Value("int32"),
-                                "bbox": datasets.Sequence(datasets.Value("int32")),
+                                # "bbox": datasets.Sequence(datasets.Value("int32")),
                             }
                     )
                 }

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -356,9 +356,9 @@ class PanopticQuality(evaluate.Metric):
                 # 1st Seq - height dim, 2nd - width dim
                 {
                     "predictions": datasets.Sequence(datasets.Image()),
-                    "references": datasets.Sequence(datasets.Image()),
-                    "predicted_annotations": datasets.Sequence(dict),
-                    "reference_annotations": datasets.Sequence(dict),
+                    # "references": datasets.Sequence(datasets.Image()),
+                    # "predicted_annotations": datasets.Sequence(dict),
+                    # "reference_annotations": datasets.Sequence(dict),
                 }
             ),
             reference_urls=[

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -192,7 +192,8 @@ def pq_compute_single_core(proc_id, annotation_set, predictions, references, cat
         pred_segms = {id: {k:v[idx] for k,v in pred_ann.items()} for idx, id in enumerate(pred_ann['id'])}
 
         # predicted segments area calculation + prediction sanity checks
-        pred_labels_set = set(el["id"] for el in pred_ann)
+        # pred_labels_set = set(el["id"] for el in pred_ann)
+        pred_labels_set = set(pred_ann["id"])
         labels, labels_cnt = np.unique(pan_pred, return_counts=True)
         for label, label_cnt in zip(labels, labels_cnt):
             if label not in pred_segms:

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -379,10 +379,12 @@ class PanopticQuality(evaluate.Metric):
 
         # step 1: dump predicted segmentations to folder
         for seg_img, image_id in zip(predictions, image_ids):
-            seg_img = Image.fromarray(id2rgb(np.array(seg_img)))
+            seg_img = np.array(seg_img)
+            print("Shape of seg_img:", seg_img.shape)
+            seg_img = Image.fromarray(id2rgb(seg_img))
 
             with io.BytesIO() as out:
-                f.write(seg_img.save(out, format="PNG"))
+                seg_img.save(out, format="PNG")
             
             file_name = f"{image_id:012d}.png"
             with open(os.path.join(output_dir, file_name), "wb") as f:

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -1,0 +1,387 @@
+# Copyright 2022 The HuggingFace Evaluate Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Panoptic Quality (PQ) metric."""
+
+from collections import defaultdict
+import functools
+import json
+import multiprocessing
+import os
+import time
+import traceback
+
+import numpy as np
+from PIL import Image
+
+import datasets
+import evaluate
+
+
+_DESCRIPTION = """...
+"""
+
+_KWARGS_DESCRIPTION = """
+Args:
+    predictions (`List[ndarray]`):
+        List of predicted segmentation maps, each of shape (height, width). Each segmentation map can be of a different size.
+    references (`List[ndarray]`):
+        List of ground truth segmentation maps, each of shape (height, width). Each segmentation map can be of a different size.
+    predicted_annotations (`List[ndarray]`):
+        List of predicted annotations (segments info).
+    reference_annotations (`List[ndarray]`):
+        List of reference annotations (segments info).
+    output_dir (`str`):
+        Path to the output directory.
+    categories (`dict`):
+        Dictionary mapping category IDs to something like {'name': 'wall', 'id': 0, 'isthing': 0, 'color': [120, 120, 120]}.
+        Example here: https://github.com/cocodataset/panopticapi/blob/master/panoptic_coco_categories.json.
+
+Returns:
+    `Dict[str, float | ndarray]` comprising various elements:
+    - *panoptic_quality* (`float`):
+       Panoptic quality score.
+    ...
+
+Examples:
+
+    >>> import numpy as np
+
+    >>> panoptic_quality = evaluate.load("panoptic_quality")
+
+    >>> # TODO
+"""
+
+_CITATION = """..."""
+
+
+# The decorator is used to prints an error trhown inside process
+def get_traceback(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except Exception as e:
+            print("Caught exception in worker thread:")
+            traceback.print_exc()
+            raise e
+
+    return wrapper
+
+
+def rgb2id(color):
+    if isinstance(color, np.ndarray) and len(color.shape) == 3:
+        if color.dtype == np.uint8:
+            color = color.astype(np.int32)
+        return color[:, :, 0] + 256 * color[:, :, 1] + 256 * 256 * color[:, :, 2]
+    return int(color[0] + 256 * color[1] + 256 * 256 * color[2])
+
+
+OFFSET = 256 * 256 * 256
+VOID = 0
+
+
+class PQStatCat:
+    def __init__(self):
+        self.iou = 0.0
+        self.tp = 0
+        self.fp = 0
+        self.fn = 0
+
+    def __iadd__(self, pq_stat_cat):
+        self.iou += pq_stat_cat.iou
+        self.tp += pq_stat_cat.tp
+        self.fp += pq_stat_cat.fp
+        self.fn += pq_stat_cat.fn
+        return self
+
+
+class PQStat:
+    def __init__(self):
+        self.pq_per_cat = defaultdict(PQStatCat)
+
+    def __getitem__(self, i):
+        return self.pq_per_cat[i]
+
+    def __iadd__(self, pq_stat):
+        for label, pq_stat_cat in pq_stat.pq_per_cat.items():
+            self.pq_per_cat[label] += pq_stat_cat
+        return self
+
+    def pq_average(self, categories, isthing):
+        pq, sq, rq, n = 0, 0, 0, 0
+        per_class_results = {}
+        for label, label_info in categories.items():
+            if isthing is not None:
+                cat_isthing = label_info["isthing"] == 1
+                if isthing != cat_isthing:
+                    continue
+            iou = self.pq_per_cat[label].iou
+            tp = self.pq_per_cat[label].tp
+            fp = self.pq_per_cat[label].fp
+            fn = self.pq_per_cat[label].fn
+            if tp + fp + fn == 0:
+                per_class_results[label] = {"pq": 0.0, "sq": 0.0, "rq": 0.0}
+                continue
+            n += 1
+            pq_class = iou / (tp + 0.5 * fp + 0.5 * fn)
+            sq_class = iou / tp if tp != 0 else 0
+            rq_class = tp / (tp + 0.5 * fp + 0.5 * fn)
+            per_class_results[label] = {"pq": pq_class, "sq": sq_class, "rq": rq_class}
+            pq += pq_class
+            sq += sq_class
+            rq += rq_class
+
+        return {"pq": pq / n, "sq": sq / n, "rq": rq / n, "n": n}, per_class_results
+
+
+@get_traceback
+def pq_compute_single_core(proc_id, annotation_set, gt_folder, pred_folder, categories):
+    pq_stat = PQStat()
+
+    idx = 0
+    for gt_ann, pred_ann in annotation_set:
+        if idx % 100 == 0:
+            print("Core: {}, {} from {} images processed".format(proc_id, idx, len(annotation_set)))
+        idx += 1
+
+        pan_gt = np.array(Image.open(os.path.join(gt_folder, gt_ann["file_name"])), dtype=np.uint32)
+        pan_gt = rgb2id(pan_gt)
+        pan_pred = np.array(Image.open(os.path.join(pred_folder, pred_ann["file_name"])), dtype=np.uint32)
+        pan_pred = rgb2id(pan_pred)
+
+        gt_segms = {el["id"]: el for el in gt_ann["segments_info"]}
+        pred_segms = {el["id"]: el for el in pred_ann["segments_info"]}
+
+        # predicted segments area calculation + prediction sanity checks
+        pred_labels_set = set(el["id"] for el in pred_ann["segments_info"])
+        labels, labels_cnt = np.unique(pan_pred, return_counts=True)
+        for label, label_cnt in zip(labels, labels_cnt):
+            if label not in pred_segms:
+                if label == VOID:
+                    continue
+                raise KeyError(
+                    "In the image with ID {} segment with ID {} is presented in PNG and not presented in JSON.".format(
+                        gt_ann["image_id"], label
+                    )
+                )
+            pred_segms[label]["area"] = label_cnt
+            pred_labels_set.remove(label)
+            if pred_segms[label]["category_id"] not in categories:
+                raise KeyError(
+                    "In the image with ID {} segment with ID {} has unknown category_id {}.".format(
+                        gt_ann["image_id"], label, pred_segms[label]["category_id"]
+                    )
+                )
+        if len(pred_labels_set) != 0:
+            raise KeyError(
+                "In the image with ID {} the following segment IDs {} are presented in JSON and not presented in PNG.".format(
+                    gt_ann["image_id"], list(pred_labels_set)
+                )
+            )
+
+        # confusion matrix calculation
+        pan_gt_pred = pan_gt.astype(np.uint64) * OFFSET + pan_pred.astype(np.uint64)
+        gt_pred_map = {}
+        labels, labels_cnt = np.unique(pan_gt_pred, return_counts=True)
+        for label, intersection in zip(labels, labels_cnt):
+            gt_id = label // OFFSET
+            pred_id = label % OFFSET
+            gt_pred_map[(gt_id, pred_id)] = intersection
+
+        # count all matched pairs
+        gt_matched = set()
+        pred_matched = set()
+        for label_tuple, intersection in gt_pred_map.items():
+            gt_label, pred_label = label_tuple
+            if gt_label not in gt_segms:
+                continue
+            if pred_label not in pred_segms:
+                continue
+            if gt_segms[gt_label]["iscrowd"] == 1:
+                continue
+            if gt_segms[gt_label]["category_id"] != pred_segms[pred_label]["category_id"]:
+                continue
+
+            union = (
+                pred_segms[pred_label]["area"]
+                + gt_segms[gt_label]["area"]
+                - intersection
+                - gt_pred_map.get((VOID, pred_label), 0)
+            )
+            iou = intersection / union
+            if iou > 0.5:
+                pq_stat[gt_segms[gt_label]["category_id"]].tp += 1
+                pq_stat[gt_segms[gt_label]["category_id"]].iou += iou
+                gt_matched.add(gt_label)
+                pred_matched.add(pred_label)
+
+        # count false positives
+        crowd_labels_dict = {}
+        for gt_label, gt_info in gt_segms.items():
+            if gt_label in gt_matched:
+                continue
+            # crowd segments are ignored
+            if gt_info["iscrowd"] == 1:
+                crowd_labels_dict[gt_info["category_id"]] = gt_label
+                continue
+            pq_stat[gt_info["category_id"]].fn += 1
+
+        # count false positives
+        for pred_label, pred_info in pred_segms.items():
+            if pred_label in pred_matched:
+                continue
+            # intersection of the segment with VOID
+            intersection = gt_pred_map.get((VOID, pred_label), 0)
+            # plus intersection with corresponding CROWD region if it exists
+            if pred_info["category_id"] in crowd_labels_dict:
+                intersection += gt_pred_map.get((crowd_labels_dict[pred_info["category_id"]], pred_label), 0)
+            # predicted segment is ignored if more than half of the segment correspond to VOID and CROWD regions
+            if intersection / pred_info["area"] > 0.5:
+                continue
+            pq_stat[pred_info["category_id"]].fp += 1
+    print("Core: {}, all {} images processed".format(proc_id, len(annotation_set)))
+    return pq_stat
+
+
+def pq_compute_multi_core(matched_annotations_list, gt_folder, pred_folder, categories):
+    cpu_num = multiprocessing.cpu_count()
+    annotations_split = np.array_split(matched_annotations_list, cpu_num)
+    print("Number of cores: {}, images per core: {}".format(cpu_num, len(annotations_split[0])))
+    workers = multiprocessing.Pool(processes=cpu_num)
+    processes = []
+    for proc_id, annotation_set in enumerate(annotations_split):
+        p = workers.apply_async(pq_compute_single_core, (proc_id, annotation_set, gt_folder, pred_folder, categories))
+        processes.append(p)
+    pq_stat = PQStat()
+    for p in processes:
+        pq_stat += p.get()
+    return pq_stat
+
+
+def pq_compute(gt_json_file, pred_json_file, gt_folder=None, pred_folder=None):
+    with open(gt_json_file, "r") as f:
+        gt_json = json.load(f)
+    with open(pred_json_file, "r") as f:
+        pred_json = json.load(f)
+
+    if gt_folder is None:
+        gt_folder = gt_json_file.replace(".json", "")
+    if pred_folder is None:
+        pred_folder = pred_json_file.replace(".json", "")
+    categories = {el["id"]: el for el in gt_json["categories"]}
+
+    print("Evaluation panoptic segmentation metrics:")
+    print("Ground truth:")
+    print("\tSegmentation folder: {}".format(gt_folder))
+    print("\tJSON file: {}".format(gt_json_file))
+    print("Prediction:")
+    print("\tSegmentation folder: {}".format(pred_folder))
+    print("\tJSON file: {}".format(pred_json_file))
+
+    if not os.path.isdir(gt_folder):
+        raise Exception("Folder {} with ground truth segmentations doesn't exist".format(gt_folder))
+    if not os.path.isdir(pred_folder):
+        raise Exception("Folder {} with predicted segmentations doesn't exist".format(pred_folder))
+
+    pred_annotations = {el["image_id"]: el for el in pred_json["annotations"]}
+    matched_annotations_list = []
+    for gt_ann in gt_json["annotations"]:
+        image_id = gt_ann["image_id"]
+        if image_id not in pred_annotations:
+            raise Exception("no prediction for the image with id: {}".format(image_id))
+        matched_annotations_list.append((gt_ann, pred_annotations[image_id]))
+
+    pq_stat = pq_compute_multi_core(matched_annotations_list, gt_folder, pred_folder, categories)
+
+    metrics = [("All", None), ("Things", True), ("Stuff", False)]
+    results = {}
+    for name, isthing in metrics:
+        results[name], per_class_results = pq_stat.pq_average(categories, isthing=isthing)
+        if name == "All":
+            results["per_class"] = per_class_results
+    print("{:10s}| {:>5s}  {:>5s}  {:>5s} {:>5s}".format("", "PQ", "SQ", "RQ", "N"))
+    print("-" * (10 + 7 * 4))
+
+    for name, _isthing in metrics:
+        print(
+            "{:10s}| {:5.1f}  {:5.1f}  {:5.1f} {:5d}".format(
+                name,
+                100 * results[name]["pq"],
+                100 * results[name]["sq"],
+                100 * results[name]["rq"],
+                results[name]["n"],
+            )
+        )
+
+
+@evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
+class PanopticQuality(evaluate.Metric):
+    def _info(self):
+        return evaluate.MetricInfo(
+            description=_DESCRIPTION,
+            citation=_CITATION,
+            inputs_description=_KWARGS_DESCRIPTION,
+            features=datasets.Features(
+                # 1st Seq - height dim, 2nd - width dim
+                {
+                    "predictions": datasets.Sequence(datasets.Sequence(datasets.Value("uint16"))),
+                    "references": datasets.Sequence(datasets.Sequence(datasets.Value("uint16"))),
+                }
+            ),
+            reference_urls=[
+                "https://github.com/open-mmlab/mmsegmentation/blob/71c201b1813267d78764f306a297ca717827c4bf/mmseg/core/evaluation/metrics.py"
+            ],
+        )
+
+    def _compute(
+        self,
+        predictions,
+        references,
+        predicted_annotations,
+        reference_annotations,
+        output_dir,
+        categories,
+    ):
+        if not os.path.exists(output_dir):
+            os.mkdir(output_dir)
+        
+        # step 1: create ground truth JSON file
+        gt_json_data = {"annotations": reference_annotations, "categories": categories}
+        gt_json = os.path.join(output_dir, "gt.json")
+        with open(gt_json, "w") as f:
+            f.write(json.dumps(gt_json_data))
+
+        # step 2: create predictions JSON file
+        predictions_json_data = {"annotations": predicted_annotations}
+        predictions_json = os.path.join(output_dir, "predictions.json")
+        with open(predictions_json, "w") as f:
+            f.write(json.dumps(predictions_json_data))
+
+        # step 3: dump ground truth PNG files
+        gt_folder = os.path.join(output_dir, "gt")
+        if not os.path.exists(gt_folder):
+            os.mkdir(gt_folder)
+        for image_id, gt in zip(references.keys(), references.values()):
+            gt_image = Image.fromarray(gt)
+            gt_image.save(os.path.join(gt_folder, str(image_id) + ".png"))
+
+        # step 4: dump predictions PNG files
+        for p in predictions:
+            with open(os.path.join(output_dir, p["file_name"]), "wb") as f:
+                f.write(p.pop("png_string"))
+
+        # step 5: compute PQ
+        result = pq_compute(gt_json, predictions_json, gt_folder=gt_folder, pred_folder=output_dir)
+        
+        return result

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -356,16 +356,16 @@ class PanopticQuality(evaluate.Metric):
                 {
                     "predictions": datasets.Image(),
                     "references": datasets.Image(),
-                    "predicted_annotations": {
-                        "segments_info": datasets.Sequence(
-                            {
-                                "id": datasets.Value("uint16"),
-                                "category_id": datasets.Value("uint16"),
-                                "was_fused": datasets.Value("bool"),
-                                "score": datasets.Value("float32"),
-                            }
-                        )
-                    },
+                    # "predicted_annotations": {
+                    #     "segments_info": datasets.Sequence(
+                    #         {
+                    #             "id": datasets.Value("uint16"),
+                    #             "category_id": datasets.Value("uint16"),
+                    #             "was_fused": datasets.Value("bool"),
+                    #             "score": datasets.Value("float32"),
+                    #         }
+                    #     )
+                    # },
                     "reference_annotations": {
                         "segments_info": datasets.Sequence(
                             {

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -198,7 +198,13 @@ def pq_compute_single_core(proc_id, annotation_set, predictions, references, cat
         # pred_labels_set = set(el["id"] for el in pred_ann)
         pred_labels_set = set(pred_ann["id"])
         labels, labels_cnt = np.unique(pan_pred, return_counts=True)
+
+        print("Predicted labels set:", pred_labels_set)
+        print("Labels:", labels)
+        print("Labels count:", labels_cnt)
+
         for label, label_cnt in zip(labels, labels_cnt):
+            print("Label:", label)
             if label not in pred_segms:
                 if label == VOID:
                     continue

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -380,6 +380,8 @@ class PanopticQuality(evaluate.Metric):
         # step 1: dump predicted segmentations to folder
         for seg_img, image_id in zip(predictions, image_ids):
             with io.BytesIO() as out:
+                print(type(seg_img))
+                print(seg_img)
                 seg_img = id2rgb(seg_img)
                 f.write(seg_img.save(out, format="PNG"))
             

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -191,6 +191,9 @@ def pq_compute_single_core(proc_id, annotation_set, predictions, references, cat
         gt_segms = {id: {k:v[idx] for k,v in gt_ann.items()} for idx, id in enumerate(gt_ann['id'])}
         pred_segms = {id: {k:v[idx] for k,v in pred_ann.items()} for idx, id in enumerate(pred_ann['id'])}
 
+        print("Ground truth segments:", gt_segms)
+        print("Predicted segments:", pred_segms)
+
         # predicted segments area calculation + prediction sanity checks
         # pred_labels_set = set(el["id"] for el in pred_ann)
         pred_labels_set = set(pred_ann["id"])

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -312,6 +312,7 @@ def pq_compute_single_core(proc_id, annotation_set, predictions, references, cat
 
 def pq_compute_multi_core(matched_annotations_list, predictions, references, categories):
     cpu_num = multiprocessing.cpu_count()
+    # TODO support multiprocessing
     # fix cpu numbers for now (DEBUGGING)
     cpu_num = 1
     annotations_split = np.array_split(matched_annotations_list, cpu_num)
@@ -328,34 +329,6 @@ def pq_compute_multi_core(matched_annotations_list, predictions, references, cat
 
 
 def pq_compute(predictions, references, predicted_annotations, reference_annotations, categories):
-    # categories = {el["id"]: el for el in gt_json["categories"]}
-    # with open(gt_json_file, "r") as f:
-    #     gt_json = json.load(f)
-    # with open(pred_json_file, "r") as f:
-    #     pred_json = json.load(f)
-
-    # if gt_folder is None:
-    #     gt_folder = gt_json_file.replace(".json", "")
-    # if pred_folder is None:
-    #     pred_folder = pred_json_file.replace(".json", "")
-    # categories = {el["id"]: el for el in gt_json["categories"]}
-
-    # print("Evaluation panoptic segmentation metrics:")
-    # print("Ground truth:")
-    # print("\tSegmentation folder: {}".format(gt_folder))
-    # print("\tJSON file: {}".format(gt_json_file))
-    # print("Prediction:")
-    # print("\tSegmentation folder: {}".format(pred_folder))
-    # print("\tJSON file: {}".format(pred_json_file))
-
-    # if not os.path.isdir(gt_folder):
-    #     raise Exception("Folder {} with ground truth segmentations doesn't exist".format(gt_folder))
-    # if not os.path.isdir(pred_folder):
-    #     raise Exception("Folder {} with predicted segmentations doesn't exist".format(pred_folder))
-
-    # for el in pred_json["annotations"]:
-    #     print(el)
-    # pred_annotations = {el["image_id"]: el for el in pred_json["annotations"]}
     matched_annotations_list = []
     for pred_ann, gt_ann in zip(predicted_annotations, reference_annotations):
         matched_annotations_list.append((pred_ann, gt_ann))
@@ -418,33 +391,12 @@ class PanopticQuality(evaluate.Metric):
 
     def _compute(
         self,
-        predictions,  # this corresponds to the png_string key of DetrPostProcess
+        predictions,
         references,
-        predicted_annotations,  # list of dicts, each dict containing `segments_info`. Segments info is a list of dicts, each dict containing category_id, id, iscrowd, area, bbox
+        predicted_annotations,
         reference_annotations,
         categories=None,
-        # image_ids=None,
-        # output_dir=None,
-        # gt_folder=None,
-        #  gt_json=None,
     ):
         result = pq_compute(predictions, references, predicted_annotations, reference_annotations, categories)
 
         return result
-
-
-# # step 1: create ground truth JSON file
-# gt_json_data = {"annotations": reference_annotations, "categories": categories}
-# gt_json = os.path.join(output_dir, "gt.json")
-# with open(gt_json, "w") as f:
-#     f.write(json.dumps(gt_json_data))
-
-# # step 4
-# gt_folder = os.path.join(output_dir, "gt")
-# if not os.path.exists(gt_folder):
-#     os.mkdir(gt_folder)
-# for ref in reference_annotations:
-#     image_id = ref["image_id"]
-#     file_name = f"{image_id:012d}.png"
-#     with open(os.path.join(gt_folder, file_name), "wb") as f:
-#         f.write(ref["segmentation"])

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -183,11 +183,11 @@ def pq_compute_single_core(proc_id, annotation_set, predictions, references, cat
         print("Ground truth annotation: ", gt_ann)
         print("Predicted annotation: ", pred_ann)
 
-        gt_segms = {el["id"]: el for el in gt_ann["segments_info"]}
-        pred_segms = {el["id"]: el for el in pred_ann["segments_info"]}
+        gt_segms = {el["id"]: el for el in gt_ann}
+        pred_segms = {el["id"]: el for el in pred_ann}
 
         # predicted segments area calculation + prediction sanity checks
-        pred_labels_set = set(el["id"] for el in pred_ann["segments_info"])
+        pred_labels_set = set(el["id"] for el in pred_ann)
         labels, labels_cnt = np.unique(pan_pred, return_counts=True)
         for label, label_cnt in zip(labels, labels_cnt):
             if label not in pred_segms:
@@ -359,18 +359,15 @@ class PanopticQuality(evaluate.Metric):
                 {
                     "predictions": datasets.Image(),
                     "references": datasets.Image(),
-                    "predicted_annotations": {
-                        "segments_info": datasets.Sequence(
+                    "predicted_annotations": datasets.Sequence(
                             {
                                 "id": datasets.Value("int32"),
                                 "category_id": datasets.Value("int32"),
                                 "was_fused": datasets.Value("bool"),
                                 "score": datasets.Value("float32"),
                             }
-                        )
-                    },
-                    "reference_annotations": {
-                        "segments_info": datasets.Sequence(
+                    ),
+                    "reference_annotations": datasets.Sequence(
                             {
                                 "id": datasets.Value("int32"),
                                 "category_id": datasets.Value("int32"),
@@ -378,8 +375,7 @@ class PanopticQuality(evaluate.Metric):
                                 "area": datasets.Value("int32"),
                                 "bbox": datasets.Sequence(datasets.Value("int32")),
                             }
-                        )
-                    },
+                    )
                 }
             ),
             reference_urls=["https://github.com/cocodataset/panopticapi/blob/master/panopticapi/evaluation.py"],

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -354,8 +354,8 @@ class PanopticQuality(evaluate.Metric):
             features=datasets.Features(
                 # 1st Seq - height dim, 2nd - width dim
                 {
-                    "predictions": datasets.Sequence(datasets.Image()),
-                    "references": datasets.Sequence(datasets.Image()),
+                    "predictions": datasets.Sequence(datasets.Sequence(datasets.Value("uint16"))),
+                    "references": datasets.Sequence(),
                 }
             ),
             reference_urls=[

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -357,8 +357,8 @@ class PanopticQuality(evaluate.Metric):
                 {
                     "predictions": datasets.Image(),
                     "references": datasets.Image(),
-                    "predicted_annotations": dict("segments_info"),
-                    "reference_annotations": dict("segments_info"),
+                    # "predicted_annotations": dict("segments_info"),
+                    # "reference_annotations": dict("segments_info"),
                 }
             ),
             reference_urls=[

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -356,7 +356,7 @@ class PanopticQuality(evaluate.Metric):
                 # 1st Seq - height dim, 2nd - width dim
                 {
                     "predictions": datasets.Sequence(datasets.Image()),
-                    # "references": datasets.Sequence(datasets.Image()),
+                    "references": datasets.Sequence(datasets.Image()),
                     # "predicted_annotations": datasets.Sequence(dict),
                     # "reference_annotations": datasets.Sequence(dict),
                 }

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -361,9 +361,8 @@ class PanopticQuality(evaluate.Metric):
                             {
                                 "id": datasets.Value("uint16"),
                                 "category_id": datasets.Value("uint16"),
-                                "iscrowd": datasets.Value("uint16"),
-                                "area": datasets.Value("uint16"),
-                                "bbox": datasets.Sequence(datasets.Value("uint16")),
+                                "was_fused": datasets.Value("bool"),
+                                "score": datasets.Value("float32"),
                             }
                         )
                     },
@@ -372,8 +371,9 @@ class PanopticQuality(evaluate.Metric):
                             {
                                 "id": datasets.Value("uint16"),
                                 "category_id": datasets.Value("uint16"),
-                                "was_fused": datasets.Value("bool"),
-                                "score": datasets.Value("float32"),
+                                "iscrowd": datasets.Value("uint16"),
+                                "area": datasets.Value("uint16"),
+                                "bbox": datasets.Sequence(datasets.Value("uint16")),
                             }
                         )
                     },

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -386,7 +386,7 @@ class PanopticQuality(evaluate.Metric):
             with io.BytesIO() as out:
                 seg_img.save(out, format="PNG")
             
-            file_name = f"{image_id:012d}.png"
+            file_name = f"{image_id}.png"
             with open(os.path.join(output_dir, file_name), "wb") as f:
                 f.write(out.getvalue())
 

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -380,16 +380,18 @@ class PanopticQuality(evaluate.Metric):
             os.mkdir(output_dir)
 
         # step 1: dump predicted segmentations to folder
-        for seg_img, image_id in zip(predictions, image_ids):
+        for idx, (seg_img, image_id) in enumerate(zip(predictions, image_ids)):
             seg_img = np.array(seg_img)
             print("Shape of seg_img:", seg_img.shape)
             seg_img = Image.fromarray(id2rgb(seg_img))
 
             with io.BytesIO() as out:
                 seg_img.save(out, format="PNG")
-                file_name = f"{image_id}.png"
+                file_name = f"{image_id:012d}.png"
                 with open(os.path.join(output_dir, file_name), "wb") as f:
                     f.write(out.getvalue())
+
+            predicted_annotations["image_id"] = image_id
 
         # step 2: create predictions JSON file
         # predicted_annotations is a list of segments_info

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -355,8 +355,8 @@ class PanopticQuality(evaluate.Metric):
             features=datasets.Features(
                 # 1st Seq - height dim, 2nd - width dim
                 {
-                    "predictions": datasets.Sequence(datasets.Image()),
-                    "references": datasets.Sequence(datasets.Image()),
+                    "predictions": datasets.Image(),
+                    "references": datasets.Image(),
                     # "predicted_annotations": datasets.Sequence(dict),
                     # "reference_annotations": datasets.Sequence(dict),
                 }
@@ -368,10 +368,10 @@ class PanopticQuality(evaluate.Metric):
 
     def _compute(
         self,
-        predictions=None, # this corresponds to the png_string key of DetrPostProcess
-        references=None,
-        predicted_annotations=None, # list of dicts, each dict containing `segments_info`. Segments info is a list of dicts, each dict containing category_id, id, iscrowd, area, bbox
-        reference_annotations=None,
+        predictions, # this corresponds to the png_string key of DetrPostProcess
+        references,
+        predicted_annotations, # list of dicts, each dict containing `segments_info`. Segments info is a list of dicts, each dict containing category_id, id, iscrowd, area, bbox
+        reference_annotations,
         categories=None,
         # image_ids=None,
         # output_dir=None,

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -355,8 +355,8 @@ class PanopticQuality(evaluate.Metric):
             features=datasets.Features(
                 # 1st Seq - height dim, 2nd - width dim
                 {
-                    "predictions": datasets.Sequence(datasets.Sequence(datasets.Value("uint16"))),
-                    "references": datasets.Sequence(datasets.Sequence(datasets.Value("uint16"))),
+                    "predictions": datasets.Image(),
+                    "references": datasets.Image(),
                     "predicted_annotations": datasets.Sequence(dict),
                     "reference_annotations": datasets.Sequence(dict),
                 }

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -384,8 +384,8 @@ class PanopticQuality(evaluate.Metric):
                             {
                                 "id": datasets.Value("int32"),
                                 "category_id": datasets.Value("int32"),
-                                # "was_fused": datasets.Value("bool"),
-                                # "score": datasets.Value("float32"),
+                                "was_fused": datasets.Value("bool"),
+                                "score": datasets.Value("float32"),
                             }
                     ),
                     "reference_annotations": datasets.Sequence(
@@ -394,7 +394,7 @@ class PanopticQuality(evaluate.Metric):
                                 "category_id": datasets.Value("int32"),
                                 "iscrowd": datasets.Value("int32"),
                                 "area": datasets.Value("int32"),
-                                # "bbox": datasets.Sequence(datasets.Value("int32")),
+                                "bbox": datasets.Sequence(datasets.Value("int32")),
                             }
                     )
                 }

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -166,6 +166,8 @@ class PQStat:
 
 @get_traceback
 def pq_compute_single_core(proc_id, annotation_set, predictions, references, categories):
+    print("Annotation set:", annotation_set)
+    
     pq_stat = PQStat()
 
     idx = 0

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -355,7 +355,6 @@ class PanopticQuality(evaluate.Metric):
                 # 1st Seq - height dim, 2nd - width dim
                 {
                     "predictions": datasets.Sequence(datasets.Sequence(datasets.Value("uint16"))),
-                    "references": datasets.Sequence(),
                 }
             ),
             reference_urls=[

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -355,8 +355,8 @@ class PanopticQuality(evaluate.Metric):
             features=datasets.Features(
                 # 1st Seq - height dim, 2nd - width dim
                 {
-                    "predictions": datasets.Image(),
-                    "references": datasets.Image(),
+                    "predictions": datasets.Image(decode=False),
+                    "references": datasets.Image(decode=False),
                     "predicted_annotations": datasets.Sequence(dict),
                     "reference_annotations": datasets.Sequence(dict),
                 }

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -180,6 +180,9 @@ def pq_compute_single_core(proc_id, annotation_set, predictions, references, cat
         # pan_pred = np.array(Image.open(os.path.join(pred_folder, pred_ann["file_name"])), dtype=np.uint32)
         pan_pred = rgb2id(np.array(pan_pred))
 
+        print("Ground truth annotation: ", gt_ann)
+        print("Predicted annotation: ", pred_ann)
+
         gt_segms = {el["id"]: el for el in gt_ann["segments_info"]}
         pred_segms = {el["id"]: el for el in pred_ann["segments_info"]}
 

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -355,8 +355,8 @@ class PanopticQuality(evaluate.Metric):
             features=datasets.Features(
                 # 1st Seq - height dim, 2nd - width dim
                 {
-                    "predictions": datasets.Image(decode=False),
-                    "references": datasets.Image(decode=False),
+                    "predictions": datasets.Sequence(datasets.Image()),
+                    "references": datasets.Sequence(datasets.Image()),
                     "predicted_annotations": datasets.Sequence(dict),
                     "reference_annotations": datasets.Sequence(dict),
                 }

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -203,9 +203,12 @@ def pq_compute_single_core(proc_id, annotation_set, predictions, references, cat
         print("Labels:", labels)
         print("Labels count:", labels_cnt)
 
+        print("Predicted segments:", pred_segms.keys())
+
         for label, label_cnt in zip(labels, labels_cnt):
             print("Label:", label)
             if label not in pred_segms:
+                print(f"Label {label} not in predicted segments {pred_segms.keys()}")
                 if label == VOID:
                     continue
                 # raise KeyError(

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -385,10 +385,9 @@ class PanopticQuality(evaluate.Metric):
 
             with io.BytesIO() as out:
                 seg_img.save(out, format="PNG")
-            
-            file_name = f"{image_id}.png"
-            with open(os.path.join(output_dir, file_name), "wb") as f:
-                f.write(out.getvalue())
+                file_name = f"{image_id}.png"
+                with open(os.path.join(output_dir, file_name), "wb") as f:
+                    f.write(out.getvalue())
 
         # step 2: create predictions JSON file
         # predicted_annotations is a list of segments_info

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -366,9 +366,9 @@ class PanopticQuality(evaluate.Metric):
 
     def _compute(
         self,
-        predictions=None,
+        predictions=None, # this corresponds to the png_string key of DetrPostProcess
         references=None,
-        predicted_annotations=None,
+        predicted_annotations=None, # list of dicts, each dict containing `segments_info`. Segments info is a list of dicts, each dict containing category_id, id, iscrowd, area, bbox
         image_ids=None,
         # references,
         # reference_annotations,
@@ -390,9 +390,9 @@ class PanopticQuality(evaluate.Metric):
                 with open(os.path.join(output_dir, file_name), "wb") as f:
                     f.write(out.getvalue())
 
-            for i in range(len(predicted_annotations[idx])):
-                predicted_annotations[idx][i]["image_id"] = image_id
-                predicted_annotations[idx][i]["file_name"] = file_name
+            # add image_id and file_name keys to each of the predicted annotations
+            predicted_annotations[idx]["image_id"] = image_id
+            predicted_annotations[idx]["file_name"] = file_name
 
         # step 2: create predictions JSON file
         # predicted_annotations is a list of segments_info

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -313,6 +313,8 @@ def pq_compute(gt_json_file, pred_json_file, gt_folder=None, pred_folder=None):
     if not os.path.isdir(pred_folder):
         raise Exception("Folder {} with predicted segmentations doesn't exist".format(pred_folder))
 
+    for el in pred_json["annotations"]:
+        print(el)
     pred_annotations = {el["image_id"]: el for el in pred_json["annotations"]}
     matched_annotations_list = []
     for gt_ann in gt_json["annotations"]:

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -356,16 +356,16 @@ class PanopticQuality(evaluate.Metric):
                 {
                     "predictions": datasets.Image(),
                     "references": datasets.Image(),
-                    # "predicted_annotations": {
-                    #     "segments_info": datasets.Sequence(
-                    #         {
-                    #             "id": datasets.Value("int32"),
-                    #             "category_id": datasets.Value("int32"),
-                    #             "was_fused": datasets.Value("bool"),
-                    #             "score": datasets.Value("float32"),
-                    #         }
-                    #     )
-                    # },
+                    "predicted_annotations": {
+                        "segments_info": datasets.Sequence(
+                            {
+                                "id": datasets.Value("int32"),
+                                "category_id": datasets.Value("int32"),
+                                "was_fused": datasets.Value("bool"),
+                                "score": datasets.Value("float32"),
+                            }
+                        )
+                    },
                     "reference_annotations": {
                         "segments_info": datasets.Sequence(
                             {

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -312,6 +312,8 @@ def pq_compute_single_core(proc_id, annotation_set, predictions, references, cat
 
 def pq_compute_multi_core(matched_annotations_list, predictions, references, categories):
     cpu_num = multiprocessing.cpu_count()
+    # fix cpu numbers for now (DEBUGGING)
+    cpu_num = 1
     annotations_split = np.array_split(matched_annotations_list, cpu_num)
     print("Number of cores: {}, images per core: {}".format(cpu_num, len(annotations_split[0])))
     workers = multiprocessing.Pool(processes=cpu_num)

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -382,7 +382,6 @@ class PanopticQuality(evaluate.Metric):
         # step 1: dump predicted segmentations to folder
         for idx, (seg_img, image_id) in enumerate(zip(predictions, image_ids)):
             seg_img = np.array(seg_img)
-            print("Shape of seg_img:", seg_img.shape)
             seg_img = Image.fromarray(id2rgb(seg_img))
 
             with io.BytesIO() as out:
@@ -391,7 +390,9 @@ class PanopticQuality(evaluate.Metric):
                 with open(os.path.join(output_dir, file_name), "wb") as f:
                     f.write(out.getvalue())
 
-            predicted_annotations[idx]["image_id"] = image_id
+            for i in range(len(predicted_annotations[idx])):
+                predicted_annotations[idx][i]["image_id"] = image_id
+                predicted_annotations[idx][i]["file_name"] = file_name
 
         # step 2: create predictions JSON file
         # predicted_annotations is a list of segments_info

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -361,6 +361,9 @@ class PanopticQuality(evaluate.Metric):
                             {
                                 "id": datasets.Value("uint16"),
                                 "category_id": datasets.Value("uint16"),
+                                "iscrowd": datasets.Value("uint16"),
+                                "area": datasets.Value("uint16"),
+                                "bbox": datasets.Sequence(datasets.Value("uint16")),
                             }
                         )
                     },
@@ -369,6 +372,8 @@ class PanopticQuality(evaluate.Metric):
                             {
                                 "id": datasets.Value("uint16"),
                                 "category_id": datasets.Value("uint16"),
+                                "was_fused": datasets.Value("bool"),
+                                "score": datasets.Value("float32"),
                             }
                         )
                     },

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -391,7 +391,7 @@ class PanopticQuality(evaluate.Metric):
                 with open(os.path.join(output_dir, file_name), "wb") as f:
                     f.write(out.getvalue())
 
-            predicted_annotations["image_id"] = image_id
+            predicted_annotations[idx]["image_id"] = image_id
 
         # step 2: create predictions JSON file
         # predicted_annotations is a list of segments_info

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -185,8 +185,11 @@ def pq_compute_single_core(proc_id, annotation_set, predictions, references, cat
         print("Ground truth annotation: ", gt_ann)
         print("Predicted annotation: ", pred_ann)
 
-        gt_segms = {el["id"]: el for el in gt_ann}
-        pred_segms = {el["id"]: el for el in pred_ann}
+        # gt_segms = {el["id"]: el for el in gt_ann}
+        # pred_segms = {el["id"]: el for el in pred_ann}
+
+        gt_segms = {id: {k:v[idx] for k,v in gt_ann.items()} for idx, id in enumerate(gt_ann['id'])}
+        pred_segms = {id: {k:v[idx] for k,v in pred_ann.items()} for idx, id in enumerate(pred_ann['id'])}
 
         # predicted segments area calculation + prediction sanity checks
         pred_labels_set = set(el["id"] for el in pred_ann)

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -359,8 +359,8 @@ class PanopticQuality(evaluate.Metric):
                     # "predicted_annotations": {
                     #     "segments_info": datasets.Sequence(
                     #         {
-                    #             "id": datasets.Value("uint16"),
-                    #             "category_id": datasets.Value("uint16"),
+                    #             "id": datasets.Value("int32"),
+                    #             "category_id": datasets.Value("int32"),
                     #             "was_fused": datasets.Value("bool"),
                     #             "score": datasets.Value("float32"),
                     #         }
@@ -369,11 +369,11 @@ class PanopticQuality(evaluate.Metric):
                     "reference_annotations": {
                         "segments_info": datasets.Sequence(
                             {
-                                "id": datasets.Value("uint16"),
-                                "category_id": datasets.Value("uint16"),
-                                "iscrowd": datasets.Value("uint16"),
-                                "area": datasets.Value("uint16"),
-                                "bbox": datasets.Sequence(datasets.Value("uint16")),
+                                "id": datasets.Value("int32"),
+                                "category_id": datasets.Value("int32"),
+                                "iscrowd": datasets.Value("int32"),
+                                "area": datasets.Value("int32"),
+                                "bbox": datasets.Sequence(datasets.Value("int32")),
                             }
                         )
                     },

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -174,11 +174,11 @@ def pq_compute_single_core(proc_id, annotation_set, predictions, references, cat
             print("Core: {}, {} from {} images processed".format(proc_id, idx, len(annotation_set)))
         idx += 1
 
-        # TODO perhaps work in the RGB space
+        # we go from RGB space to id space here
         # pan_gt = np.array(Image.open(os.path.join(gt_folder, gt_ann["file_name"])), dtype=np.uint32)
-        # pan_gt = rgb2id(pan_gt)
+        pan_gt = rgb2id(np.array(pan_gt))
         # pan_pred = np.array(Image.open(os.path.join(pred_folder, pred_ann["file_name"])), dtype=np.uint32)
-        # pan_pred = rgb2id(pan_pred)
+        pan_pred = rgb2id(np.array(pan_pred))
 
         gt_segms = {el["id"]: el for el in gt_ann["segments_info"]}
         pred_segms = {el["id"]: el for el in pred_ann["segments_info"]}
@@ -357,8 +357,8 @@ class PanopticQuality(evaluate.Metric):
                 {
                     "predictions": datasets.Image(),
                     "references": datasets.Image(),
-                    # "predicted_annotations": datasets.Sequence(dict),
-                    # "reference_annotations": datasets.Sequence(dict),
+                    "predicted_annotations": dict("segments_info"),
+                    "reference_annotations": dict("segments_info"),
                 }
             ),
             reference_urls=[

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -354,7 +354,7 @@ class PanopticQuality(evaluate.Metric):
             features=datasets.Features(
                 # 1st Seq - height dim, 2nd - width dim
                 {
-                    "predictions": datasets.Sequence(datasets.Sequence(datasets.Value("uint16"))),
+                    "predictions": datasets.Sequence(datasets.Image),
                 }
             ),
             reference_urls=[
@@ -380,9 +380,6 @@ class PanopticQuality(evaluate.Metric):
         # step 1: dump predicted segmentations to folder
         for seg_img, image_id in zip(predictions, image_ids):
             with io.BytesIO() as out:
-                print(type(seg_img))
-                print(seg_img)
-                seg_img = id2rgb(seg_img)
                 f.write(seg_img.save(out, format="PNG"))
             
             file_name = f"{image_id:012d}.png"

--- a/metrics/panoptic_quality/panoptic_quality.py
+++ b/metrics/panoptic_quality/panoptic_quality.py
@@ -354,7 +354,7 @@ class PanopticQuality(evaluate.Metric):
             features=datasets.Features(
                 # 1st Seq - height dim, 2nd - width dim
                 {
-                    "predictions": datasets.Sequence(datasets.Image),
+                    "predictions": datasets.Sequence(datasets.Sequence(datasets.Value("uint16"))),
                 }
             ),
             reference_urls=[
@@ -379,6 +379,8 @@ class PanopticQuality(evaluate.Metric):
 
         # step 1: dump predicted segmentations to folder
         for seg_img, image_id in zip(predictions, image_ids):
+            seg_img = Image.fromarray(id2rgb(np.array(seg_img)))
+
             with io.BytesIO() as out:
                 f.write(seg_img.save(out, format="PNG"))
             


### PR DESCRIPTION
This PR adds the panoptic quality (PQ) metric.

Unlike most metrics that only require 2 things to be provided to the add_batch method (which are the predictions and the references), the panoptic quality metric requires 2 additional things to be provided, namely the predicted `segments_info` and the ground truth `segments_info` (which contain more information about the predicted and ground truth segmentation map, respectively).

To do:

- [ ] support multiprocessing

