### PR TITLE
fix: support "squared" argument for sklearn>=1.6.1

### DIFF
--- a/metrics/mse/mse.py
+++ b/metrics/mse/mse.py
@@ -14,7 +14,7 @@
 """MSE - Mean Squared Error Metric"""
 
 import datasets
-from sklearn.metrics import mean_squared_error
+from sklearn.metrics import mean_squared_error, root_mean_squared_error
 
 import evaluate
 
@@ -112,8 +112,11 @@ class Mse(evaluate.Metric):
 
     def _compute(self, predictions, references, sample_weight=None, multioutput="uniform_average", squared=True):
 
-        mse = mean_squared_error(
-            references, predictions, sample_weight=sample_weight, multioutput=multioutput, squared=squared
-        )
+        if squared:
+            mse = mean_squared_error(references, predictions, sample_weight=sample_weight, multioutput=multioutput)
+        else:
+            mse = root_mean_squared_error(
+                references, predictions, sample_weight=sample_weight, multioutput=multioutput
+            )
 
         return {"mse": mse}

--- a/metrics/mse/requirements.txt
+++ b/metrics/mse/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-scikit-learn
+scikit-learn>=1.5.2


### PR DESCRIPTION
The `mse` metric is broken when using `scikit-learn>1.5.2`. This is because the `squared` argument was removed from [`mean_squared_error`](https://scikit-learn.org/1.5/modules/generated/sklearn.metrics.mean_squared_error.html). I believe a simple, backwards compatible fix (up to scikit-learn==1.5.2) is just to call out to `mean_squared_error` when `squared=True` and [`root_mean_squared_error`](https://scikit-learn.org/1.5/modules/generated/sklearn.metrics.root_mean_squared_error.html#sklearn.metrics.root_mean_squared_error) otherwise.

I didn't find any MSE specific unit tests so I just ran all the doc string examples and they return the correct responses.

Fixes: #663 