### PR TITLE
Support tuple format in `combine` evaluations

### DIFF
--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -874,11 +874,14 @@ class CombinedEvaluations:
         from .loading import load  # avoid circular imports
 
         self.evaluation_module_names = None
-        if isinstance(evaluation_modules, list):
+        if isinstance(evaluation_modules, (list, tuple)):
             self.evaluation_modules = evaluation_modules
         elif isinstance(evaluation_modules, dict):
             self.evaluation_modules = list(evaluation_modules.values())
             self.evaluation_module_names = list(evaluation_modules.keys())
+        else:
+            raise ValueError("`evaluation_modules` should be a list, tuple or dict")
+
         loaded_modules = []
 
         for module in self.evaluation_modules:

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -770,4 +770,3 @@ class TestEvaluationcombined_evaluation(TestCase):
 def test_combine_evaluations_in_different_forms(evaluations):
     combined_evaluation = combine(evaluations)
     assert isinstance(combined_evaluation, CombinedEvaluations)
-

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -8,7 +8,7 @@ from unittest import TestCase, mock
 import pytest
 from datasets.features import Features, Sequence, Value
 
-from evaluate.module import EvaluationModule, EvaluationModuleInfo, combine
+from evaluate.module import CombinedEvaluations, EvaluationModule, EvaluationModuleInfo, combine
 
 from .utils import require_tf, require_torch
 
@@ -757,3 +757,17 @@ class TestEvaluationcombined_evaluation(TestCase):
         self.assertDictEqual(
             expected_result, combined_evaluation.compute(predictions=predictions, references=references, pos_label=0)
         )
+
+
+@pytest.mark.parametrize(
+    "evaluations,",
+    (
+        [DummyMetric(), DummyMetric()],
+        (DummyMetric(), DummyMetric()),
+        {"metric1": DummyMetric(), "metric2": DummyMetric()},
+    ),
+)
+def test_combine_evaluations_in_different_forms(evaluations):
+    combined_evaluation = combine(evaluations)
+    assert isinstance(combined_evaluation, CombinedEvaluations)
+


### PR DESCRIPTION
Closed #603 

This PR supports tuple input in the `evaluate.combine` method.