### PR TITLE
fix: ensure scikit-learn package name consistency in library imports

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -260,6 +260,7 @@ def _download_additional_modules(
             lib = importlib.import_module(library_import_name)  # noqa F841
         except ImportError:
             library_import_name = "scikit-learn" if library_import_name == "sklearn" else library_import_name
+            library_import_path = "scikit-learn" if library_import_name == "scikit-learn" else library_import_path
             needs_to_be_installed.add((library_import_name, library_import_path))
     if needs_to_be_installed:
         raise ImportError(


### PR DESCRIPTION
# Fix: Correct scikit-learn package name in dependency installation

## Problem
When users try to import `sklearn` in their evaluation scripts, they might get confused about the correct package name for installation.

## Solution
Added logic to ensure users are directed to install the correct package name `scikit-learn` instead of `sklearn` when dependencies are missing.

#Previous Import error message: 
ImportError: To be able to use evaluate-metric/accuracy, you need to install the following dependencies['scikit-learn'] using 'pip install sklearn' for instance'

#Correct Import error message: 
ImportError: To be able to use evaluate-metric/accuracy, you need to install the following dependencies['scikit-learn'] using 'pip install scikit-learn' for instance'

## Changes
```python
library_import_name = "scikit-learn" if library_import_name == "sklearn" else library_import_name
library_import_path = "scikit-learn" if library_import_name == "scikit-learn" else library_import_path
```

## Impact
Users will now receive the correct installation command (`pip install scikit-learn`) instead of the incorrect one (`pip install sklearn`) when the package is not installed, preventing confusion and ensuring successful package installation.