### PR TITLE
use jiwer < 4.0.0

### DIFF
--- a/metrics/cer/requirements.txt
+++ b/metrics/cer/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-jiwer
+jiwer<4

--- a/metrics/wer/requirements.txt
+++ b/metrics/wer/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/huggingface/evaluate@{COMMIT_PLACEHOLDER}
-jiwer
+jiwer<4


### PR DESCRIPTION
Instead of PR #661, this PR simply does not allow new version 4.0.0 released today.  