### PR TITLE
docs: remove duplicate 'a' in poseval README

### DIFF
--- a/metrics/poseval/README.md
+++ b/metrics/poseval/README.md
@@ -54,7 +54,7 @@ It can also take several optional arguments:
 
 ## Output values
 
-This metric returns a a classification report as a dictionary with a summary of scores for overall and per type:
+This metric returns a classification report as a dictionary with a summary of scores for overall and per type:
 
 Overall (weighted and macro avg):
 


### PR DESCRIPTION
## Description

Remove a duplicated article in the poseval metric README:

- `returns a a classification report` → `returns a classification report`

## Test plan

- [x] Confirmed surrounding sentence still reads correctly after the change.