### PR TITLE
Added the ability to return the dictionary to the WER metric.

### DIFF
--- a/metrics/wer/wer.py
+++ b/metrics/wer/wer.py
@@ -96,7 +96,7 @@ class WER(evaluate.Metric):
     def _compute(self, predictions=None, references=None, concatenate_texts=False, return_dict=False):
         if concatenate_texts:
             if return_dict:
-                return {"wer" : (compute_measures(references, predictions)["wer")]}
+                return {"wer" : (compute_measures(references, predictions)["wer"])}
             return compute_measures(references, predictions)["wer"]
         else:
             incorrect = 0

--- a/metrics/wer/wer.py
+++ b/metrics/wer/wer.py
@@ -93,8 +93,10 @@ class WER(evaluate.Metric):
             ],
         )
 
-    def _compute(self, predictions=None, references=None, concatenate_texts=False):
+    def _compute(self, predictions=None, references=None, concatenate_texts=False, return_dict=False):
         if concatenate_texts:
+            if return_dict:
+                return {"wer" : (compute_measures(references, predictions)["wer")]}
             return compute_measures(references, predictions)["wer"]
         else:
             incorrect = 0
@@ -103,4 +105,6 @@ class WER(evaluate.Metric):
                 measures = compute_measures(reference, prediction)
                 incorrect += measures["substitutions"] + measures["deletions"] + measures["insertions"]
                 total += measures["substitutions"] + measures["deletions"] + measures["hits"]
+            if return_dict:
+                return {"wer" : (incorrect / total)}
             return incorrect / total


### PR DESCRIPTION
Hello. Added the ability to return the result in the dictionary to the WER metric. I'm not sure I've done everything correctly (it's the first time I suggest changes for the bibiloteka). #516

The essence of the problem: Because the WER metric returns a value, but not a dictionary containing the name of the metric and its value, with it often have to do unnecessary conversion constructs. 

This is my proposal to solve this problem while maintaining compatibility with the old code.

That is, add an additional parameter to this metric that has a default value. This parameter defines the type of the returned parameter.

I will be grateful if you can tell me how to test and what else should be done.