### PR TITLE
fix `add` method

### DIFF
--- a/metrics/rouge/README.md
+++ b/metrics/rouge/README.md
@@ -60,6 +60,7 @@ It can also deal with lists of references for each predictions:
 ...                         references=references)
 >>> print(results)
 {'rouge1': 0.8333, 'rouge2': 0.5, 'rougeL': 0.8333, 'rougeLsum': 0.8333}```
+```
 
 ### Inputs
 - **predictions** (`list`): list of predictions to score. Each prediction

--- a/metrics/rouge/debug_test.py
+++ b/metrics/rouge/debug_test.py
@@ -1,0 +1,23 @@
+import evaluate
+
+rouge = evaluate.load("rouge")
+rouge.add(predictions="sentence 1", references="sentence 1")
+print(rouge.compute())
+
+# rouge = evaluate.load("rouge")
+# print("Adding predictions and references")
+# print(rouge.features)
+# predictions = ["hello there", "general kenobi"]
+# references = [["hello", "there"], ["general kenobi", "general yoda"]]
+# for sample_pred, sample_ref in zip(predictions, references):
+#     rouge.add(predictions=sample_pred, references=sample_ref)
+# # rouge.add(predictions= 0, references= 0)
+# print("Computing metrics")
+# print(rouge.compute())
+
+# print("Adding predictions and references")
+# predictions = ["hello there", "general kenobi"]
+# references = [["hello", "there"], ["general kenobi", "general yoda"]]
+# results = rouge.compute(predictions=predictions,
+#                        references=references)
+# print(results)

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -569,8 +569,8 @@ class EvaluationModule(EvaluationModuleInfoMixin):
             self.selected_feature_format = self._infer_feature_from_example(example)
             self._init_writer()
         try:
-            self._enforce_nested_string_type(self.info.features, example)
-            example = self.info.features.encode_example(example)
+            self._enforce_nested_string_type(self.selected_feature_format, example)
+            example = self.selected_feature_format.encode_example(example)
             self.writer.write(example)
         except (pa.ArrowInvalid, TypeError):
             error_msg = (


### PR DESCRIPTION
Fixes #355 

1.  Rouge's README.md typo correction
2.  changes in self.info.features

I've investigated two possible sources of error methods as per suggested by you @lvwerra, namely the `_infer_feature_from_example` or` _enforce_nested_string_type`.

After some debugging, I found that the former method may work as intended. It correctly picks the right schema format for a given prediction and reference input. For example, when I ran the code below, 

```
rouge = evaluate.load("rouge")
rouge.add(predictions="sentence 1", references="sentence 1")
print(rouge.compute())
```

there are two schemas available for rouge (as it supports multiple reference inputs for a single prediction) which are saved as a list like follows `[{'predictions': Value(dtype='string', id='sequence'), 'references': Sequence(feature=Value(dtype='string', id='sequence'), length=-1, id=None)}, {'predictions': Value(dtype='string', id='sequence'), 'references': Value(dtype='string', id='sequence')}]`. the method will then update the right format to `self.selected_feature_format`.

I suspect the problem arises when the code tries to call _enforce_nested_string_type on self.info.features which stores both schemas rather than the one that was chosen by `_infer_feature_from_example`. this discrepancy then leads to _enforce_nested_string_type enforcing on the reference _**sequence**_ schema when it was supposed to enforce it on the reference _**value**_ schema. 

So I changed self.info.features to self.selected_feature_format and it works. I tried on a few other tests that I created in `debug_test.py` and they all passed -  this probably isn't the right way of doing code tests but I'm new so yeah 😅. 