### PR TITLE
fix(module): export EvaluationModuleError and wrap _compute failures

### DIFF
--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -45,7 +45,15 @@ from .hub import push_to_hub
 from .info import ComparisonInfo, EvaluationModuleInfo, MeasurementInfo, MetricInfo
 from .inspect import inspect_evaluation_module, list_evaluation_modules
 from .loading import load
-from .module import CombinedEvaluations, Comparison, EvaluationModule, Measurement, Metric, combine
+from .module import (
+    CombinedEvaluations,
+    Comparison,
+    EvaluationModule,
+    EvaluationModuleError,
+    Measurement,
+    Metric,
+    combine,
+)
 from .saving import save
 from .utils import *
 from .utils import gradio, logging

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -41,6 +41,15 @@ from .utils.logging import get_logger
 logger = get_logger(__name__)
 
 
+class EvaluationModuleError(Exception):
+    """Raised when an evaluation module's ``_compute`` method fails.
+
+    Catching this exception lets callers distinguish evaluate-specific
+    failures from unrelated ``Exception`` subclasses without importing
+    internal sklearn or numpy error types.
+    """
+
+
 class FileFreeLock(BaseFileLock):
     """Thread lock until a file **cannot** be locked"""
 
@@ -464,7 +473,12 @@ class EvaluationModule(EvaluationModuleInfoMixin):
 
             inputs = {input_name: self.data[input_name][:] for input_name in self._feature_names()}
             with temp_seed(self.seed):
-                output = self._compute(**inputs, **compute_kwargs)
+                try:
+                    output = self._compute(**inputs, **compute_kwargs)
+                except EvaluationModuleError:
+                    raise
+                except Exception as e:
+                    raise EvaluationModuleError(f"Metric '{self.name}' raised {type(e).__name__}: {e}") from e
 
             if self.buf_writer is not None:
                 self.buf_writer = None

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 # Lint as: python3
-""" EvaluationModule base class."""
+"""EvaluationModule base class."""
+
 import collections
 import itertools
 import os
@@ -39,6 +40,10 @@ from .utils.logging import get_logger
 
 
 logger = get_logger(__name__)
+
+
+class EvaluationModuleError(Exception):
+    """Raised when an EvaluationModule's compute step fails."""
 
 
 class FileFreeLock(BaseFileLock):
@@ -464,7 +469,12 @@ class EvaluationModule(EvaluationModuleInfoMixin):
 
             inputs = {input_name: self.data[input_name][:] for input_name in self._feature_names()}
             with temp_seed(self.seed):
-                output = self._compute(**inputs, **compute_kwargs)
+                try:
+                    output = self._compute(**inputs, **compute_kwargs)
+                except EvaluationModuleError:
+                    raise
+                except Exception as e:
+                    raise EvaluationModuleError(f"Metric '{self.name}' computation failed: {e}") from e
 
             if self.buf_writer is not None:
                 self.buf_writer = None


### PR DESCRIPTION
## Summary

`EvaluationModuleError` was absent from `evaluate`'s public API, so callers had
no way to catch evaluate-specific failures without catching the broad `Exception`
base class or importing internal sklearn/numpy error types.  This made it
impossible to write `except evaluate.EvaluationModuleError` — doing so raised an
`AttributeError` because the symbol was never exported.

This PR adds the `EvaluationModuleError` class to `src/evaluate/module.py` and
exports it from `src/evaluate/__init__.py`.  It also wraps the `_compute()` call
inside `EvaluationModule.compute()` so that raw backend exceptions (e.g.
`ValueError: y_true contains only one label` from sklearn) surface as
`EvaluationModuleError` with a descriptive message, rather than leaking
implementation details to callers.

## Issue

Fixes #758

## Local verification

```
=== black check ===
All done! ✨ 🍰 ✨
2 files would be left unchanged.

=== isort check ===
(no output — no changes needed)

=== flake8 ===
(no output — no issues)

=== pytest tests/test_metric.py (22 passed, 2 skipped, 2 deselected) ===
PASSED test_concurrent_metrics
PASSED test_distributed_metrics
PASSED test_dummy_metric
PASSED test_dummy_metric_pickle
PASSED test_input_numpy
SKIPPED test_input_tf (torch/tf not installed)
SKIPPED test_input_torch (torch/tf not installed)
PASSED test_metric_with_cache_dir
PASSED test_multiple_features
PASSED test_separate_experiments_in_parallel
PASSED test_string_casting
PASSED test_string_casting_tested_once
PASSED test_metric_with_multilabel[None-...]
PASSED test_metric_with_multilabel[multilabel-...]
PASSED test_safety_checks_process_vars
PASSED test_metric_with_non_standard_feature_names_add
PASSED test_metric_with_non_standard_feature_names_add_batch
PASSED test_metric_with_non_standard_feature_names_compute
PASSED TestEvaluationcombined_evaluation::test_add
PASSED TestEvaluationcombined_evaluation::test_add_batch
PASSED TestEvaluationcombined_evaluation::test_duplicate_module
PASSED TestEvaluationcombined_evaluation::test_force_prefix_with_dict
PASSED TestEvaluationcombined_evaluation::test_single_module
PASSED TestEvaluationcombined_evaluation::test_two_modules_with_same_score_name

Note: test_modules_from_string excluded — it tries to load 'accuracy' from the
Hub and fails in a network-isolated environment; the failure is pre-existing
(confirmed against upstream/main without my changes).

=== EvaluationModuleError smoke test ===
import evaluate
assert hasattr(evaluate, 'EvaluationModuleError')
try:
    raise evaluate.EvaluationModuleError('...')
except evaluate.EvaluationModuleError:
    pass
all assertions passed
=== LOCAL_TEST_PASSED ===
```

## Risk

Wrapping `_compute()` is a breaking change only for callers that currently catch
the raw `ValueError`/`KeyError`/etc. raised by metric backends and rely on their
exact type — but that pattern was already undocumented and fragile.  The
`EvaluationModuleError` preserves the original exception via `from e` so
`__cause__` is always available.  No existing test expectations were changed.
