### PR TITLE
Fix typos in poseval metric

### DIFF
--- a/metrics/poseval/README.md
+++ b/metrics/poseval/README.md
@@ -12,7 +12,7 @@ tags:
 - metric
 description: >-
   The poseval metric can be used to evaluate POS taggers. Since seqeval does not work well with POS data 
-  that is not in IOB format the poseval is an alternative. It treats each token in the dataset as independant 
+  that is not in IOB format the poseval is an alternative. It treats each token in the dataset as independent 
   observation and computes the precision, recall and F1-score irrespective of sentences. It uses scikit-learns's
   classification report to compute the scores.
 ---
@@ -21,7 +21,7 @@ description: >-
 
 ## Metric description
 
-The poseval metric can be used to evaluate POS taggers. Since seqeval does not work well with POS data (see e.g. [here](https://stackoverflow.com/questions/71327693/how-to-disable-seqeval-label-formatting-for-pos-tagging)) that is not in IOB format the poseval is an alternative. It treats each token in the dataset as independant observation and computes the precision, recall and F1-score irrespective of sentences. It uses scikit-learns's [classification report](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.classification_report.html) to compute the scores.
+The poseval metric can be used to evaluate POS taggers. Since seqeval does not work well with POS data (see e.g. [here](https://stackoverflow.com/questions/71327693/how-to-disable-seqeval-label-formatting-for-pos-tagging)) that is not in IOB format the poseval is an alternative. It treats each token in the dataset as independent observation and computes the precision, recall and F1-score irrespective of sentences. It uses scikit-learns's [classification report](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.classification_report.html) to compute the scores.
 
 
 ## How to use 

--- a/metrics/poseval/poseval.py
+++ b/metrics/poseval/poseval.py
@@ -38,7 +38,7 @@ _CITATION = """\
 _DESCRIPTION = """\
 The poseval metric can be used to evaluate POS taggers. Since seqeval does not work well with POS data \
 (see e.g. [here](https://stackoverflow.com/questions/71327693/how-to-disable-seqeval-label-formatting-for-pos-tagging))\
-that is not in IOB format the poseval metric is an alternative. It treats each token in the dataset as independant \
+that is not in IOB format the poseval metric is an alternative. It treats each token in the dataset as independent \
 observation and computes the precision, recall and F1-score irrespective of sentences. It uses scikit-learns's \
 [classification report](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.classification_report.html) \
 to compute the scores.


### PR DESCRIPTION
## Summary
- Fixed "independant" -> "independent" typo in `metrics/poseval/poseval.py` (1 instance)
- Fixed "independant" -> "independent" typo in `metrics/poseval/README.md` (2 instances)