### PR TITLE
replace evaluate DownloadConfig with datasets

### DIFF
--- a/src/evaluate/evaluation_suite/__init__.py
+++ b/src/evaluate/evaluation_suite/__init__.py
@@ -4,12 +4,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, Optional, Union
 
-from datasets import Dataset, DownloadMode, load_dataset
+from datasets import Dataset, DownloadConfig, DownloadMode, load_dataset
 from datasets.utils.version import Version
 
 from ..evaluator import evaluator
 from ..loading import evaluation_module_factory
-from ..utils.file_utils import DownloadConfig
 from ..utils.logging import get_logger
 
 

--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Type, Union
 from urllib.parse import urlparse
 
-from datasets import DownloadMode
+from datasets import DownloadConfig, DownloadMode
 from datasets.builder import DatasetBuilder
 from datasets.packaged_modules import _EXTENSION_TO_MODULE, _hash_python_lines
 from datasets.utils.filelock import FileLock
@@ -36,7 +36,6 @@ from datasets.utils.version import Version
 from . import SCRIPTS_VERSION, config
 from .module import EvaluationModule
 from .utils.file_utils import (
-    DownloadConfig,
     cached_path,
     head_hf_s3,
     hf_hub_url,

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -23,13 +23,12 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pyarrow as pa
-from datasets import DatasetInfo, DownloadManager
+from datasets import DatasetInfo, DownloadConfig, DownloadManager
 from datasets.arrow_dataset import Dataset
 from datasets.arrow_reader import ArrowReader
 from datasets.arrow_writer import ArrowWriter
 from datasets.features import Features, Sequence, Value
 from datasets.features.features import _check_non_null_non_empty_recursive
-from datasets.utils.file_utils import DownloadConfig
 from datasets.utils.filelock import BaseFileLock, FileLock, Timeout
 from datasets.utils.py_utils import copyfunc, temp_seed, zip_dict
 

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -29,13 +29,13 @@ from datasets.arrow_reader import ArrowReader
 from datasets.arrow_writer import ArrowWriter
 from datasets.features import Features, Sequence, Value
 from datasets.features.features import _check_non_null_non_empty_recursive
+from datasets.utils.file_utils import DownloadConfig
 from datasets.utils.filelock import BaseFileLock, FileLock, Timeout
 from datasets.utils.py_utils import copyfunc, temp_seed, zip_dict
 
 from . import config
 from .info import EvaluationModuleInfo
 from .naming import camelcase_to_snakecase
-from .utils.file_utils import DownloadConfig
 from .utils.logging import get_logger
 
 

--- a/src/evaluate/utils/file_utils.py
+++ b/src/evaluate/utils/file_utils.py
@@ -16,14 +16,14 @@ import tempfile
 import time
 import urllib
 from contextlib import closing, contextmanager
-from dataclasses import dataclass
 from functools import partial
 from hashlib import sha256
 from pathlib import Path
-from typing import Dict, List, Optional, Type, TypeVar, Union
+from typing import List, Optional, Type, TypeVar, Union
 from urllib.parse import urljoin, urlparse
 
 import requests
+from datasets import DownloadConfig
 from datasets.utils.extract import ExtractManager
 from datasets.utils.filelock import FileLock
 
@@ -137,55 +137,6 @@ def hash_url_to_filename(url, etag=None):
         filename += ".py"
 
     return filename
-
-
-@dataclass
-class DownloadConfig:
-    """Configuration for our cached path manager.
-
-    Attributes:
-        cache_dir (:obj:`str` or :obj:`Path`, optional): Specify a cache directory to save the file to (overwrite the
-            default cache dir).
-        force_download (:obj:`bool`, default ``False``): If True, re-dowload the file even if it's already cached in
-            the cache dir.
-        resume_download (:obj:`bool`, default ``False``): If True, resume the download if incompletly recieved file is
-            found.
-        proxies (:obj:`dict`, optional):
-        user_agent (:obj:`str`, optional): Optional string or dict that will be appended to the user-agent on remote
-            requests.
-        extract_compressed_file (:obj:`bool`, default ``False``): If True and the path point to a zip or tar file,
-            extract the compressed file in a folder along the archive.
-        force_extract (:obj:`bool`, default ``False``): If True when extract_compressed_file is True and the archive
-            was already extracted, re-extract the archive and override the folder where it was extracted.
-        delete_extracted (:obj:`bool`, default ``False``): Whether to delete (or keep) the extracted files.
-        use_etag (:obj:`bool`, default ``True``): Whether to use the ETag HTTP response header to validate the cached files.
-        num_proc (:obj:`int`, optional): The number of processes to launch to download the files in parallel.
-        max_retries (:obj:`int`, default ``1``): The number of times to retry an HTTP request if it fails.
-        use_auth_token (:obj:`str` or :obj:`bool`, optional): Optional string or boolean to use as Bearer token
-            for remote files on the Datasets Hub. If True, will get token from ~/.huggingface.
-        ignore_url_params (:obj:`bool`, default ``False``): Whether to strip all query parameters and #fragments from
-            the download URL before using it for caching the file.
-        download_desc (:obj:`str`, optional): A description to be displayed alongside with the progress bar while downloading the files.
-    """
-
-    cache_dir: Optional[Union[str, Path]] = None
-    force_download: bool = False
-    resume_download: bool = False
-    local_files_only: bool = False
-    proxies: Optional[Dict] = None
-    user_agent: Optional[str] = None
-    extract_compressed_file: bool = False
-    force_extract: bool = False
-    delete_extracted: bool = False
-    use_etag: bool = True
-    num_proc: Optional[int] = None
-    max_retries: int = 1
-    use_auth_token: Optional[Union[str, bool]] = None
-    ignore_url_params: bool = False
-    download_desc: Optional[str] = None
-
-    def copy(self) -> "DownloadConfig":
-        return self.__class__(**{k: copy.deepcopy(v) for k, v in self.__dict__.items()})
 
 
 def cached_path(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -4,6 +4,7 @@ import tempfile
 from unittest import TestCase
 
 import pytest
+from datasets import DownloadConfig
 
 import evaluate
 from evaluate.loading import (
@@ -12,7 +13,6 @@ from evaluate.loading import (
     LocalEvaluationModuleFactory,
     evaluation_module_factory,
 )
-from evaluate.utils.file_utils import DownloadConfig
 
 from .utils import OfflineSimulationMode, offline
 


### PR DESCRIPTION
replaces internal `DownloadConfig` with the one from datasets for better compatibility.

Closes #440 