### PR TITLE
Fix wrong lib name in ImportError mesage

### DIFF
--- a/metrics/bleu/tokenizer_13a.py
+++ b/metrics/bleu/tokenizer_13a.py
@@ -61,7 +61,7 @@ class TokenizerRegexp(BaseTokenizer):
         :param line: a segment to tokenize
         :return: the tokenized line
         """
-        for (_re, repl) in self._re:
+        for _re, repl in self._re:
             line = _re.sub(repl, line)
 
         # no leading or trailing spaces, single space within words

--- a/metrics/google_bleu/tokenizer_13a.py
+++ b/metrics/google_bleu/tokenizer_13a.py
@@ -61,7 +61,7 @@ class TokenizerRegexp(BaseTokenizer):
         :param line: a segment to tokenize
         :return: the tokenized line
         """
-        for (_re, repl) in self._re:
+        for _re, repl in self._re:
             line = _re.sub(repl, line)
 
         # no leading or trailing spaces, single space within words

--- a/metrics/indic_glue/indic_glue.py
+++ b/metrics/indic_glue/indic_glue.py
@@ -132,12 +132,16 @@ class IndicGlue(evaluate.Metric):
             inputs_description=_KWARGS_DESCRIPTION,
             features=datasets.Features(
                 {
-                    "predictions": datasets.Value("int64")
-                    if self.config_name != "cvit-mkb-clsr"
-                    else datasets.Sequence(datasets.Value("float32")),
-                    "references": datasets.Value("int64")
-                    if self.config_name != "cvit-mkb-clsr"
-                    else datasets.Sequence(datasets.Value("float32")),
+                    "predictions": (
+                        datasets.Value("int64")
+                        if self.config_name != "cvit-mkb-clsr"
+                        else datasets.Sequence(datasets.Value("float32"))
+                    ),
+                    "references": (
+                        datasets.Value("int64")
+                        if self.config_name != "cvit-mkb-clsr"
+                        else datasets.Sequence(datasets.Value("float32"))
+                    ),
                 }
             ),
             codebase_urls=[],

--- a/metrics/roc_auc/roc_auc.py
+++ b/metrics/roc_auc/roc_auc.py
@@ -155,15 +155,17 @@ class ROCAUC(evaluate.Metric):
                     "references": datasets.Value("int32"),
                 }
                 if self.config_name == "multiclass"
-                else {
-                    "references": datasets.Sequence(datasets.Value("int32")),
-                    "prediction_scores": datasets.Sequence(datasets.Value("float")),
-                }
-                if self.config_name == "multilabel"
-                else {
-                    "references": datasets.Value("int32"),
-                    "prediction_scores": datasets.Value("float"),
-                }
+                else (
+                    {
+                        "references": datasets.Sequence(datasets.Value("int32")),
+                        "prediction_scores": datasets.Sequence(datasets.Value("float")),
+                    }
+                    if self.config_name == "multilabel"
+                    else {
+                        "references": datasets.Value("int32"),
+                        "prediction_scores": datasets.Value("float"),
+                    }
+                )
             ),
             reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_auc_score.html"],
         )

--- a/metrics/squad_v2/compute_score.py
+++ b/metrics/squad_v2/compute_score.py
@@ -5,6 +5,7 @@ plot precision-recall curves if an additional na_prob.json file is provided.
 This file is expected to map question ID's to the model's predicted probability
 that a question is unanswerable.
 """
+
 import argparse
 import collections
 import json

--- a/metrics/super_glue/record_evaluation.py
+++ b/metrics/super_glue/record_evaluation.py
@@ -3,7 +3,6 @@ Official evaluation script for ReCoRD v1.0.
 (Some functions are adopted from the SQuAD evaluation script.)
 """
 
-
 import argparse
 import json
 import re

--- a/src/evaluate/evaluator/audio_classification.py
+++ b/src/evaluate/evaluator/audio_classification.py
@@ -119,7 +119,6 @@ class AudioClassificationEvaluator(Evaluator):
         label_column: str = "label",
         label_mapping: Optional[Dict[str, Number]] = None,
     ) -> Tuple[Dict[str, float], Any]:
-
         """
         input_column (`str`, defaults to `"file"`):
             The name of the column containing either the audio files or a raw waveform, represented as a numpy array, in the dataset specified by `data`.

--- a/src/evaluate/evaluator/image_classification.py
+++ b/src/evaluate/evaluator/image_classification.py
@@ -87,7 +87,6 @@ class ImageClassificationEvaluator(Evaluator):
         label_column: str = "label",
         label_mapping: Optional[Dict[str, Number]] = None,
     ) -> Tuple[Dict[str, float], Any]:
-
         """
         input_column (`str`, defaults to `"image"`):
             The name of the column containing the images as PIL ImageFile in the dataset specified by `data`.

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -95,9 +95,11 @@ class DummyQuestionAnsweringPipeline:
     def __call__(self, question, context, **kwargs):
         if self.v2:
             return [
-                {"score": 0.95, "start": 31, "end": 39, "answer": "Felix"}
-                if i % 2 == 0
-                else {"score": 0.95, "start": 0, "end": 0, "answer": ""}
+                (
+                    {"score": 0.95, "start": 31, "end": 39, "answer": "Felix"}
+                    if i % 2 == 0
+                    else {"score": 0.95, "start": 0, "end": 0, "answer": ""}
+                )
                 for i in range(len(question))
             ]
         else:


### PR DESCRIPTION
## Summary

This PR addresses an issue encountered during the setup of the `rouge` metric via the `evaluate` library. 

After attempting to load `rouge` with `rouge = evaluate.load("rouge");`, I was prompted to install additional dependencies (`nltk`, `rouge_score`, `absl`). However, an error occurred while trying to install `absl`, revealing a misnaming issue in the installation process. 

This PR corrects the library name to `absl-py`, which is the correct identifier for pip installations. <br>
Additionally, this PR applies code styling to various files in the repository, which I assume were committed without running the `make style` command.

## Changes
- Corrected the library naming to fix the ImportError encountered when setting up the `rouge` metric. 
  ```python
    library_import_name = "absl-py" if library_import_name == "absl" else library_import_name
  ```
- Ran the `make style` command to apply code styling. This command formatted not only the modified file but also other files in the repository.

## Impact
- **Correctness:** Ensures that the library name is correct in the **ImportError** message for a better user experience.
- **Code Quality:** Increases the uniformity of the codebase by enforcing style guidelines across all files, which may not have been properly formatted in past contributions.