### PR TITLE
Add custom device selection such as 'cuda:1' for perplexity

### DIFF
--- a/metrics/perplexity/perplexity.py
+++ b/metrics/perplexity/perplexity.py
@@ -105,9 +105,12 @@ class Perplexity(evaluate.Metric):
     ):
 
         if device is not None:
-            assert device in ["gpu", "cpu", "cuda"], "device should be either gpu or cpu."
             if device == "gpu":
                 device = "cuda"
+            try:
+                device = torch.device(device)
+            except Exception as e:
+                raise e
         else:
             device = "cuda" if torch.cuda.is_available() else "cpu"
 


### PR DESCRIPTION
Current `device` of perplexity can only be one of `gpu`, `cpu` or `cuda`. This PR enables users to run perplexity on devices such as `cuda:1`.