### PR TITLE
Adding tokenizer_id to perplexity evaluation

### DIFF
--- a/metrics/perplexity/README.md
+++ b/metrics/perplexity/README.md
@@ -44,6 +44,7 @@ results = perplexity.compute(predictions=predictions, model_id='gpt2')
 ### Inputs
 - **model_id** (str): model used for calculating Perplexity. NOTE: Perplexity can only be calculated for causal language models.
     - This includes models such as gpt2, causal variations of bert, causal versions of t5, and more (the full list can be found in the AutoModelForCausalLM documentation here: https://huggingface.co/docs/transformers/master/en/model_doc/auto#transformers.AutoModelForCausalLM )
+- **tokenizer_id** (str): tokenizer used for calculating Perplexity.
 - **predictions** (list of str): input text, where each separate text snippet is one list entry.
 - **batch_size** (int): the batch size to run texts through the model. Defaults to 16.
 - **add_start_token** (bool): whether to add the start token to the texts, so the perplexity can include the probability of the first word. Defaults to True.

--- a/metrics/perplexity/perplexity.py
+++ b/metrics/perplexity/perplexity.py
@@ -43,6 +43,7 @@ Args:
                     in the AutoModelForCausalLM documentation here:
                     https://huggingface.co/docs/transformers/master/en/model_doc/auto#transformers.AutoModelForCausalLM )
 
+    tokenizer_id (str): tokenizer used for calculating Perplexity.
     predictions (list of str): input text, each separate text snippet
         is one list entry.
     batch_size (int): the batch size to run texts through the model. Defaults to 16.
@@ -101,7 +102,14 @@ class Perplexity(evaluate.Metric):
         )
 
     def _compute(
-        self, predictions, model_id, batch_size: int = 16, add_start_token: bool = True, device=None, max_length=None
+        self,
+        predictions,
+        model_id,
+        tokenizer_id,
+        batch_size: int = 16,
+        add_start_token: bool = True,
+        device=None,
+        max_length=None,
     ):
 
         if device is not None:
@@ -114,7 +122,10 @@ class Perplexity(evaluate.Metric):
         model = AutoModelForCausalLM.from_pretrained(model_id)
         model = model.to(device)
 
-        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        if tokenizer_id is None:
+            tokenizer_id = model_id
+
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_id)
 
         # if batch_size > 1 (which generally leads to padding being required), and
         # if there is not an already assigned pad_token, assign an existing


### PR DESCRIPTION
The motivation behind this PR is to allow a tokenizer different from the model.
This is useful when you are running in an air-gapped environment and the tokenizer lives in a different place.