### PR TITLE
fix(mse): support sklearn versions without root_mean_squared_error

### DIFF
--- a/metrics/mse/README.md
+++ b/metrics/mse/README.md
@@ -82,7 +82,7 @@ Example with the `uniform_average` config:
 {'mse': 0.375}
 ```
 
-Example with `squared = True`, which returns the RMSE:
+Example with `squared = False`, which returns the RMSE:
 ```python
 >>> mse_metric = evaluate.load("mse")
 >>> predictions = [2.5, 0.0, 2, 8]

--- a/metrics/mse/mse.py
+++ b/metrics/mse/mse.py
@@ -14,7 +14,12 @@
 """MSE - Mean Squared Error Metric"""
 
 import datasets
-from sklearn.metrics import mean_squared_error, root_mean_squared_error
+from sklearn.metrics import mean_squared_error
+
+try:
+    from sklearn.metrics import root_mean_squared_error
+except ImportError:  # sklearn < 1.4
+    root_mean_squared_error = None
 
 import evaluate
 
@@ -112,10 +117,21 @@ class Mse(evaluate.Metric):
 
     def _compute(self, predictions, references, sample_weight=None, multioutput="uniform_average", squared=True):
 
-        mse = (
-            mean_squared_error(references, predictions, sample_weight=sample_weight, multioutput=multioutput)
-            if squared
-            else root_mean_squared_error(references, predictions, sample_weight=sample_weight, multioutput=multioutput)
-        )
+        if squared:
+            mse = mean_squared_error(
+                references, predictions, sample_weight=sample_weight, multioutput=multioutput
+            )
+        elif root_mean_squared_error is not None:
+            mse = root_mean_squared_error(
+                references, predictions, sample_weight=sample_weight, multioutput=multioutput
+            )
+        else:
+            mse = mean_squared_error(
+                references,
+                predictions,
+                sample_weight=sample_weight,
+                multioutput=multioutput,
+                squared=False,
+            )
 
         return {"mse": mse}


### PR DESCRIPTION
Fixes huggingface/evaluate#669

## Summary
- Add sklearn import fallback when `root_mean_squared_error` is unavailable
- Fix RMSE README example label (`squared=False`)

## Test plan
- [x] Verified MSE/RMSE compute paths for both sklearn code paths