### PR TITLE
Fix typo: IoUO -> IoU in types_of_evaluations.mdx

### DIFF
--- a/docs/source/types_of_evaluations.mdx
+++ b/docs/source/types_of_evaluations.mdx
@@ -10,7 +10,7 @@ A metric measures the performance of a model on a given dataset. This is often b
 Examples of metrics include:
 - [Accuracy](https://huggingface.co/metrics/accuracy) : the proportion of correct predictions among the total number of cases processed.
 - [Exact Match](https://huggingface.co/metrics/exact_match): the rate at which the input predicted strings exactly match their references.
-- [Mean Intersection over union (IoUO)](https://huggingface.co/metrics/mean_iou): the area of overlap between the predicted segmentation of an image and the ground truth divided by the area of union between the predicted segmentation and the ground truth.
+- [Mean Intersection over union (IoU)](https://huggingface.co/metrics/mean_iou): the area of overlap between the predicted segmentation of an image and the ground truth divided by the area of union between the predicted segmentation and the ground truth.
 
 Metrics are often used to track model performance on benchmark datasets, and to report progress on tasks such as [machine translation](https://huggingface.co/tasks/translation) and [image classification](https://huggingface.co/tasks/image-classification).
 


### PR DESCRIPTION
Fixes #639.

Fixes a typo in the docs where "Mean Intersection over union" was abbreviated as `IoUO` instead of `IoU`.

**Change:**
`docs/source/types_of_evaluations.mdx` — `IoUO` -> `IoU`

This is a single-line documentation fix; no code or behavior changes.

_Note: this PR was prepared with the assistance of an AI coding tool (Claude Code)._
