### PR TITLE
Fix typo: Remove redundant trailing quote

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -265,7 +265,7 @@ def _download_additional_modules(
         raise ImportError(
             f"To be able to use {name}, you need to install the following dependencies"
             f"{[lib_name for lib_name, lib_path in needs_to_be_installed]} using 'pip install "
-            f"{' '.join([lib_path for lib_name, lib_path in needs_to_be_installed])}' for instance'"
+            f"{' '.join([lib_path for lib_name, lib_path in needs_to_be_installed])}' for instance"
         )
     return local_imports
 


### PR DESCRIPTION
I found that redundant trailing quote (*for instance'*)

* Python 3.11.8
* `pip install evaluate` (0.4.3)

```python
>>> import evaluate
>>> metric = evaluate.load("accuracy")
Downloading builder script: 100%|██████████| 4.20k/4.20k [00:00<00:00, 7.01MB/s]
Traceback (most recent call last):

  File "/.../.venv/lib/python3.11/site-packages/evaluate/loading.py", line 265, in _download_additional_modules
    raise ImportError(
ImportError: To be able to use evaluate-metric/accuracy, you need to install the following dependencies['scikit-learn'] using 'pip install sklearn' for instance'
```