### PR TITLE
Fix evaluator's docstring examples

### DIFF
--- a/src/evaluate/evaluation_suite/__init__.py
+++ b/src/evaluate/evaluation_suite/__init__.py
@@ -18,7 +18,7 @@ logger = get_logger(__name__)
 @dataclass
 class SubTask:
     task_type: str
-    data: [Union[str, Dataset]] = None
+    data: Optional[Union[str, Dataset]] = None
     subset: Optional[str] = None
     split: Optional[str] = None
     data_preprocessor: Optional[Callable] = None

--- a/src/evaluate/evaluator/audio_classification.py
+++ b/src/evaluate/evaluator/audio_classification.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from numbers import Number
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
 
 from datasets import Dataset
 from typing_extensions import Literal
@@ -21,6 +21,10 @@ from typing_extensions import Literal
 from ..module import EvaluationModule
 from ..utils.file_utils import add_end_docstrings, add_start_docstrings
 from .base import EVALUATOR_COMPUTE_RETURN_DOCSTRING, EVALUTOR_COMPUTE_START_DOCSTRING, Evaluator
+
+
+if TYPE_CHECKING:
+    from transformers import FeatureExtractionMixin, Pipeline, PreTrainedModel, PreTrainedTokenizer, TFPreTrainedModel
 
 
 TASK_DOCUMENTATION = r"""

--- a/src/evaluate/evaluator/automatic_speech_recognition.py
+++ b/src/evaluate/evaluator/automatic_speech_recognition.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
 
 from datasets import Dataset
 from typing_extensions import Literal
@@ -20,6 +20,10 @@ from typing_extensions import Literal
 from ..module import EvaluationModule
 from ..utils.file_utils import add_end_docstrings, add_start_docstrings
 from .base import EVALUATOR_COMPUTE_RETURN_DOCSTRING, EVALUTOR_COMPUTE_START_DOCSTRING, Evaluator
+
+
+if TYPE_CHECKING:
+    from transformers import Pipeline, PreTrainedModel, PreTrainedTokenizer, TFPreTrainedModel
 
 
 TASK_DOCUMENTATION = r"""

--- a/src/evaluate/evaluator/image_classification.py
+++ b/src/evaluate/evaluator/image_classification.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from numbers import Number
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
 
 from datasets import Dataset
 from typing_extensions import Literal
@@ -21,6 +21,10 @@ from typing_extensions import Literal
 from ..module import EvaluationModule
 from ..utils.file_utils import add_end_docstrings, add_start_docstrings
 from .base import EVALUATOR_COMPUTE_RETURN_DOCSTRING, EVALUTOR_COMPUTE_START_DOCSTRING, Evaluator
+
+
+if TYPE_CHECKING:
+    from transformers import FeatureExtractionMixin, Pipeline, PreTrainedModel, PreTrainedTokenizer, TFPreTrainedModel
 
 
 TASK_DOCUMENTATION = r"""

--- a/src/evaluate/evaluator/question_answering.py
+++ b/src/evaluate/evaluator/question_answering.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 # Lint as: python3
 from datasets import Dataset
@@ -30,6 +30,10 @@ from ..utils.file_utils import add_end_docstrings, add_start_docstrings
 from ..utils.logging import get_logger
 from .base import EVALUATOR_COMPUTE_RETURN_DOCSTRING, EVALUTOR_COMPUTE_START_DOCSTRING, Evaluator
 from .utils import DatasetColumn
+
+
+if TYPE_CHECKING:
+    from transformers import Pipeline, PreTrainedModel, PreTrainedTokenizer, TFPreTrainedModel
 
 
 logger = get_logger(__name__)

--- a/src/evaluate/evaluator/text_classification.py
+++ b/src/evaluate/evaluator/text_classification.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from numbers import Number
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
 
 from datasets import Dataset, load_dataset
 from typing_extensions import Literal
@@ -22,6 +22,10 @@ from ..module import EvaluationModule
 from ..utils.file_utils import add_end_docstrings, add_start_docstrings
 from .base import EVALUATOR_COMPUTE_RETURN_DOCSTRING, EVALUTOR_COMPUTE_START_DOCSTRING, Evaluator
 from .utils import DatasetColumnPair
+
+
+if TYPE_CHECKING:
+    from transformers import Pipeline, PreTrainedModel, PreTrainedTokenizer, TFPreTrainedModel
 
 
 TASK_DOCUMENTATION = r"""

--- a/src/evaluate/evaluator/token_classification.py
+++ b/src/evaluate/evaluator/token_classification.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 from datasets import ClassLabel, Dataset, Sequence
 from typing_extensions import Literal
@@ -21,6 +21,10 @@ from ..module import EvaluationModule
 from ..utils.file_utils import add_end_docstrings, add_start_docstrings
 from .base import EVALUATOR_COMPUTE_RETURN_DOCSTRING, EVALUTOR_COMPUTE_START_DOCSTRING, Evaluator
 from .utils import DatasetColumn
+
+
+if TYPE_CHECKING:
+    from transformers import Pipeline, PreTrainedModel, PreTrainedTokenizer, TFPreTrainedModel
 
 
 TASK_DOCUMENTATION = r"""


### PR DESCRIPTION
The Text2TextGenerationEvaluators'  `.compute` method [docstring](https://huggingface.co/docs/evaluate/main/en/package_reference/evaluator_classes#evaluate.Text2TextGenerationEvaluator) does not display the examples block (due to wrong indentation), so this PR fixes that and improves type hints.
