### PR TITLE
Recognize existing directories with dots when saving results

### DIFF
--- a/src/evaluate/saving.py
+++ b/src/evaluate/saving.py
@@ -53,7 +53,7 @@ def save(path_or_file, **data):
 
 def _setup_path(path_or_file, current_time):
     path_or_file = Path(path_or_file)
-    is_file = len(path_or_file.suffix) > 0
+    is_file = not path_or_file.is_dir() and len(path_or_file.suffix) > 0
     if is_file:
         folder = path_or_file.parent
         file_name = path_or_file.name

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -42,3 +42,12 @@ class TestSave(TestCase):
         for key in SAVE_EXTRA_KEYS:
             _ = loaded_result_dict.pop(key)
         self.assertDictEqual(result_dict, loaded_result_dict)
+
+
+def test_save_to_existing_directory_with_suffix(tmp_path):
+    directory = tmp_path / "experiment.v1"
+    directory.mkdir()
+    path = evaluate.save(directory, accuracy=0.75)
+    assert path.parent == directory
+    assert path.name.startswith("result-")
+    assert json.loads(path.read_text())["accuracy"] == 0.75


### PR DESCRIPTION
An existing directory such as `experiment.v1` is mistaken for a file because it has a suffix. Check whether the path is a directory before deciding to use it as the output filename.

Adds a save-and-read regression test for a dotted directory.
