### PR TITLE
Fix toxicity and regard measurements to default to GPU inference

### DIFF
--- a/measurements/regard/regard.py
+++ b/measurements/regard/regard.py
@@ -17,6 +17,7 @@
 from collections import defaultdict
 from operator import itemgetter
 from statistics import mean
+import torch
 
 import datasets
 from transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline
@@ -142,8 +143,15 @@ class Regard(evaluate.Measurement):
     def _download_and_prepare(self, dl_manager):
         regard_tokenizer = AutoTokenizer.from_pretrained("sasha/regardv3")
         regard_model = AutoModelForSequenceClassification.from_pretrained("sasha/regardv3")
+
+        device = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
         self.regard_classifier = pipeline(
-            "text-classification", model=regard_model, top_k=4, tokenizer=regard_tokenizer, truncation=True
+            "text-classification",
+            model=regard_model,
+            top_k=4, 
+            tokenizer=regard_tokenizer,
+            truncation=True,
+            device=device
         )
 
     def _compute(

--- a/measurements/toxicity/toxicity.py
+++ b/measurements/toxicity/toxicity.py
@@ -14,6 +14,8 @@
 
 """ Toxicity detection measurement. """
 
+import torch
+
 import datasets
 from transformers import pipeline
 
@@ -129,7 +131,9 @@ class Toxicity(evaluate.Measurement):
             model_name = "facebook/roberta-hate-speech-dynabench-r4-target"
         else:
             model_name = self.config_name
-        self.toxic_classifier = pipeline("text-classification", model=model_name, top_k=99999, truncation=True)
+
+        device = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
+        self.toxic_classifier = pipeline("text-classification", model=model_name, top_k=99999, truncation=True, device=device)
 
     def _compute(self, predictions, aggregation="all", toxic_label="hate", threshold=0.5):
         scores = toxicity(predictions, self.toxic_classifier, toxic_label)


### PR DESCRIPTION
It would likely be better to passthrough the torch device, but defaulting to GPU inference seems at least much better than defaulting to CPU inference.