### PR TITLE
Pin numpy<2 as required by tensorflow to fix doc building

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ TESTS_REQUIRE = [
     "pytest-datadir",
     "pytest-xdist",
     # optional dependencies
+    "numpy<2.0.0",  # tensorflow requires numpy < 2
     "tensorflow>=2.3,!=2.6.0,!=2.6.1, <=2.10",
     "torch",
     # metrics dependencies


### PR DESCRIPTION
Pin numpy<2 as required by tensorflow to fix doc building.

Fix #630.