### PR TITLE
fix(loading): forward download_config to LocalEvaluationModuleFactory

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -617,13 +617,13 @@ def evaluation_module_factory(
     if path.endswith(filename):
         if os.path.isfile(path):
             return LocalEvaluationModuleFactory(
-                path, download_mode=download_mode, dynamic_modules_path=dynamic_modules_path
+                path, download_mode=download_mode, download_config=download_config, dynamic_modules_path=dynamic_modules_path
             ).get_module()
         else:
             raise FileNotFoundError(f"Couldn't find a metric script at {relative_to_absolute_path(path)}")
     elif os.path.isfile(combined_path):
         return LocalEvaluationModuleFactory(
-            combined_path, download_mode=download_mode, dynamic_modules_path=dynamic_modules_path
+            combined_path, download_mode=download_mode, download_config=download_config, dynamic_modules_path=dynamic_modules_path
         ).get_module()
     elif is_relative_path(path) and path.count("/") <= 1 and not force_local_path:
         try:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -2,6 +2,7 @@ import importlib
 import os
 import tempfile
 from unittest import TestCase
+from unittest.mock import patch
 
 import pytest
 from datasets import DownloadConfig
@@ -99,6 +100,35 @@ class ModuleFactoryTest(TestCase):
         )
         module_factory_result = factory.get_module()
         assert importlib.import_module(module_factory_result.module_path) is not None
+
+    def test_evaluation_module_factory_local_py_path_passes_download_config(self):
+        # Regression test for https://github.com/huggingface/evaluate/issues/709:
+        # evaluation_module_factory must forward download_config to LocalEvaluationModuleFactory
+        # when a direct .py path is given (path.endswith(filename) branch).
+        py_path = os.path.join(self._metric_loading_script_dir, f"{METRIC_LOADING_SCRIPT_NAME}.py")
+        with patch("evaluate.loading.LocalEvaluationModuleFactory", wraps=LocalEvaluationModuleFactory) as spy:
+            evaluation_module_factory(
+                py_path,
+                download_config=self.download_config,
+                dynamic_modules_path=self.dynamic_modules_path,
+            )
+            spy.assert_called_once()
+            _, kwargs = spy.call_args
+            assert kwargs.get("download_config") is self.download_config
+
+    def test_evaluation_module_factory_local_dir_path_passes_download_config(self):
+        # Regression test for https://github.com/huggingface/evaluate/issues/709:
+        # evaluation_module_factory must forward download_config to LocalEvaluationModuleFactory
+        # when a directory path is given (combined_path branch).
+        with patch("evaluate.loading.LocalEvaluationModuleFactory", wraps=LocalEvaluationModuleFactory) as spy:
+            evaluation_module_factory(
+                self._metric_loading_script_dir,
+                download_config=self.download_config,
+                dynamic_modules_path=self.dynamic_modules_path,
+            )
+            spy.assert_called_once()
+            _, kwargs = spy.call_args
+            assert kwargs.get("download_config") is self.download_config
 
     def test_CachedMetricModuleFactory(self):
         path = os.path.join(self._metric_loading_script_dir, f"{METRIC_LOADING_SCRIPT_NAME}.py")


### PR DESCRIPTION
## Summary

`evaluation_module_factory` has two code paths for loading a local metric script (lines 619–621 and 625–627 of `src/evaluate/loading.py`). Both paths construct a `LocalEvaluationModuleFactory` but omit the `download_config` argument that the caller explicitly passed in. As a result, the factory falls back to a blank `DownloadConfig()` for any secondary downloads it performs (e.g. fetching external requirements files declared in the script's `_HF_REQUIRES_PYTHON` imports). This silently ignores caller-supplied settings such as `local_files_only=True`, `cache_dir`, or custom proxies, which can cause unexpected network requests or connection failures in air-gapped / offline environments.

The fix is a two-line change: pass `download_config=download_config` to the `LocalEvaluationModuleFactory` constructor in both branches. The class already accepts and uses the parameter — it was just never forwarded from `evaluation_module_factory`.

Two regression tests were added that spy on `LocalEvaluationModuleFactory.__init__` (via `unittest.mock.patch(wraps=…)`) to assert the `download_config` object is forwarded for both the direct-`.py`-path branch and the directory-path branch.

## Issue

Fixes #709

## Local verification

```
$ cd /tmp/evaluate
$ python -m pytest tests/test_load.py::ModuleFactoryTest::test_LocalMetricModuleFactory \
    tests/test_load.py::ModuleFactoryTest::test_evaluation_module_factory_local_py_path_passes_download_config \
    tests/test_load.py::ModuleFactoryTest::test_evaluation_module_factory_local_dir_path_passes_download_config \
    -v

============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
collecting ... collected 3 items

tests/test_load.py::ModuleFactoryTest::test_LocalMetricModuleFactory PASSED [ 33%]
tests/test_load.py::ModuleFactoryTest::test_evaluation_module_factory_local_py_path_passes_download_config PASSED [ 66%]
tests/test_load.py::ModuleFactoryTest::test_evaluation_module_factory_local_dir_path_passes_download_config PASSED [100%]

============================== 3 passed in 1.52s ==============================
=== LOCAL_TEST_PASSED ===
```

(The other tests in `test_load.py` require connectivity to huggingface.co and fail with `ConnectionError 403` in this offline environment; they fail identically on the unmodified `main` branch.)

## Risk

The change is a pure addition of a previously-missing argument that was already declared in `LocalEvaluationModuleFactory.__init__`. It does not alter the existing `download_config` object, does not change the fallback default for callers that do not pass one (they still get `DownloadConfig()` via the `or DownloadConfig()` guard in the factory constructor), and has no effect on Hub-based loading paths. The only behaviour change is that callers who do pass a `download_config` will now have it respected for local scripts — closing a silent data-loss bug.
