### PR TITLE
feat(perplexity): forward kwargs to from_pretrained

### DIFF
--- a/measurements/perplexity/README.md
+++ b/measurements/perplexity/README.md
@@ -47,6 +47,9 @@ results = perplexity.compute(data=input_texts, model_id='gpt2')
 - **batch_size** (int): the batch size to run texts through the model. Defaults to 16.
 - **add_start_token** (bool): whether to add the start token to the texts, so the perplexity can include the probability of the first word. Defaults to True.
 - **device** (str): device to run on, defaults to `cuda` when available
+- **max_length** (int, optional): truncate inputs longer than this many tokens
+- **model_kwargs** (dict, optional): forwarded to `AutoModelForCausalLM.from_pretrained` (e.g. `token` for gated models)
+- **tokenizer_kwargs** (dict, optional): forwarded to `AutoTokenizer.from_pretrained`
 
 ### Output Values
 This metric outputs a dictionary with the perplexity scores for the text input in the list, and the average perplexity.
@@ -91,6 +94,20 @@ print(round(results["mean_perplexity"], 2))
 >>>576.76
 print(round(results["perplexities"][0], 2))
 >>>889.28
+```
+
+### Gated models
+
+For models that require authentication, pass your Hugging Face token through `model_kwargs` and `tokenizer_kwargs` instead of relying on a global login:
+
+```python
+perplexity = evaluate.load("perplexity", module_type="measurement")
+results = perplexity.compute(
+    model_id="meta-llama/Meta-Llama-3.1-8B-Instruct",
+    data=["The quick brown fox jumps over the lazy dog."],
+    model_kwargs={"token": os.environ["HF_TOKEN"]},
+    tokenizer_kwargs={"token": os.environ["HF_TOKEN"]},
+)
 ```
 
 ## Limitations and Bias

--- a/measurements/perplexity/perplexity.py
+++ b/measurements/perplexity/perplexity.py
@@ -50,6 +50,8 @@ Args:
         so the perplexity can include the probability of the first word. Defaults to True.
     device (str): device to run on, defaults to 'cuda' when available
     max_length (int): the maximum length to truncate input texts to. Should be set to the maximum length the model supports. Defaults to None.
+    model_kwargs (dict, optional): Extra keyword arguments forwarded to `AutoModelForCausalLM.from_pretrained`, for example `token` when loading a gated model.
+    tokenizer_kwargs (dict, optional): Extra keyword arguments forwarded to `AutoTokenizer.from_pretrained`.
 Returns:
     perplexity: dictionary containing the perplexity scores for the texts
         in the input list, as well as the mean perplexity. If one of the input texts is
@@ -102,8 +104,21 @@ class Perplexity(evaluate.Measurement):
         )
 
     def _compute(
-        self, data, model_id, batch_size: int = 16, add_start_token: bool = True, device=None, max_length=None
+        self,
+        data,
+        model_id,
+        batch_size: int = 16,
+        add_start_token: bool = True,
+        device=None,
+        max_length=None,
+        model_kwargs=None,
+        tokenizer_kwargs=None,
     ):
+
+        if model_kwargs is None:
+            model_kwargs = {}
+        if tokenizer_kwargs is None:
+            tokenizer_kwargs = {}
 
         if device is not None:
             assert device in ["gpu", "cpu", "cuda"], "device should be either gpu or cpu."
@@ -112,10 +127,10 @@ class Perplexity(evaluate.Measurement):
         else:
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        model = AutoModelForCausalLM.from_pretrained(model_id)
+        model = AutoModelForCausalLM.from_pretrained(model_id, **model_kwargs)
         model = model.to(device)
 
-        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        tokenizer = AutoTokenizer.from_pretrained(model_id, **tokenizer_kwargs)
 
         # if batch_size > 1 (which generally leads to padding being required), and
         # if there is not an already assigned pad_token, assign an existing

--- a/tests/test_perplexity_model_kwargs.py
+++ b/tests/test_perplexity_model_kwargs.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from measurements.perplexity.perplexity import Perplexity
+
+
+def test_perplexity_forwards_pretrained_kwargs():
+    metric = Perplexity()
+    with patch("measurements.perplexity.perplexity.AutoModelForCausalLM.from_pretrained") as mock_model, patch(
+        "measurements.perplexity.perplexity.AutoTokenizer.from_pretrained"
+    ) as mock_tokenizer, patch.object(metric, "_compute", wraps=metric._compute) as wrapped:
+        # Stop before the forward pass; we only care about the from_pretrained calls.
+        mock_model.side_effect = RuntimeError("stop-after-load")
+        try:
+            metric._compute(
+                data=["hello"],
+                model_id="meta-llama/Meta-Llama-3.1-8B-Instruct",
+                model_kwargs={"token": "hf_test_token"},
+                tokenizer_kwargs={"token": "hf_test_token", "trust_remote_code": True},
+            )
+        except RuntimeError as exc:
+            assert str(exc) == "stop-after-load"
+
+    mock_model.assert_called_once_with("meta-llama/Meta-Llama-3.1-8B-Instruct", token="hf_test_token")
+    mock_tokenizer.assert_called_once_with(
+        "meta-llama/Meta-Llama-3.1-8B-Instruct",
+        token="hf_test_token",
+        trust_remote_code=True,
+    )
+    wrapped.assert_called_once()


### PR DESCRIPTION
Fixes huggingface/evaluate#680

## Summary
- Add `model_kwargs` and `tokenizer_kwargs` to the perplexity measurement
- Document how to pass a token for gated checkpoints

## Test plan
- [x] Unit test checks kwargs are forwarded to both `from_pretrained` calls