### PR TITLE
when using custom models for perplexity metrix, support trust_remote_code

### DIFF
--- a/measurements/perplexity/perplexity.py
+++ b/measurements/perplexity/perplexity.py
@@ -102,7 +102,7 @@ class Perplexity(evaluate.Measurement):
         )
 
     def _compute(
-        self, data, model_id, batch_size: int = 16, add_start_token: bool = True, device=None, max_length=None
+        self, data, model_id, batch_size: int = 16, add_start_token: bool = True, device=None, max_length=None, trust_remote_code=None
     ):
 
         if device is not None:
@@ -112,10 +112,10 @@ class Perplexity(evaluate.Measurement):
         else:
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        model = AutoModelForCausalLM.from_pretrained(model_id)
+        model = AutoModelForCausalLM.from_pretrained(model_id, trust_remote_code=trust_remote_code)
         model = model.to(device)
 
-        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)
 
         # if batch_size > 1 (which generally leads to padding being required), and
         # if there is not an already assigned pad_token, assign an existing

--- a/metrics/perplexity/perplexity.py
+++ b/metrics/perplexity/perplexity.py
@@ -101,7 +101,7 @@ class Perplexity(evaluate.Metric):
         )
 
     def _compute(
-        self, predictions, model_id, batch_size: int = 16, add_start_token: bool = True, device=None, max_length=None
+        self, predictions, model_id, batch_size: int = 16, add_start_token: bool = True, device=None, max_length=None, trust_remote_code=None
     ):
 
         if device is not None:
@@ -111,10 +111,10 @@ class Perplexity(evaluate.Metric):
         else:
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        model = AutoModelForCausalLM.from_pretrained(model_id)
+        model = AutoModelForCausalLM.from_pretrained(model_id, trust_remote_code=trust_remote_code)
         model = model.to(device)
 
-        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)
 
         # if batch_size > 1 (which generally leads to padding being required), and
         # if there is not an already assigned pad_token, assign an existing


### PR DESCRIPTION
Use other models to compute perplexity that might need trust_remote_code support