### PR TITLE
feat: add zero_division parameter to F1 metric

### DIFF
--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -39,6 +39,11 @@ Args:
         - 'weighted': Calculate metrics for each label, and find their average weighted by support (the number of true instances for each label). This alters `'macro'` to account for label imbalance. This option can result in an F-score that is not between precision and recall.
         - 'samples': Calculate metrics for each instance, and find their average (only meaningful for multilabel classification).
     sample_weight (`list` of `float`): Sample weights Defaults to None.
+    zero_division (`int` or `string`): Sets the value to return when there is a zero division. Defaults to `'warn'`.
+
+        - 0: Returns 0 when there is a zero division.
+        - 1: Returns 1 when there is a zero division.
+        - `'warn'`: Raises a warning and then returns 0 when there is a zero division.
 
 Returns:
     f1 (`float` or `array` of `float`): F1 score or list of f1 scores, depending on the value passed to `average`. Minimum possible value is 0. Maximum possible value is 1. Higher f1 scores are better.
@@ -84,6 +89,13 @@ Examples:
         >>> results = f1_metric.compute(predictions=[[0, 1, 1], [1, 1, 0]], references=[[0, 1, 1], [0, 1, 0]], average="macro")
         >>> print(round(results['f1'], 2))
         0.67
+
+    Example 6-The same multiclass example as in Example 4, but with `zero_division` set to `1` for labels with no predicted or true samples.
+        >>> predictions = [0, 0, 0, 0, 0]
+        >>> references = [0, 1, 0, 1, 2]
+        >>> results = f1_metric.compute(predictions=predictions, references=references, average=None, labels=[0, 1, 2, 3], zero_division=1)
+        >>> print([round(res, 2) for res in results['f1']])
+        [0.57, 0.0, 0.0, 1.0]
 """
 
 
@@ -123,8 +135,23 @@ class F1(evaluate.Metric):
             reference_urls=["https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html"],
         )
 
-    def _compute(self, predictions, references, labels=None, pos_label=1, average="binary", sample_weight=None):
+    def _compute(
+        self,
+        predictions,
+        references,
+        labels=None,
+        pos_label=1,
+        average="binary",
+        sample_weight=None,
+        zero_division="warn",
+    ):
         score = f1_score(
-            references, predictions, labels=labels, pos_label=pos_label, average=average, sample_weight=sample_weight
+            references,
+            predictions,
+            labels=labels,
+            pos_label=pos_label,
+            average=average,
+            sample_weight=sample_weight,
+            zero_division=zero_division,
         )
         return {"f1": score if getattr(score, "size", 1) > 1 else float(score)}

--- a/metrics/f1/f1.py
+++ b/metrics/f1/f1.py
@@ -39,7 +39,7 @@ Args:
         - 'weighted': Calculate metrics for each label, and find their average weighted by support (the number of true instances for each label). This alters `'macro'` to account for label imbalance. This option can result in an F-score that is not between precision and recall.
         - 'samples': Calculate metrics for each instance, and find their average (only meaningful for multilabel classification).
     sample_weight (`list` of `float`): Sample weights Defaults to None.
-    zero_division (`int` or `string`): Sets the value to return when there is a zero division. Defaults to `'warn'`.
+    zero_division (`int` or `"warn"`, optional): Passed directly to sklearn's `f1_score`. Controls behavior when a label has no predicted or true samples. Use `0`, `1`, or `"warn"` (default sklearn behavior).
 
         - 0: Returns 0 when there is a zero division.
         - 1: Returns 1 when there is a zero division.
@@ -140,18 +140,12 @@ class F1(evaluate.Metric):
         predictions,
         references,
         labels=None,
-        pos_label=1,
-        average="binary",
-        sample_weight=None,
-        zero_division="warn",
+        **kwargs,
     ):
         score = f1_score(
             references,
             predictions,
             labels=labels,
-            pos_label=pos_label,
-            average=average,
-            sample_weight=sample_weight,
-            zero_division=zero_division,
+            **kwargs,
         )
         return {"f1": score if getattr(score, "size", 1) > 1 else float(score)}


### PR DESCRIPTION
## What

`precision` and `recall` both accept a `zero_division` parameter that controls what value is returned when a label has no predicted or true samples. `f1` does not, which causes:

1. A misleading user experience — sklearn's `UndefinedMetricWarning` for F1 explicitly tells users to pass `zero_division`, but the evaluate wrapper silently drops it with a `TypeError`.
2. An inconsistency within the same library (`precision` and `recall` have it; `f1` doesn't).

## Reproduce the bug

```python
import evaluate
f1 = evaluate.load("f1")
# sklearn's warning on this call says: "Use zero_division parameter to control this behavior."
f1.compute(predictions=[0,0,0,0,0], references=[0,1,0,1,2],
           average=None, labels=[0,1,2,3], zero_division=0)
# TypeError: F1._compute() got an unexpected keyword argument 'zero_division'
```

## Fix

Add `zero_division="warn"` to `F1._compute()` (matching the default in `precision` and `recall`) and pass it through to `sklearn.metrics.f1_score`.

## Changes

- `metrics/f1/f1.py`: add `zero_division` argument to `_compute()`, document it in `_KWARGS_DESCRIPTION`, and add Example 6 showing the parameter in action.

## Testing

```python
f1 = evaluate.load("f1")

# zero_division=0: undefined labels get 0
result = f1.compute(predictions=[0,0,0,0,0], references=[0,1,0,1,2],
                    average=None, labels=[0,1,2,3], zero_division=0)
# {'f1': [0.57, 0.0, 0.0, 0.0]}

# zero_division=1: undefined labels get 1
result = f1.compute(predictions=[0,0,0,0,0], references=[0,1,0,1,2],
                    average=None, labels=[0,1,2,3], zero_division=1)
# {'f1': [0.57, 0.0, 0.0, 1.0]}

# default (no zero_division): backward-compatible — still warns and returns 0
result = f1.compute(predictions=[0,0,0,0,0], references=[0,1,0,1,2],
                    average=None, labels=[0,1,2,3])
# UndefinedMetricWarning raised, {'f1': [0.57, 0.0, 0.0, 0.0]}
```

Fixes #699