### PR TITLE
docs: stop listing BLEURT checkpoint as a compute() argument

### DIFF
--- a/metrics/bleurt/README.md
+++ b/metrics/bleurt/README.md
@@ -41,6 +41,8 @@ This metric takes as input lists of predicted sentences and reference sentences:
 >>> results = bleurt.compute(predictions=predictions, references=references)
 ```
 
+The BLEURT checkpoint is chosen when the metric is loaded, with the `config_name` argument of `load`, and cannot be changed in `compute`.
+
 ### Inputs
 
 For the `load` function:
@@ -96,7 +98,7 @@ The [original BLEURT paper](https://arxiv.org/pdf/2004.04696.pdf) showed that BL
 
 Furthermore, currently BLEURT only supports English-language scoring, given that it leverages models trained on English corpora. It may also reflect, to a certain extent, biases and correlations that were present in the model training data. 
 
-Finally, calculating the BLEURT metric involves downloading the BLEURT model that is used to compute the score, which can take a significant amount of time depending on the model chosen. Starting with the default model, `bleurt-tiny`, and testing out larger models if necessary can be a useful approach if memory or internet speed is an issue.
+Finally, calculating the BLEURT metric involves downloading the BLEURT model that is used to compute the score, which can take a significant amount of time depending on the model chosen. Starting with a small checkpoint, such as the default `"bleurt-base-128"` or the even smaller `"bleurt-tiny-128"`, and testing out larger models if necessary can be a useful approach if memory or internet speed is an issue.
 
 
 ## Citation

--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -45,10 +45,12 @@ See the project's README at https://github.com/google-research/bleurt#readme for
 _KWARGS_DESCRIPTION = """
 BLEURT score.
 
+The BLEURT checkpoint is not an argument of `compute`: it is selected when the metric is loaded, with the
+`config_name` argument of `evaluate.load`, and defaults to `bleurt-base-128`.
+
 Args:
     `predictions` (list of str): prediction/candidate sentences
     `references` (list of str): reference sentences
-    `checkpoint` BLEURT checkpoint. Will default to BLEURT-tiny if None.
 
 Returns:
     'scores': List of scores.
@@ -57,6 +59,7 @@ Examples:
     >>> predictions = ["hello there", "general kenobi"]
     >>> references = ["hello there", "general kenobi"]
     >>> bleurt = evaluate.load("bleurt")
+    >>> # bleurt = evaluate.load("bleurt", config_name="BLEURT-20")  # you can also choose which checkpoint to use
     >>> results = bleurt.compute(predictions=predictions, references=references)
     >>> print([round(v, 2) for v in results["scores"]])
     [1.03, 1.04]


### PR DESCRIPTION
Fixes #679.

#708 already fixed the README Inputs section. The metric docstring still listed checkpoint under compute Args, and Limitations still said the default was bleurt-tiny.

checkpoint is config_name on load; default is bleurt-base-128.

tests/test_metric_common.py -k test_load_metric_bleurt: 1 passed.