### PR TITLE
Update comet

### DIFF
--- a/metrics/comet/README.md
+++ b/metrics/comet/README.md
@@ -36,7 +36,11 @@ reference = ["They were able to control the fire.", "Schools and kindergartens o
 comet_score = comet_metric.compute(predictions=hypothesis, references=reference, sources=source)
 ```
 
-It has several configurations, named after the COMET model to be used. It will default to `wmt20-comet-da` (previously known as `wmt-large-da-estimator-1719`). Alternate models that can be chosen include `wmt20-comet-qe-da`, `wmt21-comet-mqm`, `wmt21-cometinho-da`, `wmt21-comet-qe-mqm` and `emnlp20-comet-rank`. Notably, a distilled model is also available, which is 80% smaller and 2.128x faster while performing close to non-distilled alternatives. You can use it with the identifier `eamt22-cometinho-da`. This version, called Cometinho, was elected as [the best paper](https://aclanthology.org/2022.eamt-1.9) at the annual European conference on machine translation.
+It has several configurations, named after the COMET model to be used. For versions below 2.0 it will default to `wmt20-comet-da` (previously known as `wmt-large-da-estimator-1719`) and for the latest versions (>= 2.0) it will default to `Unbabel/wmt22-comet-da`. 
+
+Alternative models that can be chosen include `wmt20-comet-qe-da`, `wmt21-comet-mqm`, `wmt21-cometinho-da`, `wmt21-comet-qe-mqm` and `emnlp20-comet-rank`. Notably, a distilled model is also available, which is 80% smaller and 2.128x faster while performing close to non-distilled alternatives. You can use it with the identifier `eamt22-cometinho-da`. This version, called Cometinho, was elected as [the best paper](https://aclanthology.org/2022.eamt-1.9) at the annual European conference on Machine Translation.
+
+> NOTE: In `unbabel-comet>=2.0` all models were moved to Hugging Face Hub and you need to add the suffix `Unbabel/` to be able to download and use them. For example for the distilled version replace `eamt22-cometinho-da` with `Unbabel/eamt22-cometinho-da`.
 
 It also has several optional arguments:
 
@@ -44,7 +48,7 @@ It also has several optional arguments:
 
 `progress_bar`a boolean -- if set to `True`, progress updates will be printed out. The default value is `False`.
 
-More information about model characteristics can be found on the [COMET website](https://unbabel.github.io/COMET/html/models.html).
+More information about model characteristics can be found on the [COMET website](https://unbabel.github.io/COMET/html/index.html).
 
 ## Output values
 
@@ -107,9 +111,40 @@ Afrikaans, Albanian, Amharic, Arabic, Armenian, Assamese, Azerbaijani, Basque, B
 
 Thus, results for language pairs containing uncovered languages are unreliable, as per the [COMET website](https://github.com/Unbabel/COMET)
 
-Also, calculating the COMET metric involves downloading the model from which features are obtained -- the default model, `wmt20-comet-da`, takes over 1.79GB of storage space and downloading it can take a significant amount of time depending on the speed of your internet connection. If this is an issue, choose a smaller model; for instance `wmt21-cometinho-da` is 344MB.
+Also, calculating the COMET metric involves downloading the model from which features are obtained -- the default model, `wmt22-comet-da`, takes over 2.32GB of storage space and downloading it can take a significant amount of time depending on the speed of your internet connection. If this is an issue, choose a smaller model; for instance `eamt22-cometinho-da` is 344MB.
+
+### Interpreting Scores:
+
+When using COMET to evaluate machine translation, it's important to understand how to interpret the scores it produces.
+
+In general, COMET models are trained to predict quality scores for translations. These scores are typically normalized using a z-score transformation to account for individual differences among annotators. While the raw score itself does not have a direct interpretation, it is useful for ranking translations and systems according to their quality.
+
+However, for the latest COMET models like `Unbabel/wmt22-comet-da`, we have introduced a new training approach that scales the scores between 0 and 1. This makes it easier to interpret the scores: a score close to 1 indicates a high-quality translation, while a score close to 0 indicates a translation that is no better than random chance.
+
+It's worth noting that when using COMET to compare the performance of two different translation systems, it's important to run statistical significance measures to reliably compare scores between systems.
 
 ## Citation
+```bibtex
+@inproceedings{rei-etal-2022-comet,
+    title = "{COMET}-22: Unbabel-{IST} 2022 Submission for the Metrics Shared Task",
+    author = "Rei, Ricardo  and
+      C. de Souza, Jos{\'e} G.  and
+      Alves, Duarte  and
+      Zerva, Chrysoula  and
+      Farinha, Ana C  and
+      Glushkova, Taisiya  and
+      Lavie, Alon  and
+      Coheur, Luisa  and
+      Martins, Andr{\'e} F. T.",
+    booktitle = "Proceedings of the Seventh Conference on Machine Translation (WMT)",
+    month = dec,
+    year = "2022",
+    address = "Abu Dhabi, United Arab Emirates (Hybrid)",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.wmt-1.52",
+    pages = "578--585",
+}
+```
 
 ```bibtex
 @inproceedings{rei-EtAl:2020:WMT,


### PR DESCRIPTION
[COMET metric](https://github.com/Unbabel/COMET) was recently updated to v2.0 and the predict interface returns a single class instead of two floats.

This pull request adds a simple verification to the package version and changes the behaviour accordingly.

Also, we updated the metric README which was slightly outdated. We recently released better and improved metrics that we developed for the [WMT22 Metrics shared task](https://www.statmt.org/wmt22/pdf/2022.wmt-1.52.pdf). For versions above 2.0 the default metric is `wmt22-comet-da` instead of `wmt20-comet-da`. This new model performs better across language pairs and domain while being more interpretable. You can check the [blogpost here](https://resources.unbabel.com/r-d-blog/introducing-unbabel-comet-v2-0).

