### PR TITLE
Remove the comments that pollute library_import_path in _download_additional_modules and correct import_library_name for "absl"

### DIFF
--- a/metrics/rouge/rouge.py
+++ b/metrics/rouge/rouge.py
@@ -14,9 +14,9 @@
 """ ROUGE metric from Google Research github repo. """
 
 # The dependencies in https://github.com/google-research/google-research/blob/master/rouge/requirements.txt
-import absl  # Here to have a nice missing dependency error message early on
+import absl
 import datasets
-import nltk  # Here to have a nice missing dependency error message early on
+import nltk
 import numpy  # Here to have a nice missing dependency error message early on
 import six  # Here to have a nice missing dependency error message early on
 from rouge_score import rouge_scorer, scoring

--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -260,7 +260,8 @@ def _download_additional_modules(
             lib = importlib.import_module(library_import_name)  # noqa F841
         except ImportError:
             library_import_name = "scikit-learn" if library_import_name == "sklearn" else library_import_name
-            library_import_name = "absl-py" if library_import_name == "absl-py" else library_import_name
+            library_import_name = "absl-py" if library_import_name == "absl" else library_import_name
+            library_import_path = "absl-py" if library_import_path == "absl" else library_import_path
             needs_to_be_installed.add((library_import_name, library_import_path))
     if needs_to_be_installed:
         raise ImportError(

--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -260,6 +260,7 @@ def _download_additional_modules(
             lib = importlib.import_module(library_import_name)  # noqa F841
         except ImportError:
             library_import_name = "scikit-learn" if library_import_name == "sklearn" else library_import_name
+            library_import_name = "absl-py" if library_import_name == "absl-py" else library_import_name
             needs_to_be_installed.add((library_import_name, library_import_path))
     if needs_to_be_installed:
         raise ImportError(


### PR DESCRIPTION
This PR removes two comments that pollute variable library_import_path in _download_additional_modules.

Before changes, when error message generated by _download_additional_modules prompts the user to install nltk, rouge_score and absl (wrong name, it should be called "absl-py"), the error message prints out the comments from metrics/rouge/rouge.py, rather than actual lib_path. Please see the image below.
<img width="772" height="138" alt="polluted_error_messages" src="https://github.com/user-attachments/assets/c0fe45a2-2b77-4285-9744-a6c578f975f2" />

"Here to have a nice missing dependency error message" is stored in lib_path and it is printed out.
These two "Here to have a nice missing dependency error message" are from metrics/rouge/rouge.py. Remove these two comments can solve the issues.
Also, pip install absl, as advised by error message, would result in error. It should be "absl-py"

After this PR, the error message would output correct pip commands that could be used by users directly and provide information they need.

@lhoestq
@sgugger

@Rocketknight1
(sorry to bother you again, this pr is also important. I would like to let you know if other contributors in this repo are not able to review my pr)