### PR TITLE
Fix text2text generation_kwargs leaking across compute calls

### DIFF
--- a/src/evaluate/evaluator/text2text_generation.py
+++ b/src/evaluate/evaluator/text2text_generation.py
@@ -127,8 +127,9 @@ class Text2TextGenerationEvaluator(Evaluator):
         label_column: str = "label",
         generation_kwargs: dict = None,
     ) -> Tuple[Dict[str, float], Any]:
-        if generation_kwargs is not None:
-            self.PIPELINE_KWARGS.update(generation_kwargs)
+        # `PIPELINE_KWARGS` is a class attribute, so it is shadowed with a per-call copy to keep
+        # `generation_kwargs` from leaking into later calls and into other evaluator instances.
+        self.PIPELINE_KWARGS = {**type(self).PIPELINE_KWARGS, **(generation_kwargs or {})}
 
         result = super().compute(
             model_or_pipeline=model_or_pipeline,

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -63,8 +63,10 @@ class DummyText2TextGenerationPipeline:
     def __init__(self, prefix="generated", task="text2text-generation"):
         self.task = task
         self.prefix = prefix
+        self.call_kwargs = None
 
     def __call__(self, inputs, **kwargs):
+        self.call_kwargs = kwargs
         return [{f"{self.prefix}_text": "Lorem ipsum"} for _ in inputs]
 
 
@@ -959,6 +961,28 @@ class TestText2TextGenerationEvaluator(TestCase):
             metric="rouge",
         )
         self.assertEqual(results["rouge1"], 1.0)
+
+    def test_generation_kwargs(self):
+        self.evaluator.compute(
+            model_or_pipeline=self.pipe,
+            data=self.data,
+            generation_kwargs={"max_length": 5},
+        )
+        self.assertEqual(self.pipe.call_kwargs, {"truncation": True, "max_length": 5})
+
+    def test_generation_kwargs_are_not_persisted(self):
+        self.evaluator.compute(
+            model_or_pipeline=self.pipe,
+            data=self.data,
+            generation_kwargs={"max_length": 5},
+        )
+        self.assertEqual(Text2TextGenerationEvaluator.PIPELINE_KWARGS, {"truncation": True})
+
+        evaluator("text2text-generation").compute(
+            model_or_pipeline=self.pipe,
+            data=self.data,
+        )
+        self.assertEqual(self.pipe.call_kwargs, {"truncation": True})
 
     def test_summarization(self):
         pipe = DummyText2TextGenerationPipeline(task="summarization", prefix="summary")


### PR DESCRIPTION
## Description

`Text2TextGenerationEvaluator.compute()` did `self.PIPELINE_KWARGS.update(generation_kwargs)`. `PIPELINE_KWARGS` is a class attribute, so kwargs from one `compute()` leaked into later calls, including on a freshly constructed evaluator. `SummarizationEvaluator` and `TranslationEvaluator` inherit the same leak.

Build a per-call dict from the class defaults instead of mutating them.

Distinct from #794/#795. Not the same as #775 (task validation) or #754 (proposal to delete these evaluators).

## Tests

`python -m pytest tests/test_evaluator.py -k Text2Text -v` → 7 passed, 1 skipped (new test failed on main).
`python -m pytest tests/test_evaluator.py` → 43 passed, 14 skipped.