### PR TITLE
Add pyarrow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ REQUIRED_PKGS = [
     # Utilities from PyPA to e.g., compare versions
     "packaging",
     "responses<0.19",
+    "pyarrow",
 ]
 
 TEMPLATE_REQUIRE = [


### PR DESCRIPTION
`pyarrow` is a [runtime dependency](https://github.com/huggingface/evaluate/blob/main/src/evaluate/module.py#L25) and also used for [testing](https://github.com/huggingface/evaluate/blob/main/tests/conftest.py#L9-L10).