### PR TITLE
docs(naming): add missing docstrings to filename utility functions

### DIFF
--- a/src/evaluate/naming.py
+++ b/src/evaluate/naming.py
@@ -44,12 +44,52 @@ def snakecase_to_camelcase(name):
 
 
 def filename_prefix_for_name(name):
+    """Return the snake_case filename prefix for a given dataset name.
+
+    Args:
+        name (`str`): Dataset name (must not contain path separators).
+
+    Returns:
+        `str`: The snake_case version of `name`, used as the base prefix for data files.
+
+    Raises:
+        `ValueError`: If `name` looks like a file path rather than a plain dataset name.
+
+    Example:
+        ```py
+        >>> filename_prefix_for_name("MyDataset")
+        'my_dataset'
+        ```
+    """
     if os.path.basename(name) != name:
         raise ValueError(f"Should be a dataset name, not a path: {name}")
     return camelcase_to_snakecase(name)
 
 
 def filename_prefix_for_split(name, split):
+    """Return the filename prefix for a specific dataset split.
+
+    Combines the snake_case dataset name with the split name, following
+    the pattern ``<snake_case_name>-<split>``.
+
+    Args:
+        name (`str`): Dataset name (must not contain path separators).
+        split (`str`): Split identifier, e.g. ``"train"``, ``"test"``, or
+            a dotted sub-split such as ``"train.clean"``.
+
+    Returns:
+        `str`: The filename prefix in the form ``<name_prefix>-<split>``.
+
+    Raises:
+        `ValueError`: If `name` looks like a path, or `split` does not match
+            the expected pattern ``^\\w+(\\.\\w+)*$``.
+
+    Example:
+        ```py
+        >>> filename_prefix_for_split("MyDataset", "train")
+        'my_dataset-train'
+        ```
+    """
     if os.path.basename(name) != name:
         raise ValueError(f"Should be a dataset name, not a path: {name}")
     if not re.match(_split_re, split):
@@ -58,6 +98,25 @@ def filename_prefix_for_split(name, split):
 
 
 def filepattern_for_dataset_split(dataset_name, split, data_dir, filetype_suffix=None):
+    """Return a glob pattern matching all shard files for a dataset split.
+
+    Args:
+        dataset_name (`str`): Dataset name (must not contain path separators).
+        split (`str`): Split identifier, e.g. ``"train"`` or ``"validation"``.
+        data_dir (`str`): Directory where the dataset files are stored.
+        filetype_suffix (`str`, *optional*): File extension to append before the
+            glob wildcard, e.g. ``"parquet"`` → ``"my_dataset-train.parquet*"``.
+            When ``None`` the pattern has no extension suffix.
+
+    Returns:
+        `str`: A glob pattern of the form ``<data_dir>/<prefix>[.<suffix>]*``.
+
+    Example:
+        ```py
+        >>> filepattern_for_dataset_split("MyDataset", "train", "/data", "parquet")
+        '/data/my_dataset-train.parquet*'
+        ```
+    """
     prefix = filename_prefix_for_split(dataset_name, split)
     if filetype_suffix:
         prefix += f".{filetype_suffix}"
@@ -66,6 +125,24 @@ def filepattern_for_dataset_split(dataset_name, split, data_dir, filetype_suffix
 
 
 def filename_for_dataset_split(dataset_name, split, filetype_suffix=None):
+    """Return the filename (without directory) for a dataset split.
+
+    Args:
+        dataset_name (`str`): Dataset name (must not contain path separators).
+        split (`str`): Split identifier, e.g. ``"train"`` or ``"test"``.
+        filetype_suffix (`str`, *optional*): File extension to append, e.g.
+            ``"arrow"`` → ``"my_dataset-train.arrow"``. When ``None`` no
+            extension is added.
+
+    Returns:
+        `str`: The filename string, e.g. ``"my_dataset-train.arrow"``.
+
+    Example:
+        ```py
+        >>> filename_for_dataset_split("MyDataset", "train", "arrow")
+        'my_dataset-train.arrow'
+        ```
+    """
     prefix = filename_prefix_for_split(dataset_name, split)
     if filetype_suffix:
         prefix += f".{filetype_suffix}"
@@ -73,6 +150,27 @@ def filename_for_dataset_split(dataset_name, split, filetype_suffix=None):
 
 
 def filepath_for_dataset_split(dataset_name, split, data_dir, filetype_suffix=None):
+    """Return the full file path for a dataset split file.
+
+    Combines `data_dir` and the result of :func:`filename_for_dataset_split`
+    to produce an absolute-or-relative path suitable for reading or writing.
+
+    Args:
+        dataset_name (`str`): Dataset name (must not contain path separators).
+        split (`str`): Split identifier, e.g. ``"train"`` or ``"validation"``.
+        data_dir (`str`): Directory where the dataset files are stored.
+        filetype_suffix (`str`, *optional*): File extension without the leading
+            dot, e.g. ``"arrow"``. When ``None`` no extension is added.
+
+    Returns:
+        `str`: Full path of the form ``<data_dir>/<filename>``.
+
+    Example:
+        ```py
+        >>> filepath_for_dataset_split("MyDataset", "train", "/data", "arrow")
+        '/data/my_dataset-train.arrow'
+        ```
+    """
     filename = filename_for_dataset_split(
         dataset_name=dataset_name,
         split=split,


### PR DESCRIPTION
## Summary

Five public functions in `src/evaluate/naming.py` had no docstrings at all, making their expected inputs, outputs, and error conditions invisible to IDE tooling and to contributors reading the source.

This PR adds complete docstrings following the existing HuggingFace style used throughout the codebase (Google-style with backtick-formatted types):

| Function | What was added |
|----------|---------------|
| `filename_prefix_for_name` | `Args`, `Returns`, `Raises`, `Example` |
| `filename_prefix_for_split` | `Args`, `Returns`, `Raises`, `Example` |
| `filepattern_for_dataset_split` | `Args`, `Returns`, `Example` |
| `filename_for_dataset_split` | `Args`, `Returns`, `Example` |
| `filepath_for_dataset_split` | `Args`, `Returns`, cross-reference to helper, `Example` |

## No logic changes

Documentation only — no behaviour was modified.

## CI checks

- `black --check` ✅
- `isort --check-only` ✅
- `flake8` ✅