### PR TITLE
Update Gradio description to clarify text-based input

### DIFF
--- a/src/evaluate/utils/gradio.py
+++ b/src/evaluate/utils/gradio.py
@@ -118,8 +118,10 @@ def launch_gradio_widget(metric):
             datatype=json_to_string_type(gradio_input_types),
         ),
         outputs=gr.outputs.Textbox(label=metric.name),
-        description=metric.info.description + '\nIf this is a text-based metric, make sure to wrap you input in double'
-                                              ' quotes. Alternatively you can use a JSON-formatted list as input.',
+        description=(
+            metric.info.description + "\nIf this is a text-based metric, make sure to wrap you input in double quotes."
+            " Alternatively you can use a JSON-formatted list as input."
+        ),
         title=f"Metric: {metric.name}",
         article=parse_readme(local_path / "README.md"),
         # TODO: load test cases and use them to populate examples

--- a/src/evaluate/utils/gradio.py
+++ b/src/evaluate/utils/gradio.py
@@ -118,7 +118,8 @@ def launch_gradio_widget(metric):
             datatype=json_to_string_type(gradio_input_types),
         ),
         outputs=gr.outputs.Textbox(label=metric.name),
-        description=metric.info.description,
+        description=metric.info.description + '\nIf this is a text-based metric, make sure to wrap you input in double'
+                                              ' quotes. Alternatively you can use a JSON-formatted list as input.',
         title=f"Metric: {metric.name}",
         article=parse_readme(local_path / "README.md"),
         # TODO: load test cases and use them to populate examples


### PR DESCRIPTION
As discussed on internal Slack.

The input format for text-based metrics is not always clear. The Gradio app requires JSON-like input (so text enclosed in double quotes). If that is not given, an error is raised but not error details are given.

While ultimately a more informative error message would be the better solution, this PR provides a temporary solution by simply telling users the expected input format for text-based metrics.