### PR TITLE
Fix metadata path leaking outside cache when an ancestor dir contains '.py'

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -330,7 +330,9 @@ def _copy_script_and_other_resources_in_importable_dir(
             shutil.copyfile(original_local_path, importable_local_file)
 
         # Record metadata associating original dataset path with local unique folder
-        meta_path = importable_local_file.split(".py")[0] + ".json"
+        # (use splitext so an ancestor directory containing ".py" — pyenv, pycache,
+        # pypy paths — doesn't truncate the prefix to before that directory)
+        meta_path = os.path.splitext(importable_local_file)[0] + ".json"
         if not os.path.exists(meta_path):
             meta = {"original file path": original_local_path, "local file path": importable_local_file}
             # the filename is *.py in our case, so better rename to filenam.json instead of filename.py.json

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -138,3 +138,47 @@ class ModuleFactoryTest(TestCase):
                 evaluation_module_factory(
                     metric, download_config=self.download_config, dynamic_modules_path=self.dynamic_modules_path
                 )
+
+
+def test_copy_script_metadata_path_when_ancestor_dir_contains_py():
+    """Regression: meta_path derivation when an ancestor directory contains ".py".
+
+    The previous implementation used `importable_local_file.split(".py")[0]`,
+    which splits on every occurrence, so a cache path under ~/.pyenv/... wrote
+    the metadata to ~/.json — outside the cache tree — instead of next to the
+    copied script.
+    """
+    import json
+
+    from evaluate.loading import _copy_script_and_other_resources_in_importable_dir
+
+    with tempfile.TemporaryDirectory() as root:
+        # Simulate a pyenv-style cache path: ancestor directory contains ".py".
+        importable_directory_path = os.path.join(root, ".pyenv", "evaluate_modules")
+        # The FileLock acquired inside the function needs the parent dir to exist.
+        os.makedirs(os.path.dirname(importable_directory_path), exist_ok=True)
+        subdirectory_name = "abcd1234"
+        name = "accuracy"
+
+        original_script_path = os.path.join(root, "src_accuracy.py")
+        with open(original_script_path, "w", encoding="utf-8") as f:
+            f.write("# dummy metric script\n")
+
+        _copy_script_and_other_resources_in_importable_dir(
+            name=name,
+            importable_directory_path=importable_directory_path,
+            subdirectory_name=subdirectory_name,
+            original_local_path=original_script_path,
+            local_imports=[],
+            additional_files=[],
+            download_mode=None,
+        )
+
+        expected_meta = os.path.join(importable_directory_path, subdirectory_name, name + ".json")
+        leaked_meta = os.path.join(root, ".json")
+
+        assert os.path.exists(expected_meta), f"meta file missing at {expected_meta}"
+        assert not os.path.exists(leaked_meta), f"meta file leaked to {leaked_meta}"
+        with open(expected_meta, "r", encoding="utf-8") as f:
+            meta = json.load(f)
+        assert meta["original file path"] == original_script_path


### PR DESCRIPTION
## Summary

`_copy_script_and_other_resources_in_importable_dir` (`src/evaluate/loading.py:333`) derives the cache metadata JSON sibling of the loaded script:

```python
meta_path = importable_local_file.split(".py")[0] + ".json"
```

The intent (per the comment two lines below — *"the filename is *.py in our case, so better rename to filenam.json instead of filename.py.json"*) is to swap the trailing `.py` extension for `.json`. But `str.split(".py")` splits on **every** occurrence of `.py` and `[0]` keeps everything before the first.

For any user whose cache path has `.py` somewhere in an **ancestor** directory — `.pyenv`, `.pycache`, pypy install paths, project directories containing `.py` — the prefix gets truncated to before that directory.

A pyenv user with an importable file at
`/home/u/.pyenv/versions/.../evaluate_modules/metrics/accuracy/<hash>/accuracy.py`
ends up writing the metadata to **`/home/u/.json`** — outside the cache tree — and every subsequent `evaluate.load(...)` clobbers it.

```python
>>> "/home/u/.pyenv/.../accuracy.py".split(".py")[0] + ".json"
'/home/u/.json'                                                # current

>>> os.path.splitext("/home/u/.pyenv/.../accuracy.py")[0] + ".json"
'/home/u/.pyenv/.../accuracy.json'                             # fixed
```

## Fix

Use `os.path.splitext(...)[0]` so only the trailing extension is stripped, matching the comment's stated intent.

## Why this isn't a behavior change someone is relying on

`grep -rn '"original file path"\|"local file path"\|meta_path'` shows nothing in the repo reads the metadata back — it's write-only informational JSON. The only effect of the bug is junk JSON files at unexpected paths.

## Test plan

Added `test_copy_script_metadata_path_when_ancestor_dir_contains_py` in `tests/test_load.py`. It calls `_copy_script_and_other_resources_in_importable_dir` with `importable_directory_path = <tmp>/.pyenv/evaluate_modules` and asserts:

- the metadata file exists at `<tmp>/.pyenv/evaluate_modules/<hash>/accuracy.json` (next to the script);
- nothing was leaked to `<tmp>/.json`.

The test **fails on `main`** with `AssertionError: meta file missing at <expected path>` and **passes** with this change. `pytest tests/test_load.py::test_copy_script_metadata_path_when_ancestor_dir_contains_py` → 1 passed.