### PR TITLE
feat(module): add EvaluationModuleError to public API and wrap _compute exceptions

### DIFF
--- a/src/evaluate/__init__.py
+++ b/src/evaluate/__init__.py
@@ -45,7 +45,7 @@ from .hub import push_to_hub
 from .info import ComparisonInfo, EvaluationModuleInfo, MeasurementInfo, MetricInfo
 from .inspect import inspect_evaluation_module, list_evaluation_modules
 from .loading import load
-from .module import CombinedEvaluations, Comparison, EvaluationModule, Measurement, Metric, combine
+from .module import CombinedEvaluations, Comparison, EvaluationModule, EvaluationModuleError, Measurement, Metric, combine
 from .saving import save
 from .utils import *
 from .utils import gradio, logging

--- a/src/evaluate/module.py
+++ b/src/evaluate/module.py
@@ -40,6 +40,22 @@ from .utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+class EvaluationModuleError(Exception):
+    """Exception raised when an :class:`EvaluationModule` computation fails.
+
+    Wraps internal errors (e.g. from sklearn or numpy) so callers can catch
+    evaluate-specific failures without catching broad :exc:`Exception`.
+
+    Example::
+
+        import evaluate
+        acc = evaluate.load("accuracy")
+        try:
+            acc.compute(predictions=[], references=[])
+        except evaluate.EvaluationModuleError as e:
+            print(f"Metric computation failed: {e}")
+    """
+
 
 class FileFreeLock(BaseFileLock):
     """Thread lock until a file **cannot** be locked"""
@@ -464,7 +480,14 @@ class EvaluationModule(EvaluationModuleInfoMixin):
 
             inputs = {input_name: self.data[input_name][:] for input_name in self._feature_names()}
             with temp_seed(self.seed):
-                output = self._compute(**inputs, **compute_kwargs)
+                try:
+                    output = self._compute(**inputs, **compute_kwargs)
+                except EvaluationModuleError:
+                    raise
+                except Exception as e:
+                    raise EvaluationModuleError(
+                        f"Metric computation failed for '{self.name}': {e}"
+                    ) from e
 
             if self.buf_writer is not None:
                 self.buf_writer = None


### PR DESCRIPTION
## Summary

`EvaluationModuleError` did not exist in the public API, so users had no way to catch evaluate-specific errors — raw `ValueError` / `KeyError` from sklearn or numpy leaked straight to the caller.

## Changes

**`src/evaluate/module.py`**
- Introduces `EvaluationModuleError(Exception)` right after the logger setup
- Wraps the `self._compute(**inputs, **compute_kwargs)` call in `compute()` so any unexpected exception is re-raised as `EvaluationModuleError` with a descriptive message; already-typed errors are re-raised as-is

**`src/evaluate/__init__.py`**
- Exports `EvaluationModuleError` alongside `EvaluationModule`

## Before / After

```python
import evaluate

acc = evaluate.load("accuracy")

# Before:
# hasattr(evaluate, "EvaluationModuleError")  # False
# acc.compute(predictions=[], references=[])  # raises raw ValueError

# After:
print(hasattr(evaluate, "EvaluationModuleError"))  # True

try:
    acc.compute(predictions=[], references=[])
except evaluate.EvaluationModuleError as e:
    print(f"Caught: {e}")
# Caught: Metric computation failed for 'accuracy': ...
```

Fixes #758