### PR TITLE
Suppress NLTK download logs for meteor and word_length

### DIFF
--- a/docs/source/creating_and_sharing.mdx
+++ b/docs/source/creating_and_sharing.mdx
@@ -59,7 +59,7 @@ Or if you need to download the NLTK `"punkt_tab"` resources:
 ```py
 def _download_and_prepare(self, dl_manager):
     import nltk
-    nltk.download("punkt_tab")
+    nltk.download("punkt_tab", quiet=True)
 ```
 
 Next, we need to define how the computation of the evaluation module works.

--- a/docs/source/creating_and_sharing.mdx
+++ b/docs/source/creating_and_sharing.mdx
@@ -58,8 +58,12 @@ Or if you need to download the NLTK `"punkt_tab"` resources:
 
 ```py
 def _download_and_prepare(self, dl_manager):
+    import io
+    from contextlib import redirect_stdout
     import nltk
-    nltk.download("punkt_tab", quiet=True)
+
+    with redirect_stdout(io.StringIO()):
+        nltk.download("punkt_tab", quiet=True)
 ```
 
 Next, we need to define how the computation of the evaluation module works.

--- a/measurements/word_length/word_length.py
+++ b/measurements/word_length/word_length.py
@@ -82,12 +82,19 @@ class WordLength(evaluate.Measurement):
         )
 
     def _download_and_prepare(self, dl_manager):
+        import io
+        from contextlib import redirect_stdout
+
         import nltk
 
+        def _silent_download(pkg: str) -> None:
+            with redirect_stdout(io.StringIO()):
+                nltk.download(pkg, quiet=True)
+
         if NLTK_VERSION >= version.Version("3.9.0"):
-            nltk.download("punkt_tab")
+            _silent_download("punkt_tab")
         else:
-            nltk.download("punkt")
+            _silent_download("punkt")
 
     def _compute(self, data, tokenizer=word_tokenize):
         """Returns the average word length of the input data"""

--- a/metrics/meteor/meteor.py
+++ b/metrics/meteor/meteor.py
@@ -117,15 +117,22 @@ class Meteor(evaluate.Metric):
         )
 
     def _download_and_prepare(self, dl_manager):
+        import io
+        from contextlib import redirect_stdout
+
         import nltk
 
-        nltk.download("wordnet")
+        def _silent_download(pkg: str) -> None:
+            with redirect_stdout(io.StringIO()):
+                nltk.download(pkg, quiet=True)
+
+        _silent_download("wordnet")
         if NLTK_VERSION >= version.Version("3.9.0"):
-            nltk.download("punkt_tab")
+            _silent_download("punkt_tab")
         elif NLTK_VERSION >= version.Version("3.6.5"):
-            nltk.download("punkt")
+            _silent_download("punkt")
         if NLTK_VERSION >= version.Version("3.6.6"):
-            nltk.download("omw-1.4")
+            _silent_download("omw-1.4")
 
     def _compute(self, predictions, references, alpha=0.9, beta=3, gamma=0.5):
         multiple_refs = isinstance(references[0], list)


### PR DESCRIPTION
NLTK can still emit [nltk_data] logs even with quiet=True depending on version.
This PR redirects stdout around nltk.download calls to keep module loading quiet, and updates the docs example accordingly.

Fixes #671