### PR TITLE
replace deprecated methods of jiwer

### DIFF
--- a/metrics/cer/cer.py
+++ b/metrics/cer/cer.py
@@ -137,23 +137,23 @@ class CER(evaluate.Metric):
 
     def _compute(self, predictions, references, concatenate_texts=False):
         if concatenate_texts:
-            return jiwer.compute_measures(
+            return jiwer.process_words(
                 references,
                 predictions,
-                truth_transform=cer_transform,
+                reference_transform=cer_transform,
                 hypothesis_transform=cer_transform,
-            )["wer"]
+            ).wer
 
         incorrect = 0
         total = 0
         for prediction, reference in zip(predictions, references):
-            measures = jiwer.compute_measures(
+            out = jiwer.process_words(
                 reference,
                 prediction,
-                truth_transform=cer_transform,
+                reference_transform=cer_transform,
                 hypothesis_transform=cer_transform,
             )
-            incorrect += measures["substitutions"] + measures["deletions"] + measures["insertions"]
-            total += measures["substitutions"] + measures["deletions"] + measures["hits"]
+            incorrect += out.substitutions + out.deletions + out.insertions
+            total += out.substitutions + out.deletions + out.hits
 
         return incorrect / total

--- a/metrics/wer/wer.py
+++ b/metrics/wer/wer.py
@@ -14,7 +14,7 @@
 """ Word Error Ratio (WER) metric. """
 
 import datasets
-from jiwer import compute_measures
+from jiwer import process_words
 
 import evaluate
 
@@ -95,12 +95,12 @@ class WER(evaluate.Metric):
 
     def _compute(self, predictions=None, references=None, concatenate_texts=False):
         if concatenate_texts:
-            return compute_measures(references, predictions)["wer"]
+            return process_words(references, predictions).wer
         else:
             incorrect = 0
             total = 0
             for prediction, reference in zip(predictions, references):
-                measures = compute_measures(reference, prediction)
-                incorrect += measures["substitutions"] + measures["deletions"] + measures["insertions"]
-                total += measures["substitutions"] + measures["deletions"] + measures["hits"]
+                out = process_words(reference, prediction)
+                incorrect += out.substitutions + out.deletions + out.insertions
+                total += out.substitutions + out.deletions + out.hits
             return incorrect / total


### PR DESCRIPTION
The `compute_measures` method in `jiwer` has been deprecated since Mar 17, 2023. This PR updates the usage.

By the way, can you comment on the use of `concatenate_texts`? There is no difference between the two branches, as the exact for-loop is also done internally by jiwer.
