### PR TITLE
fix: treat sentiment-analysis and text-classification as the same evaluator task

### DIFF
--- a/src/evaluate/evaluator/base.py
+++ b/src/evaluate/evaluator/base.py
@@ -32,6 +32,7 @@ except ImportError:
 try:
     import transformers
     from transformers import Pipeline, pipeline
+    from transformers.pipelines import TASK_ALIASES
 
     TRANSFORMERS_AVAILABLE = True
 except ImportError:
@@ -207,6 +208,11 @@ class Evaluator(ABC):
             logger.info("GPU found. The default device for pipeline inference is set to GPU (CUDA:0).")
 
         return device
+
+    @staticmethod
+    def _normalize_task(task: str) -> str:
+        """Helper function to resolve a task alias (e.g. `"sentiment-analysis"`) to its canonical task name."""
+        return TASK_ALIASES.get(task, task)
 
     @abstractmethod
     def predictions_processor(self, *args, **kwargs):
@@ -471,7 +477,9 @@ class Evaluator(ABC):
                 pipe = model_or_pipeline
             if tokenizer is not None and feature_extractor is not None:
                 logger.warning("Ignoring the value of the preprocessor argument (`tokenizer` or `feature_extractor`).")
-        if (pipe.task != self.task) and not (self.task == "translation" and pipe.task.startswith("translation")):
+        if (self._normalize_task(pipe.task) != self._normalize_task(self.task)) and not (
+            self.task == "translation" and pipe.task.startswith("translation")
+        ):
             raise ValueError(
                 f"Incompatible `model_or_pipeline`. Please specify `model_or_pipeline` compatible with the `{self.task}` task."
             )

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -69,8 +69,8 @@ class DummyText2TextGenerationPipeline:
 
 
 class DummyTextClassificationPipeline:
-    def __init__(self, sleep_time=None):
-        self.task = "text-classification"
+    def __init__(self, sleep_time=None, task="text-classification"):
+        self.task = task
         self.sleep_time = sleep_time
 
     def __call__(self, inputs, **kwargs):
@@ -259,6 +259,22 @@ class TestTextClassificationEvaluator(TestCase):
             label_mapping=self.label_mapping,
         )
         self.assertEqual(results["accuracy"], 1.0)
+
+    def test_task_alias_pipe_init(self):
+        # `sentiment-analysis` is an alias of `text-classification`, so both names have to be accepted
+        # on the evaluator side as well as on the pipeline side
+        for evaluator_task, pipe_task in [
+            ("sentiment-analysis", "text-classification"),
+            ("text-classification", "sentiment-analysis"),
+        ]:
+            results = evaluator(evaluator_task).compute(
+                model_or_pipeline=DummyTextClassificationPipeline(task=pipe_task),
+                data=self.data,
+                input_column="text",
+                label_column="label",
+                label_mapping=self.label_mapping,
+            )
+            self.assertEqual(results["accuracy"], 1.0)
 
     @slow
     def test_model_init(self):


### PR DESCRIPTION
transformers treats sentiment-analysis as an alias of text-classification (and ner of token-classification). evaluate documents evaluator("sentiment-analysis") as supported, but prepare_pipeline compared the raw task strings, so a text-classification pipeline passed to evaluator("sentiment-analysis") raised ValueError.

Both sides are now resolved through transformers TASK_ALIASES before comparing.

Tests: python3 -m pytest tests/test_evaluator.py::TestTextClassificationEvaluator -q — 8 passed, 2 skipped. Distinct from #790-#797.