### PR TITLE
[metric] macro and weighted average metrics for seqeval

### DIFF
--- a/metrics/seqeval/README.md
+++ b/metrics/seqeval/README.md
@@ -103,7 +103,7 @@ Maximal values (full match) :
 >>> references = [['O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
 >>> results = seqeval.compute(predictions=predictions, references=references)
 >>> print(results)
-{'MISC': {'precision': 1.0, 'recall': 1.0, 'f1': 1.0, 'number': 1}, 'PER': {'precision': 1.0, 'recall': 1.0, 'f1': 1.0, 'number': 1}, 'overall_precision': 1.0, 'overall_recall': 1.0, 'overall_f1': 1.0, 'overall_accuracy': 1.0}
+{'MISC': {'precision': 1.0, 'recall': 1.0, 'f1': 1.0, 'number': 1}, 'PER': {'precision': 1.0, 'recall': 1.0, 'f1': 1.0, 'number': 1}, 'overall_precision': 1.0, 'overall_recall': 1.0, 'overall_f1': 1.0, 'overall_accuracy': 1.0, 'macro_precision': 1.0, 'macro_recall': 1.0, 'macro_f1': 1.0, 'weighted_precision': 1.0, 'weighted_recall': 1.0, 'weighted_f1': 1.0}
 
 ```
 
@@ -115,7 +115,7 @@ Minimal values (no match):
 >>> references = [['B-MISC', 'O', 'O'], ['I-PER', '0', 'I-PER']]
 >>> results = seqeval.compute(predictions=predictions, references=references)
 >>> print(results)
-{'MISC': {'precision': 0.0, 'recall': 0.0, 'f1': 0.0, 'number': 1}, 'PER': {'precision': 0.0, 'recall': 0.0, 'f1': 0.0, 'number': 2}, '_': {'precision': 0.0, 'recall': 0.0, 'f1': 0.0, 'number': 1}, 'overall_precision': 0.0, 'overall_recall': 0.0, 'overall_f1': 0.0, 'overall_accuracy': 0.0}
+{'MISC': {'precision': 0.0, 'recall': 0.0, 'f1': 0.0, 'number': 1}, 'PER': {'precision': 0.0, 'recall': 0.0, 'f1': 0.0, 'number': 2}, '_': {'precision': 0.0, 'recall': 0.0, 'f1': 0.0, 'number': 1}, 'overall_precision': 0.0, 'overall_recall': 0.0, 'overall_f1': 0.0, 'overall_accuracy': 0.0, 'macro_precision': 0.0, 'macro_recall': 0.0, 'macro_f1': 0.0, 'weighted_precision': 0.0, 'weighted_recall': 0.0, 'weighted_f1': 0.0}
 ```
 
 Partial match:
@@ -126,7 +126,7 @@ Partial match:
 >>> references = [['O', 'O', 'O', 'B-MISC', 'I-MISC', 'I-MISC', 'O'], ['B-PER', 'I-PER', 'O']]
 >>> results = seqeval.compute(predictions=predictions, references=references)
 >>> print(results)
-{'MISC': {'precision': 0.0, 'recall': 0.0, 'f1': 0.0, 'number': 1}, 'PER': {'precision': 1.0, 'recall': 1.0, 'f1': 1.0, 'number': 1}, 'overall_precision': 0.5, 'overall_recall': 0.5, 'overall_f1': 0.5, 'overall_accuracy': 0.8}
+{'MISC': {'precision': 0.0, 'recall': 0.0, 'f1': 0.0, 'number': 1}, 'PER': {'precision': 1.0, 'recall': 1.0, 'f1': 1.0, 'number': 1}, 'overall_precision': 0.5, 'overall_recall': 0.5, 'overall_f1': 0.5, 'overall_accuracy': 0.8, 'macro_precision': 0.5, 'macro_recall': 0.5, 'macro_f1': 0.5, 'weighted_precision': 0.5, 'weighted_recall': 0.5, 'weighted_f1': 0.5}
 ```
 
 ## Limitations and bias

--- a/metrics/seqeval/seqeval.py
+++ b/metrics/seqeval/seqeval.py
@@ -80,6 +80,14 @@ Returns:
             'precision': precision,
             'recall': recall,
             'f1': F1 score, also known as balanced F-score or F-measure,
+        Macro average:
+            'macro_precision': macro precision,
+            'macro_recall': macro recall,
+            'macro_f1': macro F1 score
+        Weighted average:
+            'weighted_precision': weighted precision,
+            'weighted_recall': weighted recall,
+            'weighted_f1': weighted F1 score
         Per type:
             'precision': precision,
             'recall': recall,
@@ -143,8 +151,8 @@ class Seqeval(evaluate.Metric):
             sample_weight=sample_weight,
             zero_division=zero_division,
         )
-        report.pop("macro avg")
-        report.pop("weighted avg")
+        macro_score = report.pop("macro avg")
+        weighted_score = report.pop("weighted avg")
         overall_score = report.pop("micro avg")
 
         scores = {
@@ -160,5 +168,13 @@ class Seqeval(evaluate.Metric):
         scores["overall_recall"] = overall_score["recall"]
         scores["overall_f1"] = overall_score["f1-score"]
         scores["overall_accuracy"] = accuracy_score(y_true=references, y_pred=predictions)
+
+        scores["macro_precision"] = macro_score["precision"]
+        scores["macro_recall"] = macro_score["recall"]
+        scores["macro_f1"] = macro_score["f1-score"]
+
+        scores["weighted_precision"] = weighted_score["precision"]
+        scores["weighted_recall"] = weighted_score["recall"]
+        scores["weighted_f1"] = weighted_score["f1-score"]
 
         return scores


### PR DESCRIPTION
Hi everyone!

I've noticed that seqeval module doesn't return weighted and macro metrics, but sometimes it's good to get them back. On the another hand, seqeval library calculates them.
So, the thing is only in `pop` (remove) metrics out in the evaluate library. 


Default previous behavior:
removing "macro" and "weighted" metrics
```python
report.pop("macro avg")
report.pop("weighted avg")
```

Current behavior:
Add them as supplement metrics into final metrics dictionary


  