### PR TITLE
Removed unused and restrictive `responses` requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,7 @@ REQUIRED_PKGS = [
     # To get datasets from the Datasets Hub on huggingface.co
     "huggingface-hub>=0.7.0",
     # Utilities from PyPA to e.g., compare versions
-    "packaging",
-    "responses<0.19",
+    "packaging"
 ]
 
 TEMPLATE_REQUIRE = [


### PR DESCRIPTION
I removed the `responses` library from the requirements:
* it is not imported or used anywhere in the code
* it is pinned to a restrictive version that prevents installation of `evaluate` in some projects