### PR TITLE
docs: fix 'allows to see' grammar in label_distribution README

### DIFF
--- a/measurements/label_distribution/README.md
+++ b/measurements/label_distribution/README.md
@@ -21,7 +21,7 @@ The label distribution measurements returns the fraction of each label represent
 
 ## Intended Uses
 
-Calculating the distribution of labels in a dataset allows to see how balanced the labels in your dataset are, which
+Calculating the distribution of labels in a dataset allows you to see how balanced the labels in your dataset are, which
 can help choosing a relevant metric (e.g. accuracy when the dataset is balanced, versus F1 score when there is an
 imbalance).
 


### PR DESCRIPTION
## What does this PR do?

Fixes grammar in the label distribution measurement README: "allows to see" → "allows you to see".

Docs-only wording fix; no metric behavior change.