### PR TITLE
Fix typo and document normalize values in confusion_matrix README

### DIFF
--- a/metrics/confusion_matrix/README.md
+++ b/metrics/confusion_matrix/README.md
@@ -54,11 +54,11 @@ At minimum, this metric requires predictions and references as inputs.
 - **references** (`list` of `int`): Ground truth labels.
 - **labels** (`list` of `int`): List of labels to index the matrix. This may be used to reorder or select a subset of labels.
 - **sample_weight** (`list` of `float`): Sample weights.
-- **normalize** (`str`): Normalizes confusion matrix over the true (rows), predicted (columns) conditions or all the population. 
+- **normalize** (`str`): Normalizes confusion matrix over the true (rows), predicted (columns) conditions or all the population. Permitted values are `'true'`, `'pred'`, `'all'`, or `None` (default).
 
 
 ### Output Values
-- **confusion_matrix**(`list` of `list` of `str`): Confusion matrix. Minimum possible value is 0. Maximum possible value is 1.0, or the number of examples input, if `normalize` is set to `True`.
+- **confusion_matrix**(`list` of `list` of `str`): Confusion matrix. Minimum possible value is 0. Maximum possible value is 1.0, or the number of examples in the input, if `normalize` is set to `None` (default).
 
 Output Example(s):
 ```python


### PR DESCRIPTION
Fix typo and document normalize values in confusion_matrix README

Closes #652

## What this fixes

In `metrics/confusion_matrix/README.md`:

1. **Typo in Output Values**: "or the number of examples input" is missing
   a word and should read "or the number of examples in the input". The
   same sentence also referenced `normalize` being set to `True`, but
   `normalize` is a string parameter (passed straight through to
   `sklearn.metrics.confusion_matrix`) and its default is `None`, not a
   boolean `True`. Corrected to "if `normalize` is set to `None` (default)".

2. **Missing valid values for `normalize`**: The Inputs section described
   what `normalize` does but never listed the permitted values. Added the
   permitted values `'true'`, `'pred'`, `'all'`, or `None` (default),
   matching the underlying `sklearn.metrics.confusion_matrix` implementation
   used by this metric (see `metrics/confusion_matrix/confusion_matrix.py`,
   which passes `normalize` straight through to sklearn).

## Verification

- Confirmed against current `main` that both issues were still present
  before this fix.
- Change is scoped to the README only; no code or behavior changes.

Note: this documentation fix was prepared with AI assistance (Claude Code)
and reviewed before submission.
