### PR TITLE
Support scalar results in combined evaluations

### DIFF
--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -982,6 +982,10 @@ class CombinedEvaluations:
 
     def _merge_results(self, results):
         merged_results = {}
+        results = [
+            result if isinstance(result, dict) else {module_name: result}
+            for module_name, result in zip(self.evaluation_module_names, results)
+        ]
         results_keys = list(itertools.chain.from_iterable([r.keys() for r in results]))
         duplicate_keys = {item for item, count in collections.Counter(results_keys).items() if count > 1}
 

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -757,3 +757,14 @@ class TestEvaluationcombined_evaluation(TestCase):
         self.assertDictEqual(
             expected_result, combined_evaluation.compute(predictions=predictions, references=references, pos_label=0)
         )
+
+    def test_combined_evaluation_with_scalar_results(self):
+        predictions = ["this is the prediction", "there is an other sample"]
+        references = ["this is the reference", "there is another one"]
+        expected_result = {"wer": 0.5, "cer": 0.34146341463414637}
+
+        combined_evaluation = combine(["wer", "cer"])
+
+        self.assertDictEqual(
+            expected_result, combined_evaluation.compute(predictions=predictions, references=references)
+        )


### PR DESCRIPTION
## Summary

Fixes #516.

Some evaluation modules (e.g. wer and cer) return scalar values rather than dictionaries. `CombinedEvaluations._merge_results()` assumes every module returns a dictionary and attempts to call `.keys()` on each result, causing combined evaluation to fail.

This change wraps scalar results using the corresponding evaluation module name before merging, allowing scalar-returning evaluation modules to be combined while preserving the existing behavior for dictionary-returning modules.

## Tests

Added a regression test covering:

```python
evaluate.combine(["wer", "cer"]).compute(...)
```

which now returns the expected combined evaluation results without raising an exception.