### PR TITLE
fix: raise clear ValueError when add_batch receives None inputs

### DIFF
--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -510,6 +510,13 @@ class EvaluationModule(EvaluationModuleInfoMixin):
             )
         batch = {"predictions": predictions, "references": references, **kwargs}
         batch = {input_name: batch[input_name] for input_name in self._feature_names()}
+        none_inputs = [name for name, val in batch.items() if val is None]
+        if none_inputs:
+            raise ValueError(
+                f"Batch inputs contain None for the following fields: {none_inputs}. "
+                "All inputs must be non-None sequences (lists, arrays, or tensors). "
+                "Check that your compute_metrics function passes non-None predictions and references."
+            )
         if self.writer is None:
             self.selected_feature_format = self._infer_feature_from_batch(batch)
             self._init_writer()


### PR DESCRIPTION
## What
`add_batch()` crashed with a cryptic `TypeError: object of type 'NoneType' has no len()` when `predictions` or `references` was `None`. The error originated at line 518 (`if len(column) > 0`), was caught by the `except (pa.ArrowInvalid, TypeError)` handler, then immediately crashed again at line 523 (`len(batch[c])`) — producing a second, equally confusing traceback.

## Why
This affects anyone following the HuggingFace Trainer tutorial whose `compute_metrics` function conditionally returns `None` (e.g. when evaluation data is partially unavailable). The root error message gives no indication which field was `None` or why.

## Reproduce
```python
import evaluate
acc = evaluate.load("accuracy")
acc.add_batch(predictions=None, references=[0, 1])
# Before fix → TypeError: object of type 'NoneType' has no len()
# After fix  → ValueError: Batch inputs contain None for the following fields: ['predictions']. ...
```

## Fix
Validate the batch dict immediately after construction and raise a descriptive `ValueError` that names the offending fields and tells the user to check their `compute_metrics` return value. The change is 6 lines.

## Testing
```python
import evaluate
acc = evaluate.load("accuracy")
try:
    acc.add_batch(predictions=None, references=[0, 1])
except ValueError as e:
    print(e)
# Batch inputs contain None for the following fields: ['predictions'].
# All inputs must be non-None sequences (lists, arrays, or tensors).
# Check that your compute_metrics function passes non-None predictions and references.
```

Fixes #668