### PR TITLE
Fix mean computation in Mahalanobis distance

### DIFF
--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -22,7 +22,7 @@ import evaluate
 _DESCRIPTION = """
 Compute the Mahalanobis Distance
 
-Mahalonobis distance is the distance between a point and a distribution.
+Mahalanobis distance is the distance between a point and a distribution.
 And not between two distinct points. It is effectively a multivariate equivalent of the Euclidean distance.
 It was introduced by Prof. P. C. Mahalanobis in 1936
 and has been used in various statistical applications ever since
@@ -47,7 +47,7 @@ Args:
     X: List of datapoints to be compared with the `reference_distribution`.
     reference_distribution: List of datapoints from the reference distribution we want to compare to.
 Returns:
-    mahalanobis: The Mahalonobis distance for each datapoint in `X`.
+    mahalanobis: The Mahalanobis distance for each datapoint in `X`.
 Examples:
 
     >>> mahalanobis_metric = evaluate.load("mahalanobis")

--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -88,7 +88,8 @@ class Mahalanobis(evaluate.Metric):
             )
 
         # Get mahalanobis distance for each prediction
-        X_minus_mu = X - np.mean(reference_distribution)
+        mu = np.mean(reference_distribution, axis=0)
+        X_minus_mu = X - mu
         cov = np.cov(reference_distribution.T)
         try:
             inv_covmat = np.linalg.inv(cov)


### PR DESCRIPTION
This PR fixes the computation of `X_minus_mu` for the Mahalanobis distance, as described in #470 .
In addition, I also fixed two typos where "Mahalanobis" was misspelled as "Mahalonobis".