### PR TITLE
Add warning about METEOR version and flag-induced score variance

### DIFF
--- a/metrics/meteor/README.md
+++ b/metrics/meteor/README.md
@@ -116,6 +116,9 @@ While the correlation between METEOR and human judgments was measured for Chines
 
 Furthermore, while the alignment and matching done in METEOR is based on unigrams, using multiple word entities (e.g. bigrams) could contribute to improving its accuracy -- this has been proposed in [more recent publications](https://www.cs.cmu.edu/~alavie/METEOR/pdf/meteor-naacl-2010.pdf) on the subject.
 
+Scores differ by up to **±10 points** across v1.0↔v1.5 and flag combinations (`-l`, `-norm`, `-vOut`). 
+Pin the Java package and document your flags. This uses the NLTK implementation (METEOR v1.0).
+[Lübbers, 2024](https://github.com/cluebbers/Reproducibility-METEOR-NLP)
 
 ## Citation
 


### PR DESCRIPTION
This pull request adds a call-out block at the top of `evaluate/metrics/meteor/README.md` to inform users about significant score discrepancies in METEOR evaluations. Variations up to ±10 points can occur due to differences between versions 1.0 and 1.5, as well as the use of specific flags (`-l`, `-norm`, `-vOut`). By highlighting this issue, users are encouraged to specify the Java package version and document the flags used to ensure reproducibility. The information is based on findings from Lübbers (2024), available at [https://github.com/cluebbers/Reproducibility-METEOR-NLP](https://github.com/cluebbers/Reproducibility-METEOR-NLP).