### PR TITLE
Silence NLTK download info

### DIFF
--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -119,11 +119,11 @@ class Meteor(evaluate.Metric):
     def _download_and_prepare(self, dl_manager):
         import nltk
 
-        nltk.download("wordnet")
+        nltk.download("wordnet", quiet=True)
         if NLTK_VERSION >= version.Version("3.6.5"):
-            nltk.download("punkt")
+            nltk.download("punkt", quiet=True)
         if NLTK_VERSION >= version.Version("3.6.6"):
-            nltk.download("omw-1.4")
+            nltk.download("omw-1.4", quiet=True)
 
     def _compute(self, predictions, references, alpha=0.9, beta=3, gamma=0.5):
         multiple_refs = isinstance(references[0], list)


### PR DESCRIPTION
Even though datasets have been downloaded due to previous evaluations, NLTK outputs download info upon every evaluation. So I silenced this :+1: