### PR TITLE
removed unnecessary `module_type` attribute

### DIFF
--- a/measurements/honest/honest.py
+++ b/measurements/honest/honest.py
@@ -115,7 +115,6 @@ class Honest(evaluate.Measurement):
 
     def _info(self):
         return evaluate.MeasurementInfo(
-            module_type="measurement",
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/measurements/label_distribution/label_distribution.py
+++ b/measurements/label_distribution/label_distribution.py
@@ -72,7 +72,6 @@ _CITATION = """\
 class LabelDistribution(evaluate.Measurement):
     def _info(self):
         return evaluate.MeasurementInfo(
-            module_type="measurement",
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/measurements/perplexity/perplexity.py
+++ b/measurements/perplexity/perplexity.py
@@ -89,7 +89,6 @@ Examples:
 class Perplexity(evaluate.Measurement):
     def _info(self):
         return evaluate.MeasurementInfo(
-            module_type="measurement",
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -121,7 +121,6 @@ class Regard(evaluate.Measurement):
         if self.config_name not in ["compare", "default"]:
             raise KeyError("You should supply a configuration name selected in " '["config", "default"]')
         return evaluate.MeasurementInfo(
-            module_type="measurement",
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/measurements/text_duplicates/text_duplicates.py
+++ b/measurements/text_duplicates/text_duplicates.py
@@ -64,8 +64,6 @@ class TextDuplicates(evaluate.Measurement):
     def _info(self):
         # TODO: Specifies the evaluate.MeasurementInfo object
         return evaluate.MeasurementInfo(
-            # This is the description that will appear on the modules page.
-            module_type="measurement",
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/measurements/toxicity/toxicity.py
+++ b/measurements/toxicity/toxicity.py
@@ -110,7 +110,6 @@ def toxicity(preds, toxic_classifier, toxic_label):
 class Toxicity(evaluate.Measurement):
     def _info(self):
         return evaluate.MeasurementInfo(
-            module_type="measurement",
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/measurements/word_count/word_count.py
+++ b/measurements/word_count/word_count.py
@@ -48,8 +48,6 @@ class WordCount(evaluate.Measurement):
 
     def _info(self):
         return evaluate.MeasurementInfo(
-            # This is the description that will appear on the modules page.
-            module_type="measurement",
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,

--- a/measurements/word_length/word_length.py
+++ b/measurements/word_length/word_length.py
@@ -59,8 +59,6 @@ class WordLength(evaluate.Measurement):
     def _info(self):
         # TODO: Specifies the evaluate.MeasurementInfo object
         return evaluate.MeasurementInfo(
-            # This is the description that will appear on the modules page.
-            module_type="measurement",
             description=_DESCRIPTION,
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,


### PR DESCRIPTION
The `module_type` is defined in the `MeasurementInfo` class, which is created specifically to define this attribute.
Reassigning `module_type` in measurements makes the `MeasurementInfo` class unnecessary. 
So, I've removed `module_type` from the measurements