### PR TITLE
Use per-dimension mean (axis=0) in mahalanobis metric

### DIFF
--- a/metrics/mahalanobis/mahalanobis.py
+++ b/metrics/mahalanobis/mahalanobis.py
@@ -54,6 +54,10 @@ Examples:
     >>> results = mahalanobis_metric.compute(reference_distribution=[[0, 1], [1, 0]], X=[[0, 1]])
     >>> print(results)
     {'mahalanobis': array([0.5])}
+    >>> # a point on the reference distribution's centroid has distance 0
+    >>> results = mahalanobis_metric.compute(reference_distribution=[[0, 10], [4, 10], [0, 14], [4, 14]], X=[[2, 12]])
+    >>> print(results)
+    {'mahalanobis': array([0.])}
 """
 
 
@@ -88,7 +92,7 @@ class Mahalanobis(evaluate.Metric):
             )
 
         # Get mahalanobis distance for each prediction
-        X_minus_mu = X - np.mean(reference_distribution)
+        X_minus_mu = X - np.mean(reference_distribution, axis=0)
         cov = np.cov(reference_distribution.T)
         try:
             inv_covmat = np.linalg.inv(cov)


### PR DESCRIPTION
## Summary

The Mahalanobis distance centers `X` on the **mean vector** (per-column centroid) of the reference distribution, but `_compute` uses `np.mean(reference_distribution)` with no axis, which collapses the 2-D reference array to a single **scalar** grand mean and broadcasts it across every feature:

```python
X_minus_mu = X - np.mean(reference_distribution)      # scalar grand mean
cov = np.cov(reference_distribution.T)                # per-column covariance
```

The very next line, `np.cov(reference_distribution.T)`, treats each column as a variable — confirming the per-dimension intent. As a result the metric is wrong for any distribution whose feature means differ.

## Reproduction

```python
import evaluate
m = evaluate.load("mahalanobis")
m.compute(reference_distribution=[[0, 10], [4, 10], [0, 14], [4, 14]], X=[[2, 12]])
# X = [2, 12] is exactly the centroid, so the distance should be 0.0
# actual:   {'mahalanobis': array([9.375])}
# expected: {'mahalanobis': array([0.])}
```

## Fix

```diff
-        X_minus_mu = X - np.mean(reference_distribution)
+        X_minus_mu = X - np.mean(reference_distribution, axis=0)
```

## Tests

Added a doctest showing a point on the distribution's centroid has distance 0. The existing doctest (`reference_distribution=[[0, 1], [1, 0]]`) is symmetric — its column means equal the grand mean — so it yields `array([0.5])` under both the old and new code and remains unchanged.
