### PR TITLE
Allow saving evaluation results when Git is not installed

### DIFF
--- a/src/evaluate/saving.py
+++ b/src/evaluate/saving.py
@@ -65,7 +65,10 @@ def _setup_path(path_or_file, current_time):
 
 
 def _git_commit_hash():
-    res = subprocess.run("git rev-parse --is-inside-work-tree".split(), cwd="./", stdout=subprocess.PIPE)
+    try:
+        res = subprocess.run("git rev-parse --is-inside-work-tree".split(), cwd="./", stdout=subprocess.PIPE)
+    except FileNotFoundError:
+        return None
     if res.stdout.decode().strip() == "true":
         res = subprocess.run("git rev-parse HEAD".split(), cwd=os.getcwd(), stdout=subprocess.PIPE)
         return res.stdout.decode().strip()

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -42,3 +42,16 @@ class TestSave(TestCase):
         for key in SAVE_EXTRA_KEYS:
             _ = loaded_result_dict.pop(key)
         self.assertDictEqual(result_dict, loaded_result_dict)
+
+
+def test_save_without_git(tmp_path, monkeypatch):
+    import evaluate.saving
+
+    def missing_git(*args, **kwargs):
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(evaluate.saving.subprocess, "run", missing_git)
+    path = evaluate.save(tmp_path / "result.json", accuracy=0.75)
+    data = json.loads(path.read_text())
+    assert data["accuracy"] == 0.75
+    assert data["_git_commit_hash"] is None


### PR DESCRIPTION
`evaluate.save()` fails with `FileNotFoundError` on systems without Git, even though the commit hash is optional metadata. Save the results with a null commit hash when the executable is unavailable.

Adds a regression test through `evaluate.save()`.
