### PR TITLE
Add required hf_token secret to build main documentation

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -13,3 +13,5 @@ jobs:
     with:
       commit_sha: ${{ github.sha }}
       package: evaluate
+    secrets:
+      hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}


### PR DESCRIPTION
Add required hf_token secret to build main documentation.

Fix #634.