### PR TITLE
missing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ REQUIRED_PKGS = [
     "huggingface-hub>=0.7.0",
     # Utilities from PyPA to e.g., compare versions
     "packaging",
+    "scikit-learn",
 ]
 
 TEMPLATE_REQUIRE = [
@@ -89,7 +90,6 @@ TESTS_REQUIRE = [
     "sacremoses",
     "scipy",
     "seqeval",
-    "scikit-learn",
     "jiwer",
     "sentencepiece",  # for bleurt
     "transformers", # for evaluator


### PR DESCRIPTION
following with the installation instructions: 
```
pip install evaluate 
```
then it fails with missing `sklearn`
```
Traceback (most recent call last):
  File "/home/stas/test/test-evaluate.py", line 10, in <module>
    metric = load("accuracy",
  File "/env/lib/conda/evaluate-test/lib/python3.9/site-packages/evaluate/loading.py", line 751, in load
    evaluation_cls = import_main_class(evaluation_module.module_path)
  File "/env/lib/conda/evaluate-test/lib/python3.9/site-packages/evaluate/loading.py", line 76, in import_main_class
    module = importlib.import_module(module_path)
  File "/env/lib/conda/evaluate-test/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/data/huggingface/modules/evaluate_modules/metrics/evaluate-metric--accuracy/f887c0aab52c2d38e1f8a215681126379eca617f96c447638f751434e8e65b14/accuracy.py", line 17, in <module>
    from sklearn.metrics import accuracy_score
ModuleNotFoundError: No module named 'sklearn'
```

on:
```
from evaluate import load
metric = load("accuracy", ...)
```
so proposing to move the requirements as suggested in this PR

alternatively, installation docs should be updated.