### PR TITLE
Support datasets 4

### DIFF
--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -462,7 +462,7 @@ class EvaluationModule(EvaluationModuleInfoMixin):
         if self.process_id == 0:
             self.data.set_format(type=self.info.format)
 
-            inputs = {input_name: self.data[input_name] for input_name in self._feature_names()}
+            inputs = {input_name: self.data[input_name][:] for input_name in self._feature_names()}
             with temp_seed(self.seed):
                 output = self._compute(**inputs, **compute_kwargs)
 


### PR DESCRIPTION
since it introduces Column objects

Fix the glue metric and others with
```
     return float((preds == labels).mean())
                  ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'bool' object has no attribute 'mean'
```