### PR TITLE
fix import error message for sklearn

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -259,7 +259,7 @@ def _download_additional_modules(
         try:
             lib = importlib.import_module(library_import_name)  # noqa F841
         except ImportError:
-            library_import_name = "scikit-learn" if library_import_name == "sklearn" else library_import_name
+            library_import_path = "scikit-learn" if library_import_name == "sklearn" else library_import_path
             needs_to_be_installed.add((library_import_name, library_import_path))
     if needs_to_be_installed:
         raise ImportError(


### PR DESCRIPTION
for sklearn, if needing install it, the ImportError should write "pip install scikit-learn" instead of "pip install sklearn"
now:
  File "/home/ubuntu/wubing/evaluate/src/evaluate/loading.py", line 265, in _download_additional_modules
    raise ImportError(
ImportError: To be able to use evaluate-metric/accuracy, you need to install the following dependencies['sklearn'] using 'pip install scikit-learn' for instance'


before:
  File "/home/ubuntu/anaconda3/envs/swift_llm/lib/python3.9/site-packages/evaluate/loading.py", line 265, in _download_additional_modules
    raise ImportError(
ImportError: To be able to use evaluate-metric/accuracy, you need to install the following dependencies['scikit-learn'] using 'pip install sklearn' for instance'