### PR TITLE
Fix example doc in load function

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -741,7 +741,7 @@ def load(
 
         ```py
         >>> from evaluate import load
-        >>> accuracy = evaluate.load("accuracy")
+        >>> accuracy = load("accuracy")
         ```
     """
     download_mode = DownloadMode(download_mode or DownloadMode.REUSE_DATASET_IF_EXISTS)


### PR DESCRIPTION
### What
The example in the docs for the `load` function is wrong, and should be 

```py
>>> from evaluate import load
>>> accuracy = load("accuracy")
```

or 

```py
>>> import evaluate
>>> accuracy = evaluate.load("accuracy")
```

### Why
Small change, but it was kinda bothering me 😅 