### PR TITLE
feat: custom evaluator and metric name to support llm evaluation #433

### DIFF
--- a/src/evaluate/evaluation_suite/__init__.py
+++ b/src/evaluate/evaluation_suite/__init__.py
@@ -7,7 +7,7 @@ from typing import Callable, Dict, Optional, Union
 from datasets import Dataset, DownloadConfig, DownloadMode, load_dataset
 from datasets.utils.version import Version
 
-from ..evaluator import evaluator
+from ..evaluator import evaluator, Evaluator
 from ..loading import evaluation_module_factory
 from ..utils.logging import get_logger
 
@@ -18,6 +18,7 @@ logger = get_logger(__name__)
 @dataclass
 class SubTask:
     task_type: str
+    evaluator: Optional[Evaluator] = None
     data: [Union[str, Dataset]] = None
     subset: Optional[str] = None
     split: Optional[str] = None
@@ -114,7 +115,7 @@ class EvaluationSuite:
                 ds = load_dataset(task.data, name=task.subset, split=task.split)
                 task.data = ds.map(task.data_preprocessor)
 
-            task_evaluator = evaluator(task.task_type)
+            task_evaluator = task.evaluator or evaluator(task.task_type)
             args_for_task = task.args_for_task
             args_for_task["model_or_pipeline"] = model_or_pipeline
             args_for_task["data"] = task.data

--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -224,6 +224,7 @@ class Evaluator(ABC):
         subset: Optional[str] = None,
         split: Optional[str] = None,
         metric: Union[str, EvaluationModule] = None,
+        metric_config_name: Optional[str] = None,
         tokenizer: Optional[Union[str, "PreTrainedTokenizer"]] = None,  # noqa: F821
         feature_extractor: Optional[Union[str, "FeatureExtractionMixin"]] = None,  # noqa: F821
         strategy: Literal["simple", "bootstrap"] = "simple",
@@ -249,7 +250,7 @@ class Evaluator(ABC):
             feature_extractor=feature_extractor,
             device=device,
         )
-        metric = self.prepare_metric(metric)
+        metric = self.prepare_metric(metric, metric_config_name)
 
         # Compute predictions
         predictions, perf_results = self.call_pipeline(pipe, pipe_inputs)
@@ -477,7 +478,7 @@ class Evaluator(ABC):
             )
         return pipe
 
-    def prepare_metric(self, metric: Union[str, EvaluationModule]):
+    def prepare_metric(self, metric: Union[str, EvaluationModule], metric_config_name: Optional[str]):
         """
         Prepare metric.
 
@@ -504,7 +505,7 @@ class Evaluator(ABC):
                 )
             metric = load(self.default_metric_name)
         elif isinstance(metric, str):
-            metric = load(metric)
+            metric = load(metric, config_name=metric_config_name)
 
         return metric
 


### PR DESCRIPTION
I have taken the initiative to develop a project aimed at building a transparent, democratic, and reproducible framework for LLM evaluation, which can be found here https://huggingface.co/spaces/SUSTech/llm-evaluate/. The goal is to enable anyone to utilize datasets and metrics hosted on Hugging Face for evaluating their own LLM models and sharing their results, datasets, metrics, and more.

Currently, the implementation of the `evaluate` feature does not support a custom evaluator. To overcome this limitation, I have integrated a custom subtask and evaluator within the existing code of the evaluation module, https://huggingface.co/spaces/SUSTech/llm-evaluate/blob/main/utils.py.

However, I encountered a challenge when attempting to utilize the metric config name to define the task. As evident in the evaluator's source code https://github.com/huggingface/evaluate/blob/0ca575d7aa0764ea646dcd5a27cb952e587ce9eb/src/evaluate/evaluator/base.py#L480, the evaluator.compute function only accepts the metric name as an argument. Consequently, if I wish to pass the metric config name, it seems that I have no option but to override the entire `evaluator.compute` function.

This approach would lead to unnecessary code complexity and difficulty in maintaining my codebase as the evaluation module grows. So I create this PR draft for enhancing `evaluate` and eliminate this inconvenience.

It would be a great pleasure for me to provide any assistance that could contribute to the enhancement of this repository and ensure cleaner code implementation.

I appreciate your time and consideration of my request. Please let me know if there is any additional information or clarification I can provide. I am eagerly looking forward to your valuable feedback and guidance.


