### PR TITLE
Trigger CI on ci-* branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - ci-*
 
 env:
   HF_ALLOW_CODE_EVAL: 1


### PR DESCRIPTION
Similar to the config in [transformers](https://github.com/huggingface/transformers/blob/fabe17a726bbf6081cfbcc975d8ac451a81f3e2d/.github/workflows/self-push.yml#L11) and [datasets](https://github.com/huggingface/datasets/blob/d6a61a1af1502677a6f2333896a6ffeede9ca21b/.github/workflows/ci.yml#L10). The goal is to trigger the tests without having to create a dumb PR (like [this one](https://github.com/huggingface/diffusers/pull/3633#issuecomment-1571773934)). Will be helpful for future pre-releases of `huggingface_hub`.