### PR TITLE
Refactor IOU and accuracy calculations with np.divide

### DIFF
--- a/metrics/mean_iou/mean_iou.py
+++ b/metrics/mean_iou/mean_iou.py
@@ -256,8 +256,18 @@ def mean_iou(
     metrics = dict()
 
     all_acc = total_area_intersect.sum() / total_area_label.sum()
-    iou = total_area_intersect / total_area_union
-    acc = total_area_intersect / total_area_label
+    iou = np.divide(
+        total_area_intersect,
+        total_area_union,
+        out=np.zeros_like(total_area_intersect),
+        where=total_area_union != 0,
+    )
+    acc = np.divide(
+        total_area_intersect,
+        total_area_label,
+        out=np.zeros_like(total_area_intersect),
+        where=total_area_label != 0,
+    )
 
     metrics["mean_iou"] = np.nanmean(iou)
     metrics["mean_accuracy"] = np.nanmean(acc)


### PR DESCRIPTION
Updated IOU and accuracy calculations to handle division by zero.

Currently, a RuntimeWarning is thrown when performing the category-wise IOU calculation, if the total_area_union or total_area_label for one of the categories is zero.

This can be handled by using the np.divide function, simply returning 0 for all categories where this happens.

Note, that the RuntimeWarning originates from numpy, e.g.:

    RuntimeWarning: invalid value encountered in divide iou = total_area_intersect / total_area_union
    RuntimeWarning: invalid value encountered in divide acc = total_area_intersect / total_area_label