### PR TITLE
fix(loading): forward download_config to LocalEvaluationModuleFactory for local paths

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -617,13 +617,19 @@ def evaluation_module_factory(
     if path.endswith(filename):
         if os.path.isfile(path):
             return LocalEvaluationModuleFactory(
-                path, download_mode=download_mode, dynamic_modules_path=dynamic_modules_path
+                path,
+                download_config=download_config,
+                download_mode=download_mode,
+                dynamic_modules_path=dynamic_modules_path,
             ).get_module()
         else:
             raise FileNotFoundError(f"Couldn't find a metric script at {relative_to_absolute_path(path)}")
     elif os.path.isfile(combined_path):
         return LocalEvaluationModuleFactory(
-            combined_path, download_mode=download_mode, dynamic_modules_path=dynamic_modules_path
+            combined_path,
+            download_config=download_config,
+            download_mode=download_mode,
+            dynamic_modules_path=dynamic_modules_path,
         ).get_module()
     elif is_relative_path(path) and path.count("/") <= 1 and not force_local_path:
         try:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,7 +1,7 @@
 import importlib
 import os
 import tempfile
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pytest
 from datasets import DownloadConfig
@@ -138,3 +138,39 @@ class ModuleFactoryTest(TestCase):
                 evaluation_module_factory(
                     metric, download_config=self.download_config, dynamic_modules_path=self.dynamic_modules_path
                 )
+
+    def test_evaluation_module_factory_passes_download_config_local_script(self):
+        """Regression test for #709: download_config must be forwarded to LocalEvaluationModuleFactory
+        when loading a local .py file directly."""
+        path = os.path.join(self._metric_loading_script_dir, f"{METRIC_LOADING_SCRIPT_NAME}.py")
+        custom_config = DownloadConfig(cache_dir=self.cache_dir, local_files_only=True)
+        with mock.patch("evaluate.loading.LocalEvaluationModuleFactory") as mock_factory:
+            mock_factory.return_value.get_module.return_value = mock.MagicMock()
+            evaluation_module_factory(
+                path,
+                download_config=custom_config,
+                dynamic_modules_path=self.dynamic_modules_path,
+            )
+            mock_factory.assert_called_once()
+            _, call_kwargs = mock_factory.call_args
+            assert (
+                call_kwargs.get("download_config") is custom_config
+            ), "download_config was not forwarded to LocalEvaluationModuleFactory for .py path"
+
+    def test_evaluation_module_factory_passes_download_config_local_dir(self):
+        """Regression test for #709: download_config must be forwarded to LocalEvaluationModuleFactory
+        when loading a local directory (combined_path case)."""
+        path = self._metric_loading_script_dir
+        custom_config = DownloadConfig(cache_dir=self.cache_dir, local_files_only=True)
+        with mock.patch("evaluate.loading.LocalEvaluationModuleFactory") as mock_factory:
+            mock_factory.return_value.get_module.return_value = mock.MagicMock()
+            evaluation_module_factory(
+                path,
+                download_config=custom_config,
+                dynamic_modules_path=self.dynamic_modules_path,
+            )
+            mock_factory.assert_called_once()
+            _, call_kwargs = mock_factory.call_args
+            assert (
+                call_kwargs.get("download_config") is custom_config
+            ), "download_config was not forwarded to LocalEvaluationModuleFactory for directory path"


### PR DESCRIPTION
## Summary

`evaluation_module_factory` has two branches that resolve a local script path — one for a bare `.py` file and one for a directory containing a same-named script. In both cases the function constructs `LocalEvaluationModuleFactory` **without** forwarding the caller-supplied `download_config`. The factory then falls back to a fresh `DownloadConfig()`, silently discarding any settings the caller passed (e.g. `local_files_only=True`, a custom `cache_dir`, or `use_etag=False`). This makes it impossible to prevent outbound network requests when loading local evaluation modules in air-gapped or restricted-network environments, because the `_download_additional_modules` path inside the factory always receives default download behaviour regardless of what the caller specified.

The fix is a one-liner (×2): add `download_config=download_config` to each `LocalEvaluationModuleFactory(...)` call at lines 619–621 and 625–627 of `src/evaluate/loading.py`. The non-local (Hub, cached) branches already pass `download_config` correctly; this aligns the local branches with them.

Two regression tests are added to `tests/test_load.py` that verify `download_config` is forwarded for both the `.py`-file path and the directory path. They use `mock.patch` to intercept the factory constructor call and assert the `download_config` kwarg matches the caller-supplied object.

## Issue

Fixes #709

## Local verification

```
# Linters (black 22.12.0, isort, flake8) — matches CI quality job
$ cd /tmp/evaluate
$ python -m black --check --line-length 119 --target-version py36 src/evaluate/loading.py tests/test_load.py
All done! ✨ 🍰 ✨
2 files would be left unchanged.

$ isort --check-only src/evaluate/loading.py tests/test_load.py
(no output — all imports correctly sorted)

$ flake8 src/evaluate/loading.py tests/test_load.py
(no output — no issues)

ALL LINTERS PASS

# Unit tests (non-network, mirrors `python -m pytest -n 2 ./tests/` unit job)
$ PYTHONPATH=/tmp/evaluate/src python -m pytest tests/test_load.py -v \
    -k "not Hub and not hub and not remote"
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
collecting ... collected 9 items / 5 deselected / 4 selected

tests/test_load.py::ModuleFactoryTest::test_CachedMetricModuleFactory PASSED [ 25%]
tests/test_load.py::ModuleFactoryTest::test_LocalMetricModuleFactory PASSED [ 50%]
tests/test_load.py::ModuleFactoryTest::test_evaluation_module_factory_passes_download_config_local_dir PASSED [ 75%]
tests/test_load.py::ModuleFactoryTest::test_evaluation_module_factory_passes_download_config_local_script PASSED [100%]

======================= 4 passed, 5 deselected in 0.07s ========================
=== LOCAL_TEST_PASSED ===
```

## Risk

The change is minimal — two `download_config=download_config` keyword arguments added to existing `LocalEvaluationModuleFactory` constructor calls. The parameter was already defined on the constructor with a safe default (`DownloadConfig()`), so passing it explicitly cannot break any existing behaviour: callers that previously got the default will now get exactly the same default (since the top-level `evaluation_module_factory` already initialises `download_config = DownloadConfig(**download_kwargs)` when none is supplied). The only callers affected are those who explicitly pass a non-default `DownloadConfig` to `evaluation_module_factory` with a local path — those callers previously had their config silently dropped; now it is respected.
