### PR TITLE
Fix incorrect error instructing to "pip install sklearn"

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -260,6 +260,7 @@ def _download_additional_modules(
         try:
             lib = importlib.import_module(library_import_name)  # noqa F841
         except ImportError:
+            library_import_name = "scikit-learn" if library_import_name=="sklearn" else library_import_name
             needs_to_be_installed.add((library_import_name, library_import_path))
     if needs_to_be_installed:
         raise ImportError(


### PR DESCRIPTION
Fixes https://github.com/huggingface/evaluate/issues/394, and what I imagine is a frequent trip-up for people who forget that the correct pypi package name is "scikit-learn."