### PR TITLE
auto-update metrics spaces to latest gradio versions with action; fixes #713

### DIFF
--- a/.github/hub/push_evaluations_to_hub.py
+++ b/.github/hub/push_evaluations_to_hub.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 import huggingface_hub
 from huggingface_hub.utils._headers import _http_user_agent
 
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 GIT_UP_TO_DATE = "On branch main\nYour branch is up to date with 'origin/main'.\
@@ -42,6 +43,23 @@ def get_git_tag(lib_path, commit_hash):
         return None
 
 
+def get_latest_pypi_version(pkg_name: str):
+    # finds the latest pypi version of a package (used for gradio)
+    command = f"python -m pip index versions {pkg_name}"
+    output = subprocess.run(command.split(),
+        stdout=subprocess.PIPE,
+        stderr=None,
+        encoding="utf-8",
+        check=True
+    )
+    firstline = output.stdout.split('\n')[0].strip()
+    matches = re.match(fr"{pkg_name} \((.+)\)$", firstline)
+    if matches is not None:
+        return matches[1]
+    else:
+        raise ValueError(f"Could not parse latest version for {pkg_name} from:\n{firstline}")
+
+
 def copy_recursive(source_base_path, target_base_path):
     """Copy directory recursively and overwrite existing files."""
     for item in source_base_path.iterdir():
@@ -60,7 +78,21 @@ def update_evaluate_dependency(requirements_path, commit_hash):
     with open(requirements_path, "w") as f:
         f.write(file_content)
 
-def push_module_to_hub(module_path, type, token, commit_hash, tag=None):
+def update_gradio_sdk_version(readme_path, gradio_sdk_version):
+    # read the yaml metadata in the readme and update the `sdk_version` field
+    with open(readme_path, "r") as f:
+        content = f.read()
+    is_gradio = re.search(r'sdk: gradio(?:[\s\S]+?^---)', content, flags=re.MULTILINE)
+    if is_gradio is None:
+        logger.warning(f"No gradio sdk found in {readme_path}, skipping sdk_version update.")
+        return
+    # replace only the sdk_version within the header
+    content = re.sub(r"(sdk_version: \d*\.\d*\.\d*)([\s\S]+?^---)", fr"sdk_version: {gradio_sdk_version}\2", content, flags=re.MULTILINE)
+    with open(readme_path, "w") as f:
+        f.write(content)
+
+
+def push_module_to_hub(module_path, type, token, commit_hash, gradio_sdk_version, tag=None):
     module_name = module_path.stem
     org = f"evaluate-{type}"
     
@@ -89,6 +121,7 @@ def push_module_to_hub(module_path, type, token, commit_hash, tag=None):
     
     copy_recursive(module_path, repo_path / module_name)
     update_evaluate_dependency(repo_path / module_name / "requirements.txt", commit_hash)
+    update_gradio_sdk_version(repo_path / module_name / "README.md", gradio_sdk_version)
     
     repo.git_add()
     try:
@@ -119,11 +152,14 @@ if __name__ == "__main__":
     if git_tag is not None:
         logger.info(f"Found tag: {git_tag}.")
 
+    gradio_sdk_version = get_latest_pypi_version('gradio')
+    logger.info(f"Latest gradio version is {gradio_sdk_version}.")
+
     for type, dir in zip(evaluation_types, evaluation_paths):
         if (evaluate_lib_path/dir).exists():
             for module_path in (evaluate_lib_path/dir).iterdir():
                 if module_path.is_dir():
                     logger.info(f"Updating: module {module_path.name}.")
-                    push_module_to_hub(module_path, type, token, commit_hash, tag=git_tag)
+                    push_module_to_hub(module_path, type, token, commit_hash, gradio_sdk_version, tag=git_tag)
         else:
             logger.warning(f"No folder {str(evaluate_lib_path/dir)} for {type} found.")

--- a/.github/workflows/update_spaces.yml
+++ b/.github/workflows/update_spaces.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.8"
+          python-version: "3.14"
       - name: Set up default Git config
         run: |
           git config --global user.name evaluate-bot
@@ -28,7 +28,7 @@ jobs:
         working-directory: ./.github/hub
         run: |
           python -m pip install --upgrade pip
-          pip install huggingface_hub==0.35.0
+          pip install 'huggingface_hub<1'
       - name: Update Hub repositories
         working-directory: ./.github/hub
         run: |


### PR DESCRIPTION
also make action more up-to-date
fixes #713

I have tested the functions that I added, however I can't run the whole action end-to-end, as it needs secrets and would result in a commit being made to the metrics.

I tested that:
1. `get_latest_pypi_version` with `gradio`: The latest gradio version is received and parsed correctly.
2. `update_gradio_sdk_version`: I've tested the regexes and taken care of edge cases where (by divine intervention) there might be more than one mention of the `sdk_version`, so we should only take the one that is inside the yaml metadata block. 
I've also added a check if the `sdk` key in the same metadata is set to `gradio`, otherwise skip. However, I did not see any metric that doesn't have this set to `gradio`.
I've also tested that the replacement works as expected and does not modify anything else.


Is there a way to test this action with this PR?


I have also updated the action itself with:
1. Latest `actions/checkout@v6` (from v2)
2. Latest `actions/setup-python@v6` (from v2)
3. `python_version` to 3.14 (from 3.8) - `gradio>5` requires at least 3.10 and 3.8 is 1.5 years EOL.
4. `huggingface_hub<1` to at least get the latest pre-1.x version (from `==0.35.0`)