### PR TITLE
Pass trust_remote_code to fix test_token_classification_parity

### DIFF
--- a/tests/test_trainer_evaluator_parity.py
+++ b/tests/test_trainer_evaluator_parity.py
@@ -283,6 +283,7 @@ class TestEvaluatorTrainerParity(unittest.TestCase):
             f"python examples/pytorch/token-classification/run_ner.py"
             f" --model_name_or_path {model_name}"
             f" --dataset_name conll2003"
+            f" --trust_remote_code"
             f" --do_eval"
             f" --output_dir {os.path.join(self.dir_path, 'tokenclassification_conll2003_transformers')}"
             f" --max_eval_samples {n_samples}",


### PR DESCRIPTION
Pass trust_remote_code to fix test_token_classification_parity.

After investigation, the test was not passing due to the following error:
```
ValueError: Loading conll2003 requires you to execute the dataset script in that repo on your local machine. Make sure you have read the code there to avoid malicious use, then set the option `trust_remote_code=True` to remove this error.
```

Fix #632.