### PR TITLE
Add RAIL Score metric for responsible AI evaluation

### DIFF
--- a/metrics/rail_score/README.md
+++ b/metrics/rail_score/README.md
@@ -1,0 +1,175 @@
+---
+title: RAIL Score
+emoji: 🛡️
+colorFrom: blue
+colorTo: indigo
+sdk: gradio
+sdk_version: 3.19.1
+app_file: app.py
+pinned: false
+tags:
+- evaluate
+- metric
+description: >-
+  RAIL Score evaluates LLM outputs across 8 responsible AI dimensions:
+  fairness, safety, reliability, transparency, privacy, accountability,
+  inclusivity, and user impact. Each dimension is scored 0-10.
+---
+
+# Metric Card for RAIL Score
+
+## Metric Description
+
+RAIL Score is a responsible AI evaluation metric that scores LLM outputs across **8 dimensions** on a 0-10 scale. It helps teams identify fairness issues, safety risks, reliability gaps, and other responsible AI concerns in model outputs.
+
+| Dimension | What It Measures |
+|-----------|-----------------|
+| Fairness | Equitable treatment across demographic groups, absence of bias |
+| Safety | Prevention of harmful, toxic, or unsafe content |
+| Reliability | Factual accuracy, internal consistency, epistemic calibration |
+| Transparency | Clear communication of limitations, reasoning, and uncertainty |
+| Privacy | Protection of personal information and sensitive data |
+| Accountability | Traceability of decisions, auditability of reasoning |
+| Inclusivity | Accessible, inclusive language for diverse users |
+| User Impact | Positive value delivered, appropriateness to user need |
+
+## How to Use
+
+RAIL Score requires an API key (free tier available at [responsibleailabs.ai](https://responsibleailabs.ai)). Set it as an environment variable or pass it directly.
+
+```python
+import evaluate
+
+rail_score = evaluate.load("rail_score")
+
+results = rail_score.compute(
+    predictions=["The capital of France is Paris, located in northern France."],
+    references=["What is the capital of France?"],
+)
+
+print(results["overall_score"])      # e.g. 8.2
+print(results["overall_confidence"]) # e.g. 0.85
+print(results["safety"])             # e.g. 9.5
+```
+
+### Deep Mode with Explanations
+
+```python
+results = rail_score.compute(
+    predictions=responses,
+    references=prompts,
+    mode="deep",
+    include_explanations=True,
+    include_issues=True,
+)
+
+for dim, explanations in results["explanations"].items():
+    print(f"{dim}: {explanations[0]}")
+```
+
+### Custom Dimension Weights
+
+```python
+# Emphasize safety and reliability (weights must sum to 100)
+results = rail_score.compute(
+    predictions=responses,
+    references=prompts,
+    weights={
+        "safety": 25, "reliability": 20, "fairness": 15,
+        "transparency": 10, "privacy": 10, "accountability": 5,
+        "inclusivity": 10, "user_impact": 5,
+    },
+)
+```
+
+### Domain-Specific Evaluation
+
+```python
+# Healthcare domain with stricter safety/reliability scoring
+results = rail_score.compute(
+    predictions=medical_responses,
+    references=medical_questions,
+    domain="healthcare",
+)
+```
+
+## Inputs
+
+- **predictions** (`list[str]`): LLM responses to evaluate.
+- **references** (`list[str]`, optional): Input prompts or context for each response.
+- **api_key** (`str`, optional): RAIL Score API key. Defaults to `RAIL_API_KEY` env var.
+- **mode** (`str`, optional): `"basic"` (default) or `"deep"` for detailed explanations.
+- **domain** (`str`, optional): Content domain: `"general"`, `"healthcare"`, `"finance"`, `"legal"`, `"education"`, or `"code"`. Default: `"general"`.
+- **dimensions** (`list[str]`, optional): Subset of dimensions to evaluate. Default: all 8.
+- **weights** (`dict[str, float]`, optional): Custom dimension weights (must sum to 100). Default: equal weights.
+- **include_explanations** (`bool`, optional): Return per-dimension explanations. Default: `False`.
+- **include_issues** (`bool`, optional): Return detected issues. Default: `False`.
+
+## Output Values
+
+- **overall_score** (`float`): Mean RAIL score across all examples (0-10).
+- **overall_confidence** (`float`): Mean confidence across all examples (0-1).
+- **{dimension}** (`float`): Mean score per dimension (0-10).
+- **{dimension}_confidence** (`float`): Mean confidence per dimension (0-1).
+- **scores** (`list[float]`): Per-example overall scores.
+- **confidences** (`list[float]`): Per-example confidence values.
+- **{dimension}_scores** (`list[float]`): Per-example dimension scores.
+- **{dimension}_confidences** (`list[float]`): Per-example dimension confidence values.
+- **explanations** (`dict`, optional): Per-dimension explanation lists (when `include_explanations=True`).
+- **issues** (`list[dict]`, optional): Detected issues (when `include_issues=True`).
+
+### Values from Popular Papers
+
+RAIL Score is designed for responsible AI evaluation rather than traditional NLP benchmarks. It complements metrics like BLEU, ROUGE, and BERTScore by evaluating safety, fairness, and trustworthiness dimensions that those metrics do not cover.
+
+## Examples
+
+Basic evaluation:
+
+```python
+>>> import evaluate
+>>> rail_score = evaluate.load("rail_score")
+>>> results = rail_score.compute(
+...     predictions=["The capital of France is Paris."],
+...     references=["What is the capital of France?"],
+... )
+>>> print(round(results["overall_score"], 1))
+8.5
+```
+
+Per-example scores and confidence:
+
+```python
+>>> results = rail_score.compute(
+...     predictions=["Paris is the capital of France.", "Just Google it."],
+...     references=["What is the capital of France?", "Can you help me?"],
+... )
+>>> for i, (score, conf) in enumerate(zip(results["scores"], results["confidences"])):
+...     print(f"Example {i}: score={score:.1f}, confidence={conf:.2f}")
+```
+
+## Limitations and Bias
+
+- Requires an external API call to the RAIL Score service, which means network latency and rate limits apply for large-scale evaluation.
+- Scores reflect the RAIL evaluation model's assessment and may not align perfectly with human judgment in all cases.
+- The privacy dimension defaults to a neutral score (5.0) when not applicable to the content.
+- Domain-specific scoring (healthcare, finance, legal) applies stricter thresholds but is still a general-purpose evaluator, not a domain-specific compliance tool.
+
+## Citation
+
+```bibtex
+@software{rail_score,
+    title = {RAIL Score: Responsible AI Evaluation Framework},
+    author = {Responsible AI Labs},
+    year = {2025},
+    url = {https://responsibleailabs.ai},
+    version = {2.4.0}
+}
+```
+
+## Further References
+
+- [RAIL Score SDK on PyPI](https://pypi.org/project/rail-score-sdk/)
+- [SDK Documentation](https://docs.responsibleailabs.ai)
+- [Responsible AI Labs](https://responsibleailabs.ai)
+- [Community metric on the Hub](https://huggingface.co/spaces/responsible-ai-labs/rail_score)

--- a/metrics/rail_score/app.py
+++ b/metrics/rail_score/app.py
@@ -1,0 +1,5 @@
+import evaluate
+from evaluate.utils import launch_gradio_widget
+
+module = evaluate.load("rail_score")
+launch_gradio_widget(module)

--- a/metrics/rail_score/rail_score.py
+++ b/metrics/rail_score/rail_score.py
@@ -1,0 +1,256 @@
+# Copyright 2025 Responsible AI Labs.
+#
+# Licensed under the MIT License.
+"""RAIL Score metric for responsible AI evaluation of LLM outputs."""
+
+import os
+import logging
+import time
+from typing import Dict, List, Optional
+
+import datasets
+
+import evaluate
+
+
+logger = logging.getLogger(__name__)
+
+
+_CITATION = """\
+@software{rail_score,
+    title = {RAIL Score: Responsible AI Evaluation Framework},
+    author = {Responsible AI Labs},
+    year = {2025},
+    url = {https://responsibleailabs.ai},
+    version = {2.4.0}
+}
+"""
+
+_DESCRIPTION = """\
+RAIL Score evaluates LLM outputs across 8 responsible AI dimensions,
+providing fine-grained scores (0-10) for each dimension plus an overall
+composite score. It helps teams identify fairness issues, safety risks,
+reliability gaps, and other responsible AI concerns in model outputs.
+
+Dimensions:
+- Fairness: Equitable treatment across demographic groups
+- Safety: Prevention of harmful or unsafe content
+- Reliability: Factual accuracy and internal consistency
+- Transparency: Clear communication of limitations and reasoning
+- Privacy: Protection of personal and sensitive information
+- Accountability: Traceability and auditability of decisions
+- Inclusivity: Accessible and inclusive language
+- User Impact: Positive value delivered to the user
+
+Requires a RAIL Score API key (free tier available at https://responsibleailabs.ai).
+"""
+
+_KWARGS_DESCRIPTION = """
+RAIL Score evaluation of LLM responses across 8 responsible AI dimensions.
+
+Args:
+    predictions (list of str): LLM responses to evaluate.
+    references (list of str): Input prompts or context for each response (optional).
+    api_key (str): RAIL Score API key. Defaults to RAIL_API_KEY environment variable.
+        Get a free key at https://responsibleailabs.ai.
+    mode (str): "basic" (default) or "deep" for detailed explanations.
+    domain (str): Content domain. One of "general", "healthcare", "finance",
+        "legal", "education", or "code". Default: "general".
+    dimensions (list of str): Subset of dimensions to evaluate. Default: all 8.
+    weights (dict): Custom dimension weights for the overall score.
+        Values must sum to 100. Default: equal weights (12.5 each).
+    include_explanations (bool): Return per-dimension explanations. Default: False.
+    include_issues (bool): Return detected issues. Default: False.
+
+Returns:
+    overall_score (float): Mean RAIL score across all examples.
+    overall_confidence (float): Mean confidence across all examples.
+    {dimension} (float): Mean score per dimension.
+    {dimension}_confidence (float): Mean confidence per dimension.
+    scores (list of float): Per-example overall scores.
+    confidences (list of float): Per-example overall confidence values.
+
+Examples:
+    >>> import evaluate
+    >>> rail_score = evaluate.load("rail_score")
+    >>> results = rail_score.compute(
+    ...     predictions=["The capital of France is Paris."],
+    ...     references=["What is the capital of France?"],
+    ... )
+    >>> print(round(results["overall_score"], 1))
+    8.5
+"""
+
+ALL_DIMENSIONS = [
+    "fairness",
+    "safety",
+    "reliability",
+    "transparency",
+    "privacy",
+    "accountability",
+    "inclusivity",
+    "user_impact",
+]
+
+
+@evaluate.utils.file_utils.add_start_docstrings(_DESCRIPTION, _KWARGS_DESCRIPTION)
+class RAILScore(evaluate.Metric):
+    """RAIL Score metric for responsible AI evaluation of LLM outputs."""
+
+    def _info(self):
+        return evaluate.MetricInfo(
+            description=_DESCRIPTION,
+            citation=_CITATION,
+            inputs_description=_KWARGS_DESCRIPTION,
+            features=[
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string"),
+                        "references": datasets.Value("string"),
+                    }
+                ),
+                datasets.Features(
+                    {
+                        "predictions": datasets.Value("string"),
+                    }
+                ),
+            ],
+            homepage="https://docs.responsibleailabs.ai",
+            codebase_urls=[
+                "https://github.com/Responsible-AI-Labs/rail-score-sdk",
+                "https://pypi.org/project/rail-score-sdk/",
+            ],
+            reference_urls=[
+                "https://responsibleailabs.ai",
+                "https://docs.responsibleailabs.ai",
+            ],
+            license="MIT",
+        )
+
+    def _compute(
+        self,
+        predictions: List[str],
+        references: Optional[List[str]] = None,
+        api_key: Optional[str] = None,
+        mode: str = "basic",
+        domain: str = "general",
+        dimensions: Optional[List[str]] = None,
+        weights: Optional[Dict[str, float]] = None,
+        include_explanations: bool = False,
+        include_issues: bool = False,
+    ) -> Dict:
+        try:
+            from rail_score_sdk import RailScoreClient
+        except ImportError:
+            raise ImportError(
+                "rail-score-sdk is required for RAIL Score. "
+                "Install it with: pip install rail-score-sdk"
+            )
+
+        key = api_key or os.environ.get("RAIL_API_KEY")
+        if not key:
+            raise ValueError(
+                "RAIL Score API key is required. Either pass api_key= to compute() "
+                "or set the RAIL_API_KEY environment variable. "
+                "Get a free key at https://responsibleailabs.ai"
+            )
+
+        client = RailScoreClient(api_key=key)
+        eval_dimensions = dimensions or ALL_DIMENSIONS
+
+        overall_scores: List[float] = []
+        overall_confidences: List[float] = []
+        dim_scores: Dict[str, List[float]] = {d: [] for d in eval_dimensions}
+        dim_confidences: Dict[str, List[float]] = {d: [] for d in eval_dimensions}
+        dim_explanations: Optional[Dict[str, List[str]]] = (
+            {d: [] for d in eval_dimensions} if include_explanations else None
+        )
+        all_issues: Optional[List[Dict]] = [] if include_issues else None
+
+        for i, prediction in enumerate(predictions):
+            context = references[i] if references is not None else None
+
+            result = self._eval_with_retry(
+                client,
+                content=prediction,
+                mode=mode,
+                dimensions=eval_dimensions,
+                weights=weights,
+                context=context,
+                domain=domain,
+                include_explanations=include_explanations,
+                include_issues=include_issues,
+            )
+
+            overall_scores.append(result.rail_score.score)
+            overall_confidences.append(result.rail_score.confidence)
+
+            for dim in eval_dimensions:
+                if dim in result.dimension_scores:
+                    ds = result.dimension_scores[dim]
+                    dim_scores[dim].append(ds.score)
+                    dim_confidences[dim].append(ds.confidence)
+                    if dim_explanations is not None:
+                        explanation = getattr(ds, "explanation", None)
+                        dim_explanations[dim].append(explanation or "")
+
+            if all_issues is not None and result.issues:
+                all_issues.extend(
+                    [
+                        {
+                            "example_index": i,
+                            "dimension": issue.dimension,
+                            "description": issue.description,
+                        }
+                        for issue in result.issues
+                    ]
+                )
+
+            if (i + 1) % 50 == 0:
+                logger.info("Evaluated %d/%d examples", i + 1, len(predictions))
+
+        n = len(overall_scores)
+        output: Dict = {
+            "overall_score": sum(overall_scores) / n if n else 0.0,
+            "overall_confidence": sum(overall_confidences) / n if n else 0.0,
+            "scores": overall_scores,
+            "confidences": overall_confidences,
+            "num_examples": n,
+        }
+
+        for dim in eval_dimensions:
+            scores = dim_scores[dim]
+            confs = dim_confidences[dim]
+            if scores:
+                output[dim] = sum(scores) / len(scores)
+                output[f"{dim}_scores"] = scores
+                output[f"{dim}_confidence"] = sum(confs) / len(confs)
+                output[f"{dim}_confidences"] = confs
+
+        if dim_explanations is not None:
+            output["explanations"] = dim_explanations
+
+        if all_issues is not None:
+            output["issues"] = all_issues
+
+        return output
+
+    @staticmethod
+    def _eval_with_retry(client, max_retries: int = 3, **kwargs):
+        """Call client.eval() with exponential backoff on rate limits."""
+        for attempt in range(max_retries):
+            try:
+                return client.eval(**kwargs)
+            except Exception as e:
+                is_rate_limit = "RateLimitError" in type(e).__name__ or "429" in str(e)
+                if is_rate_limit and attempt < max_retries - 1:
+                    wait = 2 ** (attempt + 1)
+                    logger.warning(
+                        "Rate limited, retrying in %ds (attempt %d/%d)",
+                        wait,
+                        attempt + 1,
+                        max_retries,
+                    )
+                    time.sleep(wait)
+                else:
+                    raise

--- a/metrics/rail_score/requirements.txt
+++ b/metrics/rail_score/requirements.txt
@@ -1,0 +1,1 @@
+rail-score-sdk>=2.4.0


### PR DESCRIPTION
## Summary

Adds RAIL Score as a new evaluation metric that scores LLM outputs across **8 responsible AI dimensions**: fairness, safety, reliability, transparency, privacy, accountability, inclusivity, and user impact.

Fixes #742

- Each dimension scored 0-10 with confidence values
- Custom dimension weights (sum to 100)
- Domain-specific evaluation (general, healthcare, finance, legal, education, code)
- Basic and deep modes (deep includes grounded explanations)
- Issue detection with dimension-level flagging

## Usage

```python
import evaluate

rail_score = evaluate.load("rail_score")
results = rail_score.compute(
    predictions=["The capital of France is Paris."],
    references=["What is the capital of France?"],
)
print(results["overall_score"])       # 8.2
print(results["overall_confidence"])  # 0.85
print(results["safety"])              # 9.5
```

## How to verify

```bash
pip install -e ".[dev]"
pip install rail-score-sdk
export RAIL_API_KEY="your-rail-api-key"

python -c "
import evaluate
rail_score = evaluate.load('metrics/rail_score')
results = rail_score.compute(
    predictions=['The capital of France is Paris.'],
    references=['What is the capital of France?'],
)
print(results)
"
```

Expected output: dictionary with `overall_score`, `overall_confidence`, and per-dimension scores (fairness, safety, reliability, etc.) each 0-10.

## Files added

- `metrics/rail_score/rail_score.py` -- Metric implementation
- `metrics/rail_score/README.md` -- Metric card with full documentation
- `metrics/rail_score/requirements.txt` -- `rail-score-sdk>=2.4.0`
- `metrics/rail_score/app.py` -- Gradio widget

## Note on community metric

This metric is also available as a community metric on the Hub: [responsible-ai-labs/rail_score](https://huggingface.co/spaces/responsible-ai-labs/rail_score). This PR adds it to the evaluate library directly for broader discoverability and native `evaluate.load()` support.

## Links

- [RAIL Score SDK on PyPI](https://pypi.org/project/rail-score-sdk/)
- [SDK Documentation](https://docs.responsibleailabs.ai)
- [Community metric on the Hub](https://huggingface.co/spaces/responsible-ai-labs/rail_score)