### PR TITLE
Fix minor typo in a_quick_tour.mdx

### DIFF
--- a/docs/source/a_quick_tour.mdx
+++ b/docs/source/a_quick_tour.mdx
@@ -207,7 +207,7 @@ Saving and sharing evaluation results is an important step. We provide the [`eva
 >>> result = accuracy.compute(references=[0,1,0,1], predictions=[1,0,0,1])
 
 >>> hyperparams = {"model": "bert-base-uncased"}
->>> evaluate.save("./results/"experiment="run 42", **result, **hyperparams)
+>>> evaluate.save("./results/", experiment="run 42", **result, **hyperparams)
 PosixPath('results/result-2022_05_30-22_09_11.json')
 ```
 

--- a/docs/source/a_quick_tour.mdx
+++ b/docs/source/a_quick_tour.mdx
@@ -366,7 +366,7 @@ class Suite(evaluate.EvaluationSuite):
         ]
 ```
 
-Evaluation can be run by loading the `EvaluationSuite` and calling `run()` method with a model or pipeline.
+Evaluation can be run by loading the `EvaluationSuite` and calling the `run()` method with a model or pipeline.
 
 ```
 >>> from evaluate import EvaluationSuite


### PR DESCRIPTION
This PR adds a missing comma in a call to `evaluate.save`, also a missing definite article near the end 😄 

I know this is a PR and not an issue, but I noticed in the `Save and push to the Hub` section there is a link which goes to a 404 page:

https://github.com/huggingface/datasets/blob/master/src/datasets/utils/resources/tasks.json

I looked a bit through the datasets repo but couldn't find an alternative `tasks.json`. Maybe we should change it to go to one of these pages instead? I can add this change as part of this PR if you want 🙂

- https://github.com/huggingface/datasets/tree/main/src/datasets/tasks
- https://huggingface.co/tasks
