### PR TITLE
Update spaces gradio version to 3.19.1

### DIFF
--- a/metrics/accuracy/README.md
+++ b/metrics/accuracy/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/bertscore/README.md
+++ b/metrics/bertscore/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/bleu/README.md
+++ b/metrics/bleu/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/bleurt/README.md
+++ b/metrics/bleurt/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/brier_score/README.md
+++ b/metrics/brier_score/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/cer/README.md
+++ b/metrics/cer/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/character/README.md
+++ b/metrics/character/README.md
@@ -4,7 +4,7 @@ emoji: 🔤
 colorFrom: orange
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/charcut_mt/README.md
+++ b/metrics/charcut_mt/README.md
@@ -4,7 +4,7 @@ emoji: 🔤
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/chrf/README.md
+++ b/metrics/chrf/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/code_eval/README.md
+++ b/metrics/code_eval/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/comet/README.md
+++ b/metrics/comet/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/competition_math/README.md
+++ b/metrics/competition_math/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/coval/README.md
+++ b/metrics/coval/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/cuad/README.md
+++ b/metrics/cuad/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/exact_match/README.md
+++ b/metrics/exact_match/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/f1/README.md
+++ b/metrics/f1/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/frugalscore/README.md
+++ b/metrics/frugalscore/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/glue/README.md
+++ b/metrics/glue/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/google_bleu/README.md
+++ b/metrics/google_bleu/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/indic_glue/README.md
+++ b/metrics/indic_glue/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/mae/README.md
+++ b/metrics/mae/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/mahalanobis/README.md
+++ b/metrics/mahalanobis/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/mape/README.md
+++ b/metrics/mape/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/mase/README.md
+++ b/metrics/mase/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/matthews_correlation/README.md
+++ b/metrics/matthews_correlation/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/mauve/README.md
+++ b/metrics/mauve/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/mean_iou/README.md
+++ b/metrics/mean_iou/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/meteor/README.md
+++ b/metrics/meteor/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/mse/README.md
+++ b/metrics/mse/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/nist_mt/README.md
+++ b/metrics/nist_mt/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: purple
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/pearsonr/README.md
+++ b/metrics/pearsonr/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/perplexity/README.md
+++ b/metrics/perplexity/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/poseval/README.md
+++ b/metrics/poseval/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/precision/README.md
+++ b/metrics/precision/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/recall/README.md
+++ b/metrics/recall/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/rl_reliability/README.md
+++ b/metrics/rl_reliability/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/roc_auc/README.md
+++ b/metrics/roc_auc/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/rouge/README.md
+++ b/metrics/rouge/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/sacrebleu/README.md
+++ b/metrics/sacrebleu/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/sari/README.md
+++ b/metrics/sari/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/seqeval/README.md
+++ b/metrics/seqeval/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/smape/README.md
+++ b/metrics/smape/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/spearmanr/README.md
+++ b/metrics/spearmanr/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/squad/README.md
+++ b/metrics/squad/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/squad_v2/README.md
+++ b/metrics/squad_v2/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/super_glue/README.md
+++ b/metrics/super_glue/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/ter/README.md
+++ b/metrics/ter/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/trec_eval/README.md
+++ b/metrics/trec_eval/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/wer/README.md
+++ b/metrics/wer/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/wiki_split/README.md
+++ b/metrics/wiki_split/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/xnli/README.md
+++ b/metrics/xnli/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/metrics/xtreme_s/README.md
+++ b/metrics/xtreme_s/README.md
@@ -4,7 +4,7 @@ emoji: 🤗
 colorFrom: blue
 colorTo: red
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 tags:

--- a/templates/{{ cookiecutter.module_slug }}/README.md
+++ b/templates/{{ cookiecutter.module_slug }}/README.md
@@ -7,7 +7,7 @@ tags:
 - {{ cookiecutter.module_type }}
 description: "TODO: add a description here"
 sdk: gradio
-sdk_version: 3.0.2
+sdk_version: 3.19.1
 app_file: app.py
 pinned: false
 ---


### PR DESCRIPTION
Gradio 3.0.2 is a bit dated now. This PR updates _all_ current Gradio sdk versions to 3.19.1. The cookiecutter template is also updated.

fixes #422 