### PR TITLE
Correct the warning information of loader.py

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -259,7 +259,9 @@ def _download_additional_modules(
         try:
             lib = importlib.import_module(library_import_name)  # noqa F841
         except ImportError:
-            library_import_name = "scikit-learn" if library_import_name == "sklearn" else library_import_name
+            if library_import_name == "sklearn":
+                library_import_name = "scikit-learn" 
+                library_import_path = "scikit-learn"
             needs_to_be_installed.add((library_import_name, library_import_path))
     if needs_to_be_installed:
         raise ImportError(


### PR DESCRIPTION
Hi, I notice that if the missing library is scikit-learn, the prompt will be:

```
  File "/gpfs/radev/project/ying_rex/tl688/dnabert2/lib/python3.10/site-packages/evaluate/loading.py", line 489, in get_module
    local_imports = _download_additional_modules(
  File "/gpfs/radev/project/ying_rex/tl688/dnabert2/lib/python3.10/site-packages/evaluate/loading.py", line 265, in _download_additional_modules
    raise ImportError(
ImportError: To be able to use evaluate-metric/accuracy, you need to install the following dependencies['scikit-learn'] using 'pip install sklearn' for instance'
```

But this instruction cannot work, since pip install sklearn will lead to this error:

```
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.

      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error

      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package
```

The correct instruction will be "pip install scikit-learn". So I fix it, thanks.