### PR TITLE
Fix broken link in docs/a_quick_tour.mdx

### DIFF
--- a/docs/source/a_quick_tour.mdx
+++ b/docs/source/a_quick_tour.mdx
@@ -239,7 +239,7 @@ evaluate.push_to_hub(
   dataset_type="wikitext",                # dataset name on the hub
   dataset_name="WikiText",                # pretty name
   dataset_split="test",                   # dataset split used
-  task_type="text-generation",            # task id, see https://github.com/huggingface/datasets/blob/master/src/datasets/utils/resources/tasks.json
+  task_type="text-generation",            # task id, see https://github.com/huggingface/evaluate/blob/7fa754cc38c523b69054c67b8c3b8e3f4962fbf6/src/evaluate/config.py#L154-L192
   task_name="Text Generation"             # pretty name for task
 )
 ```

--- a/docs/source/a_quick_tour.mdx
+++ b/docs/source/a_quick_tour.mdx
@@ -239,7 +239,7 @@ evaluate.push_to_hub(
   dataset_type="wikitext",                # dataset name on the hub
   dataset_name="WikiText",                # pretty name
   dataset_split="test",                   # dataset split used
-  task_type="text-generation",            # task id, see https://github.com/huggingface/evaluate/blob/7fa754cc38c523b69054c67b8c3b8e3f4962fbf6/src/evaluate/config.py#L154-L192
+  task_type="text-generation",            # task id, see https://github.com/huggingface/evaluate/blob/main/src/evaluate/config.py#L154-L192
   task_name="Text Generation"             # pretty name for task
 )
 ```


### PR DESCRIPTION
In the `Save and push to the Hub` section there is a link which goes to a 404 page:

[huggingface/datasets@master/src/datasets/utils/resources/tasks.json](https://github.com/huggingface/datasets/blob/master/src/datasets/utils/resources/tasks.json?rgh-link-date=2023-02-07T23%3A27%3A53Z)

As suggested in #417 , I'm opening a new PR to fix this link so that it points to the respective lines in `evaluate/src/evaluate/config.py` . 

The file reference is pinned to the current HEAD commit of `main` (7fa754cc), this ensures that the reference will always work (since it's a permalink) but it also means that it might eventually get stale. Should **not** pin the link to a specific commit?