### PR TITLE
Speeding up mean_iou metric computation

### DIFF
--- a/metrics/mean_iou/README.md
+++ b/metrics/mean_iou/README.md
@@ -27,13 +27,13 @@ For binary (two classes) or multi-class segmentation, the *mean IoU* of the imag
 
 ## How to Use
 
-The Mean IoU metric takes two numeric arrays as input corresponding to the predicted and ground truth segmentations:
+The Mean IoU metric takes two lists of numeric 2D arrays as input corresponding to the predicted and ground truth segmentations:
 ```python
 >>> import numpy as np
 >>> mean_iou = evaluate.load("mean_iou")
 >>> predicted = np.array([[2, 2, 3], [8, 2, 4], [3, 255, 2]])
 >>> ground_truth = np.array([[1, 2, 2], [8, 2, 1], [3, 255, 1]])
->>> results = mean_iou.compute(predictions=predicted, references=ground_truth, num_labels=10, ignore_index=255)
+>>> results = mean_iou.compute(predictions=[predicted], references=[ground_truth], num_labels=10, ignore_index=255)
 ```
 
 ### Inputs

--- a/metrics/mean_iou/mean_iou.py
+++ b/metrics/mean_iou/mean_iou.py
@@ -281,10 +281,9 @@ class MeanIoU(evaluate.Metric):
             citation=_CITATION,
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
-                # 1st Seq - height dim, 2nd - width dim
                 {
-                    "predictions": datasets.Sequence(datasets.Sequence(datasets.Value("uint16"))),
-                    "references": datasets.Sequence(datasets.Sequence(datasets.Value("uint16"))),
+                    "predictions": datasets.Image(),
+                    "references": datasets.Image(),
                 }
             ),
             reference_urls=[


### PR DESCRIPTION
Working with [semantic-segmentation](https://github.com/huggingface/transformers/tree/main/examples/pytorch/semantic-segmentation) example I observed that the `mean_iou` metric takes quite a significant time for computation (the time is comparable with a training loop).

The cause of such behavior is a conversion of resulted numpy arrays with segmentation maps to dataset format. Currently `mean_iou` metric supposes all segmentation arrays to be converted to `datasets.Sequence(datasets.Sequence(datasets.Value("uint16")))` which means converting every item of the arrays.

This PR aims to speed up the `mean_iou` by changing the Features type to `datasets.Image()`.

Here is a short script to measure computation time

```python
import time
import numpy as np
import evaluate

image_size = 256
num_images = 100
num_labels = 10

# Prepare some random data
np.random.seed(4215)
references = np.random.rand(num_images, image_size, image_size) * (num_labels - 1)
predictions = np.random.rand(num_images, image_size, image_size) * (num_labels - 1)

references = references.round().astype(np.uint16)
predictions = predictions.round().astype(np.uint16)

# Load the slow and fast implementations
slow_iou = evaluate.load("mean_iou")  # the one from evaluate lib
faster_iou = evaluate.load("./metrics/mean_iou/")  # the local, modified one

# Track the time taken for each implementation
slow_iou_start = time.time()
slow_iou_results = slow_iou.compute(
    predictions=predictions,
    references=references,
    num_labels=num_labels,
    ignore_index=0,
    reduce_labels=False,
)
slow_iou_time = time.time() - slow_iou_start
slow_mean_iou = slow_iou_results["mean_iou"]
print(f"Slow IOU: {slow_mean_iou:.3f} in {slow_iou_time:.2f} seconds")

faster_iou_start = time.time()
faster_iou_results = faster_iou.compute(
    predictions=predictions,
    references=references,
    num_labels=num_labels,
    ignore_index=0,
    reduce_labels=False,
)
faster_iou_time = time.time() - faster_iou_start
faster_mean_iou = faster_iou_results["mean_iou"]
print(f"Faster IOU: {faster_mean_iou:.3f} in {faster_iou_time:.2f} seconds")

# Chech results are the same
assert np.isclose(slow_mean_iou, faster_mean_iou), "IOU values do not match"

# >>> Slow IOU: 0.052 in 11.73 seconds
# >>> Faster IOU: 0.052 in 0.26 seconds
```

As a result, we get **5-50x speed up** in metric computation depending on the number of images, image size, and the number of classes.


P.S. PR also fixes not working example in README for mean_iou (https://github.com/huggingface/evaluate/issues/563).
