### PR TITLE
Pin hfh in CI for updating repos

### DIFF
--- a/.github/workflows/update_spaces.yml
+++ b/.github/workflows/update_spaces.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: ./.github/hub
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install huggingface_hub==0.35.0
       - name: Update Hub repositories
         working-directory: ./.github/hub
         run: |


### PR DESCRIPTION
since it uses the deprecated Repository utilities