### PR TITLE
fix(bertscore): cap tokenizer max_length for transformers>=5

### DIFF
--- a/metrics/bertscore/README.md
+++ b/metrics/bertscore/README.md
@@ -61,6 +61,8 @@ BERTScore also accepts multiple optional arguments:
 
 `use_fast_tokenizer` (bool): `use_fast` parameter passed to HF tokenizer. The default value is `False`. 
 
+`max_length` (int, optional): Maximum sequence length for tokenization. Pass this when the tokenizer config leaves `model_max_length` unset (seen with some models under transformers>=5), which can otherwise raise an `OverflowError` during scoring.
+
 
 ## Output values
 

--- a/metrics/bertscore/bertscore.py
+++ b/metrics/bertscore/bertscore.py
@@ -22,6 +22,31 @@ from packaging import version
 
 import evaluate
 
+try:
+    from transformers.tokenization_utils_base import VERY_LARGE_INTEGER
+except ImportError:
+    VERY_LARGE_INTEGER = 10**30
+
+
+def _resolve_tokenizer_max_length(tokenizer, max_length=None):
+    """Pick a truncation limit that won't overflow the Rust tokenizers backend."""
+    if max_length is not None:
+        return max_length
+
+    current = getattr(tokenizer, "model_max_length", None)
+    if current is None or current >= VERY_LARGE_INTEGER:
+        sizes = getattr(tokenizer, "max_model_input_sizes", None) or {}
+        if sizes:
+            return min(sizes.values())
+        return 512
+    return current
+
+
+def _apply_tokenizer_max_length(scorer, max_length=None):
+    resolved = _resolve_tokenizer_max_length(scorer._tokenizer, max_length=max_length)
+    scorer._tokenizer.model_max_length = resolved
+    return resolved
+
 
 @contextmanager
 def filter_logging_context():
@@ -79,6 +104,9 @@ Args:
     rescale_with_baseline (bool): Rescale bertscore with pre-computed baseline.
     baseline_path (str): Customized baseline file.
     use_fast_tokenizer (bool): `use_fast` parameter passed to HF tokenizer. New in version 0.3.10.
+    max_length (int, optional): Maximum sequence length passed to the underlying tokenizer. Useful when a model
+        does not define `model_max_length` in its tokenizer config (common with transformers>=5), which otherwise
+        can trigger an `OverflowError` during truncation.
 
 Returns:
     precision: Precision.
@@ -142,6 +170,7 @@ class BERTScore(evaluate.Metric):
         rescale_with_baseline=False,
         baseline_path=None,
         use_fast_tokenizer=False,
+        max_length=None,
     ):
 
         if isinstance(references[0], str):
@@ -199,6 +228,9 @@ class BERTScore(evaluate.Metric):
                     rescale_with_baseline=rescale_with_baseline,
                     baseline_path=baseline_path,
                 )
+                _apply_tokenizer_max_length(self.cached_bertscorer, max_length=max_length)
+            elif max_length is not None:
+                _apply_tokenizer_max_length(self.cached_bertscorer, max_length=max_length)
 
         (P, R, F) = self.cached_bertscorer.score(
             cands=predictions,

--- a/tests/test_bertscore_max_length.py
+++ b/tests/test_bertscore_max_length.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock
+
+from metrics.bertscore.bertscore import _apply_tokenizer_max_length, _resolve_tokenizer_max_length
+
+
+def test_resolve_tokenizer_max_length_prefers_explicit_value():
+    tokenizer = MagicMock(model_max_length=10**30)
+    assert _resolve_tokenizer_max_length(tokenizer, max_length=128) == 128
+
+
+def test_resolve_tokenizer_max_length_uses_model_input_sizes():
+    tokenizer = MagicMock(model_max_length=10**30, max_model_input_sizes={"microsoft/deberta-xlarge-mnli": 512})
+    assert _resolve_tokenizer_max_length(tokenizer) == 512
+
+
+def test_resolve_tokenizer_max_length_keeps_reasonable_default():
+    tokenizer = MagicMock(model_max_length=512, max_model_input_sizes={})
+    assert _resolve_tokenizer_max_length(tokenizer) == 512
+
+
+def test_apply_tokenizer_max_length_updates_tokenizer():
+    tokenizer = MagicMock(model_max_length=10**30, max_model_input_sizes={"x": 256})
+    scorer = MagicMock(_tokenizer=tokenizer)
+    assert _apply_tokenizer_max_length(scorer) == 256
+    assert tokenizer.model_max_length == 256


### PR DESCRIPTION
Fixes huggingface/evaluate#739

## Summary
- Add an optional `max_length` argument to `compute` and document it
- When a tokenizer leaves `model_max_length` unset, fall back to the model input size instead of the transformers placeholder that overflows the Rust tokenizers backend

## Test plan
- [x] Added unit tests for max-length resolution helpers