### PR TITLE
Fix McNemar ZeroDivisionError when models have no discordant pairs

### DIFF
--- a/comparisons/mcnemar/README.md
+++ b/comparisons/mcnemar/README.md
@@ -51,7 +51,7 @@ Its arguments are:
 
 The McNemar comparison outputs two things:
 
-`stat`: The McNemar statistic.
+`stat`: The McNemar statistic. It is 0 when both models are correct and incorrect on exactly the same examples, since there are no discordant pairs to compare in that case.
 
 `p`: The p value.
 

--- a/comparisons/mcnemar/mcnemar.py
+++ b/comparisons/mcnemar/mcnemar.py
@@ -35,7 +35,7 @@ Args:
     references (`list` of `int`): Ground truth labels.
 
 Returns:
-    stat (`float`): McNemar test score.
+    stat (`float`): McNemar test score. It is 0 when both models are correct and incorrect on exactly the same examples, since there are no discordant pairs to compare in that case.
     p (`float`): The p value. Minimum possible value is 0. Maximum possible value is 1.0. A lower p value means a more significant difference.
 
 Examples:
@@ -92,7 +92,9 @@ class McNemar(evaluate.Comparison):
 
         # compute statistic
         b, c = tbl[0][1], tbl[1][0]
-        statistic = abs(b - c) ** 2 / (1.0 * (b + c))
+        # without discordant pairs both models are right and wrong on exactly the same
+        # examples, so there is no evidence of a difference between them
+        statistic = abs(b - c) ** 2 / (1.0 * (b + c)) if b + c > 0 else 0.0
         df = 1
         pvalue = chi2.sf(statistic, df)
         return {"stat": statistic, "p": pvalue}

--- a/tests/test_metric_common.py
+++ b/tests/test_metric_common.py
@@ -225,3 +225,9 @@ def test_seqeval_raises_when_incorrect_scheme():
     error_message = f"Scheme should be one of [IOB1, IOB2, IOE1, IOE2, IOBES, BILOU], got {wrong_scheme}"
     with pytest.raises(ValueError, match=re.escape(error_message)):
         metric.compute(predictions=[], references=[], scheme=wrong_scheme)
+
+
+def test_mcnemar_without_discordant_pairs():
+    comparison = load(os.path.join("comparisons", "mcnemar"))
+    results = comparison.compute(references=[1, 0, 1], predictions1=[1, 0, 1], predictions2=[1, 0, 1])
+    assert results == {"stat": 0.0, "p": 1.0}


### PR DESCRIPTION
## Description

McNemar's statistic is `|b - c|² / (b + c)`. When the two models being compared produce no discordant pairs (`b + c == 0`) — comparing a model to itself, or two models that agree on every example — this raised `ZeroDivisionError`.

The comparison now reports `stat = 0.0` in that case, which yields `p = 1.0`: there is no evidence of a difference.

## Tests

`python3 -m pytest tests/test_metric_common.py -k "comparison or mcnemar" -q` → 4 passed, 3 skipped.

New `test_mcnemar_without_discordant_pairs` fails on unmodified source.