### PR TITLE
Fix size attribute error for precision/recall/f1 

### DIFF
--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -127,4 +127,4 @@ class F1(evaluate.Metric):
         score = f1_score(
             references, predictions, labels=labels, pos_label=pos_label, average=average, sample_weight=sample_weight
         )
-        return {"f1": score if getattr(score, 'size', 1) > 1 else float(score)}
+        return {"f1": score if getattr(score, "size", 1) > 1 else float(score)}

--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -127,4 +127,4 @@ class F1(evaluate.Metric):
         score = f1_score(
             references, predictions, labels=labels, pos_label=pos_label, average=average, sample_weight=sample_weight
         )
-        return {"f1": float(score) if score.size == 1 else score}
+        return {"f1": score if getattr(score, 'size', 1) > 1 else float(score)}

--- a/metrics/precision/precision.py
+++ b/metrics/precision/precision.py
@@ -142,4 +142,4 @@ class Precision(evaluate.Metric):
             sample_weight=sample_weight,
             zero_division=zero_division,
         )
-        return {"precision": score if getattr(score, 'size', 1) > 1 else float(score)}
+        return {"precision": score if getattr(score, "size", 1) > 1 else float(score)}

--- a/metrics/precision/precision.py
+++ b/metrics/precision/precision.py
@@ -142,4 +142,4 @@ class Precision(evaluate.Metric):
             sample_weight=sample_weight,
             zero_division=zero_division,
         )
-        return {"precision": float(score) if score.size == 1 else score}
+        return {"precision": score if getattr(score, 'size', 1) > 1 else float(score)}

--- a/metrics/recall/recall.py
+++ b/metrics/recall/recall.py
@@ -132,4 +132,4 @@ class Recall(evaluate.Metric):
             sample_weight=sample_weight,
             zero_division=zero_division,
         )
-        return {"recall": float(score) if score.size == 1 else score}
+        return {"recall": score if getattr(score, 'size', 1) > 1 else float(score)}

--- a/metrics/recall/recall.py
+++ b/metrics/recall/recall.py
@@ -132,4 +132,4 @@ class Recall(evaluate.Metric):
             sample_weight=sample_weight,
             zero_division=zero_division,
         )
-        return {"recall": score if getattr(score, 'size', 1) > 1 else float(score)}
+        return {"recall": score if getattr(score, "size", 1) > 1 else float(score)}


### PR DESCRIPTION
# What does this PR do?
Fix #655 .
Fix AttributeError in precision/recall/f1 metrics when handling scalar outputs from scikit-learn 1.6.0.

# Description
With the release of scikit-learn 1.6.0, some metric functions (e.g., `precision_score`, `recall_score`, `f1_score`) may return float values instead of numpy arrays for single-value results. The current implementation in evaluate assumes the presence of a `size` attribute for all outputs, which causes an AttributeError when handling scalar outputs.

This PR modifies the return statement to safely handle both numpy arrays and scalar outputs using `getattr(score, 'size', 1)`, making the metrics compatible with both scikit-learn 1.6.0 and earlier versions.

# Changes
Modified return statements in three metrics:
- metrics/precision/precision.py
- metrics/recall/recall.py
- metrics/f1/f1.py

Changed from:
```python
return {"metric_name": float(score) if score.size == 1 else score}
```
to:
```python
return {"metric_name": score if getattr(score, 'size', 1) > 1 else float(score)}
```