### PR TITLE
Export EvaluationModuleError and wrap _compute failures (fixes #758)

### DIFF
--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -45,7 +45,15 @@ from .hub import push_to_hub
 from .info import ComparisonInfo, EvaluationModuleInfo, MeasurementInfo, MetricInfo
 from .inspect import inspect_evaluation_module, list_evaluation_modules
 from .loading import load
-from .module import CombinedEvaluations, Comparison, EvaluationModule, Measurement, Metric, combine
+from .module import (
+    CombinedEvaluations,
+    Comparison,
+    EvaluationModule,
+    EvaluationModuleError,
+    Measurement,
+    Metric,
+    combine,
+)
 from .saving import save
 from .utils import *
 from .utils import gradio, logging

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -41,6 +41,16 @@ from .utils.logging import get_logger
 logger = get_logger(__name__)
 
 
+class EvaluationModuleError(Exception):
+    """Base error raised when an evaluation module fails to compute its result.
+
+    Failures coming from the underlying ``_compute`` implementation (for example a
+    ``ValueError`` or ``KeyError`` raised by scikit-learn) are wrapped in this error so
+    that callers can catch evaluate-specific failures without catching a bare
+    ``Exception``. The original exception is preserved on ``__cause__``.
+    """
+
+
 class FileFreeLock(BaseFileLock):
     """Thread lock until a file **cannot** be locked"""
 
@@ -464,7 +474,12 @@ class EvaluationModule(EvaluationModuleInfoMixin):
 
             inputs = {input_name: self.data[input_name][:] for input_name in self._feature_names()}
             with temp_seed(self.seed):
-                output = self._compute(**inputs, **compute_kwargs)
+                try:
+                    output = self._compute(**inputs, **compute_kwargs)
+                except EvaluationModuleError:
+                    raise
+                except Exception as e:
+                    raise EvaluationModuleError(f"Error computing {self.name} metric: {type(e).__name__}: {e}") from e
 
             if self.buf_writer is not None:
                 self.buf_writer = None

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -8,7 +8,8 @@ from unittest import TestCase, mock
 import pytest
 from datasets.features import Features, Sequence, Value
 
-from evaluate.module import EvaluationModule, EvaluationModuleInfo, combine
+import evaluate
+from evaluate.module import EvaluationModule, EvaluationModuleError, EvaluationModuleInfo, combine
 
 from .utils import require_tf, require_torch
 
@@ -757,3 +758,35 @@ class TestEvaluationcombined_evaluation(TestCase):
         self.assertDictEqual(
             expected_result, combined_evaluation.compute(predictions=predictions, references=references, pos_label=0)
         )
+
+
+class RaisingMetric(EvaluationModule):
+    """Dummy metric whose ``_compute`` raises a bare ``ValueError``, as scikit-learn does."""
+
+    def _info(self):
+        return EvaluationModuleInfo(
+            description="dummy metric that raises in _compute",
+            citation="insert citation here",
+            features=Features({"predictions": Value("int64"), "references": Value("int64")}),
+        )
+
+    def _compute(self, predictions, references):
+        raise ValueError("Found input variables with inconsistent numbers of samples")
+
+
+class TestEvaluationModuleError(TestCase):
+    def test_error_is_exported_from_public_api(self):
+        self.assertTrue(hasattr(evaluate, "EvaluationModuleError"))
+        self.assertIs(evaluate.EvaluationModuleError, EvaluationModuleError)
+
+    def test_compute_wraps_underlying_error(self):
+        metric = RaisingMetric(experiment_id="test_compute_wraps_underlying_error")
+        with self.assertRaises(EvaluationModuleError) as ctx:
+            metric.compute(predictions=[1], references=[1])
+        # The original exception is preserved for debugging.
+        self.assertIsInstance(ctx.exception.__cause__, ValueError)
+
+    def test_compute_catchable_via_public_api(self):
+        metric = RaisingMetric(experiment_id="test_compute_catchable_via_public_api")
+        with self.assertRaises(evaluate.EvaluationModuleError):
+            metric.compute(predictions=[1], references=[1])


### PR DESCRIPTION
Raw exceptions from a metric's _compute (for example sklearn ValueError or KeyError) currently propagate to callers of compute() unchanged, and there is no public evaluate error type to catch, so users fall back on a broad except Exception.

This adds an EvaluationModuleError class, exports it from the package, and wraps failures coming out of _compute in it. The original exception is kept on __cause__ so tracebacks and debugging are unaffected.

Note: the linked issue assumed EvaluationModuleError already existed internally; it did not, so this PR also defines the class.

Added tests in tests/test_metric.py covering that the error is importable from the public API and that a failing _compute raises EvaluationModuleError rather than a bare ValueError.

Fixes #758
