### PR TITLE
fix: pass download_config to LocalEvaluationModuleFactory calls

### DIFF
--- a/src/evaluate/loading.py
+++ b/src/evaluate/loading.py
@@ -617,13 +617,13 @@ def evaluation_module_factory(
     if path.endswith(filename):
         if os.path.isfile(path):
             return LocalEvaluationModuleFactory(
-                path, download_mode=download_mode, dynamic_modules_path=dynamic_modules_path
+                path, download_config=download_config, download_mode=download_mode, dynamic_modules_path=dynamic_modules_path
             ).get_module()
         else:
             raise FileNotFoundError(f"Couldn't find a metric script at {relative_to_absolute_path(path)}")
     elif os.path.isfile(combined_path):
         return LocalEvaluationModuleFactory(
-            combined_path, download_mode=download_mode, dynamic_modules_path=dynamic_modules_path
+            combined_path, download_config=download_config, download_mode=download_mode, dynamic_modules_path=dynamic_modules_path
         ).get_module()
     elif is_relative_path(path) and path.count("/") <= 1 and not force_local_path:
         try:


### PR DESCRIPTION
## Summary

Fixes #709.

Two call sites in `evaluation_module_factory()` that instantiate `LocalEvaluationModuleFactory` omit the `download_config` parameter:

```python
# Before (both calls):
return LocalEvaluationModuleFactory(
    path, download_mode=download_mode, dynamic_modules_path=dynamic_modules_path
).get_module()
```

This means any custom `DownloadConfig` passed by the caller (e.g. custom token, proxies, retries, or cache settings) is silently dropped when loading **local** metric scripts. The same config **is** correctly forwarded when loading from the Hub via `HubEvaluationModuleFactory`.

## Fix

Add `download_config=download_config` to both `LocalEvaluationModuleFactory` instantiations, matching the pattern already used for `HubEvaluationModuleFactory`:

```python
# After:
return LocalEvaluationModuleFactory(
    path, download_config=download_config, download_mode=download_mode, dynamic_modules_path=dynamic_modules_path
).get_module()
```

This ensures that callers who pass a `DownloadConfig` (e.g. with `use_auth_token`, `proxies`, or custom `user_agent`) have that config respected even when the metric is loaded from a local path.