### PR TITLE
fix(r_squared): implement the documented zero_division parameter

### DIFF
--- a/metrics/r_squared/r_squared.py
+++ b/metrics/r_squared/r_squared.py
@@ -15,6 +15,8 @@
 """R squared metric."""
 
 
+import warnings
+
 import datasets
 import numpy as np
 
@@ -61,6 +63,14 @@ Examples:
     >>> r_squared = r2_metric.compute(predictions=[1, 2, 3, 4], references=[0.9, 2.1, 3.2, 3.8])
     >>> print(r_squared)
     0.98
+
+    R^2 is undefined when the references have zero variance, since there is no
+    variance to explain. `zero_division` selects what to return instead:
+
+    >>> r2_metric.compute(predictions=[1, 2, 3, 4], references=[5, 5, 5, 5], zero_division=0)
+    0.0
+    >>> r2_metric.compute(predictions=[5, 5, 5, 5], references=[5, 5, 5, 5], zero_division=1)
+    1.0
 """
 
 
@@ -83,17 +93,25 @@ class r_squared(evaluate.Metric):
             ],
         )
 
-    def _compute(self, predictions=None, references=None):
+    def _compute(self, predictions=None, references=None, zero_division="warn"):
         """
         Computes the coefficient of determination (R-squared) of predictions with respect to references.
 
         Parameters:
             predictions (List or np.ndarray): The predicted values.
             references (List or np.ndarray): The true/reference values.
+            zero_division (0, 1 or "warn"): Value to return when `references` has zero
+                variance, which makes the sum of squared total zero and R^2 undefined.
+                "warn" returns 0.0 and raises a warning.
 
         Returns:
             float: The R-squared value, rounded to 3 decimal places.
         """
+        if zero_division not in (0, 1, "warn"):
+            raise ValueError(
+                f'zero_division must be one of 0, 1 or "warn", got {zero_division!r}'
+            )
+
         predictions = np.array(predictions)
         references = np.array(references)
 
@@ -105,6 +123,22 @@ class r_squared(evaluate.Metric):
 
         # Calculate sum of squared total
         sst = np.sum((references - mean_references) ** 2)
+
+        # R^2 is undefined when the references never vary: there is no variance to
+        # explain, so the ratio divides by zero. Left to numpy this returns -inf
+        # (or nan when the predictions match exactly), which then propagates
+        # silently through any downstream aggregation.
+        if sst == 0:
+            if zero_division == "warn":
+                warnings.warn(
+                    "R^2 is undefined when all `references` are identical (zero "
+                    "variance); returning 0.0. Pass zero_division=0 or 1 to choose "
+                    "the value and silence this warning.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                return 0.0
+            return float(zero_division)
 
         # Calculate R Squared
         r_squared = 1 - (ssr / sst)


### PR DESCRIPTION
Closes #803.

## The problem

`r_squared` documents a `zero_division` parameter that was never implemented:

```
zero_division: Which value to substitute as a metric value when encountering zero division.
    Should be one of 0, 1, "warn". "warn" acts as 0, but the warning is raised.
```

`zero_division` appeared exactly once in the file — in that docstring. `_compute` didn't accept it, so passing it raised `TypeError`, and the case it exists to control was unguarded:

```python
sst = np.sum((references - mean_references) ** 2)
r_squared = 1 - (ssr / sst)
```

When every reference is identical there is no variance to explain, `sst` is zero, and R^2 is undefined. numpy returns `-inf` — or `nan` when predictions match exactly — with only a `RuntimeWarning`, and `round()` passes it through.

| predictions | references | before | after (default) | `sklearn.r2_score` |
|---|---|---|---|---|
| `[1.1, 2.1, 2.9, 4.2]` | `[1, 2, 3, 4]` | 0.986 | 0.986 | 0.986 |
| `[1, 2, 3, 4]` | `[5, 5, 5, 5]` | **-inf** | 0.0 + warning | 0.0 |
| `[5, 5, 5, 5]` | `[5, 5, 5, 5]` | **nan** | 0.0 + warning | 1.0 |

Both values propagate: one constant-reference batch turns an averaged score into `nan` for a whole run, and `-inf` dominates any mean. Nothing raises, so it reads as a modelling outcome rather than an undefined computation.

## The change

Implements `zero_division` as documented — `0`, `1`, or `"warn"` — and raises `ValueError` on anything else rather than ignoring it.

The default is `"warn"`: the previously silent case becomes visible instead of quietly becoming a number the caller didn't choose. Callers who know which convention they want can pass `0` or `1` and silence it. Note the two degenerate cases differ under sklearn (0.0 when predictions miss, 1.0 when they match exactly), which is exactly why this is a caller choice rather than a fixed substitution.

Non-degenerate inputs are untouched and still agree with `sklearn.metrics.r2_score` to 3 dp.

## Tests

Adds doctest examples for both settings, which is how metrics here are covered. `tests/test_metric_common.py -k r_squared` passes (1 passed, 1 skipped).

One note for anyone reproducing: the test suite doesn't run on Python 3.12+ — `tests/utils.py` imports `distutils`, removed in 3.12. Verified on 3.11.

## Not changed

`_DESCRIPTION` says "The R^2 value ranges from 0 to 1", which isn't true for a fit worse than the mean — sklearn returns negative values there, as does this implementation. Left alone to keep this PR to one thing; happy to fix it here or separately.
