### PR TITLE
docs: specify micro average in seqeval README

### DIFF
--- a/metrics/seqeval/README.md
+++ b/metrics/seqeval/README.md
@@ -72,11 +72,11 @@ Overall:
 
 `accuracy`: the average [accuracy](https://huggingface.co/metrics/accuracy), on a scale between 0.0 and 1.0.
     
-`precision`: the average [precision](https://huggingface.co/metrics/precision), on a scale between 0.0 and 1.0.
+`precision`: the micro average [precision](https://huggingface.co/metrics/precision), on a scale between 0.0 and 1.0.
     
-`recall`: the average [recall](https://huggingface.co/metrics/recall), on a scale between 0.0 and 1.0.
+`recall`: the micro average [recall](https://huggingface.co/metrics/recall), on a scale between 0.0 and 1.0.
 
-`f1`: the average [F1 score](https://huggingface.co/metrics/f1), which is the harmonic mean of the precision and recall. It also has a scale of 0.0 to 1.0.
+`f1`: the micro average [F1 score](https://huggingface.co/metrics/f1), which is the harmonic mean of the precision and recall. It also has a scale of 0.0 to 1.0.
 
 Per type (e.g. `MISC`, `PER`, `LOC`,...):
 


### PR DESCRIPTION
The current documentation does not specify what kind of Precision/Recall/F1 scores are being returned for the `seqeval` measures. According to the [code](https://github.com/huggingface/evaluate/blob/728bd3e975809c2bc0d0575ac7783579a622ea80/metrics/seqeval/seqeval.py#L148C48-L148C48), only the micro scores are returned for the _overall_ category.

I updated the README file to mention this information explicitly. 