### PR TITLE
Fix Docs base_evaluator.mdx

### DIFF
--- a/docs/source/base_evaluator.mdx
+++ b/docs/source/base_evaluator.mdx
@@ -154,7 +154,7 @@ models = [
     "Jorgeutd/albert-base-v2-finetuned-ner",
 ]
 
-data = load_dataset("conll2003", split="validation").shuffle().select(1000)
+data = load_dataset("conll2003", split="validation").shuffle().select(range(1000))
 task_evaluator = evaluator("token-classification")
 
 results = []


### PR DESCRIPTION
Example code `dataset.select(1000)` raises `TypeError: 'int' object is not iterable`, should be `dataset.select(range(1000))`, like in the previous example.