### PR TITLE
Replace deprecated use_auth_token with token

### DIFF
--- a/.github/hub/push_evaluations_to_hub.py
+++ b/.github/hub/push_evaluations_to_hub.py
@@ -75,7 +75,7 @@ def push_module_to_hub(module_path, type, token, commit_hash, tag=None):
         # make sure we don't accidentally expose token
         raise OSError(f"Could not clone from '{clean_repo_url}'")
 
-    repo = Repository(local_dir=repo_path / module_name, use_auth_token=token)
+    repo = Repository(local_dir=repo_path / module_name, token=token)
     
     copy_recursive(module_path, repo_path / module_name)
     update_evaluate_dependency(repo_path / module_name / "requirements.txt", commit_hash)

--- a/docs/source/base_evaluator.mdx
+++ b/docs/source/base_evaluator.mdx
@@ -275,7 +275,7 @@ Let's have a look at how can evaluate image classification models on large datas
 The evaluator can be used on large datasets! Below, an example shows how to use it on ImageNet-1k for image classification. Beware that this example will require to download ~150 GB.
 
 ```python
-data = load_dataset("imagenet-1k", split="validation", use_auth_token=True)
+data = load_dataset("imagenet-1k", split="validation", token=True)
 
 pipe = pipeline(
     task="image-classification",


### PR DESCRIPTION
Replace deprecated `use_auth_token` with `token`.

Note that we need this fix to be released before we can release datasets-3.0 to avoid breaking transformers CI.

Fix #620.