### PR TITLE
Fix: message for lack of sklearn

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -259,7 +259,7 @@ def _download_additional_modules(
         try:
             lib = importlib.import_module(library_import_name)  # noqa F841
         except ImportError:
-            library_import_name = "scikit-learn" if library_import_name == "sklearn" else library_import_name
+            library_import_path = "scikit-learn" if library_import_name == "sklearn" else library_import_name
             needs_to_be_installed.add((library_import_name, library_import_path))
     if needs_to_be_installed:
         raise ImportError(


### PR DESCRIPTION
When relying on `sklearn`, the help message that should be printed is `pip install scikit-learn`, not `pip install sklearn`.