### PR TITLE
Add __repr__ methods for DatasetColumn and DatasetColumnPair

### DIFF
--- a/src/evaluate/evaluator/utils.py
+++ b/src/evaluate/evaluator/utils.py
@@ -8,6 +8,9 @@ class DatasetColumn(list):
         self.dataset = dataset
         self.key = key
 
+    def __repr__(self):
+        return f"DatasetColumn(key={self.key!r}, len={len(self)})"
+
     def __len__(self):
         return len(self.dataset)
 
@@ -64,6 +67,16 @@ class DatasetColumnPair(list):
 
         self.first_key = first_key
         self.second_key = second_key
+
+    def __repr__(self):
+        return (
+            f"DatasetColumnPair("
+            f"first_col={self.first_col!r}, "
+            f"second_col={self.second_col!r}, "
+            f"first_key={self.first_key!r}, "
+            f"second_key={self.second_key!r}, "
+            f"len={len(self)})"
+        )
 
     def __len__(self):
         return len(self.dataset)

--- a/tests/test_evaluator_utils.py
+++ b/tests/test_evaluator_utils.py
@@ -1,0 +1,20 @@
+from datasets import Dataset
+
+from evaluate.evaluator.utils import DatasetColumn, DatasetColumnPair
+
+
+def test_dataset_column_repr():
+    dataset = Dataset.from_dict({"text": ["a", "b", "c"]})
+    column = DatasetColumn(dataset, "text")
+
+    assert repr(column) == "DatasetColumn(key='text', len=3)"
+
+
+def test_dataset_column_pair_repr():
+    dataset = Dataset.from_dict({"text": ["a", "b", "c"], "label": [0, 1, 0]})
+    column_pair = DatasetColumnPair(dataset, "text", "label", "prediction", "reference")
+
+    assert repr(column_pair) == (
+        "DatasetColumnPair(first_col='text', second_col='label', "
+        "first_key='prediction', second_key='reference', len=3)"
+    )


### PR DESCRIPTION
## Summary

This PR addresses #547 by adding `__repr__()` implementations for `DatasetColumn` and `DatasetColumnPair`.

Currently, both classes inherit from `list` but do not populate the underlying list. As a result, printing either object displays `[]`, even though they provide lazy access to dataset columns. This can make debugging difficult and lead to confusing exception messages and logs.

The new representations provide a concise summary of each object without loading dataset contents into memory. For `DatasetColumn`, the representation includes the column key and dataset length. For `DatasetColumnPair`, it includes the configured column names, key mappings, and dataset length.

## Changes

* Added `__repr__()` to `DatasetColumn`
* Added `__repr__()` to `DatasetColumnPair`
* Added tests covering both representations

## Example

Before:

```python
print(DatasetColumn(...))
# []
```

After:

```python
print(DatasetColumn(...))
# DatasetColumn(key='text', len=3)
```

Similarly, `DatasetColumnPair` now provides a meaningful representation instead of displaying as an empty list.

## Testing

I added tests for both classes and verified that the new representations are returned as expected.

```bash
python -m pytest tests/test_evaluator_utils.py -v
```

Result:

```text
2 passed
```

Fixes #547.
